### PR TITLE
Implement sized deallocation operators for c++14 compatibility

### DIFF
--- a/src/xpcc/architecture/platform/driver/core/avr/newdelete.cpp
+++ b/src/xpcc/architecture/platform/driver/core/avr/newdelete.cpp
@@ -28,7 +28,19 @@ operator delete(void* ptr)
 }
 
 void
+operator delete(void* ptr, size_t size __attribute__((unused)))
+{
+	xpcc::avr::freeMemory(ptr);
+}
+
+void
 operator delete[](void* ptr)
+{
+	xpcc::avr::freeMemory(ptr);
+}
+
+void
+operator delete[](void* ptr, size_t size __attribute__((unused)))
 {
 	xpcc::avr::freeMemory(ptr);
 }


### PR DESCRIPTION
I used C++11 on the AVR before, but of lately my compiler complains about undefined reference to `operator delete(void*, unsigned int)'. This operator is needed for the sized deallocation feature of C++11. This fix implements the new delete operators by simply dropping the size parameter. However, maybe the additional parameter could be used for more efficient implementation of freeMemory.
