### PR TITLE
Driver: LSM303: Remove stray reference to LIS.

### DIFF
--- a/src/xpcc/driver/inertial/lsm303a.hpp
+++ b/src/xpcc/driver/inertial/lsm303a.hpp
@@ -13,7 +13,6 @@
 #include <xpcc/architecture/interface/register.hpp>
 #include <xpcc/processing/resumable.hpp>
 #include <xpcc/math/utils/endianness.hpp>
-#include "lis3_transport.hpp"
 
 namespace xpcc
 {


### PR DESCRIPTION
Probably from copy & paste.
