### PR TITLE
Add generic branch prediction macros

### DIFF
--- a/src/xpcc/architecture/utils.hpp
+++ b/src/xpcc/architecture/utils.hpp
@@ -115,9 +115,9 @@
 	#	define ATTRIBUTE_PACKED		__attribute__((packed))
 	#	define ATTRIBUTE_FASTCODE	__attribute__((section(".fastcode")))
 	#	define ATTRIBUTE_FASTDATA	__attribute__((section(".fastdata")))
-
-	// see http://dbp-consulting.com/tutorials/StrictAliasing.html
-	#	define ATTRIBUTE_MAY_ALIAS	__attribute__((__may_alias__))
+	#	define ATTRIBUTE_MAY_ALIAS	__attribute__((__may_alias__))	// see http://dbp-consulting.com/tutorials/StrictAliasing.html
+	#	define likely(x)			__builtin_expect(!!(x), 1)
+	#	define unlikely(x)			__builtin_expect(!!(x), 0)
 	#else
 	#	define ALWAYS_INLINE  		inline
 	#	define ATTRIBUTE_UNUSED
@@ -127,6 +127,8 @@
 	#	define ATTRIBUTE_FASTCODE
 	#	define ATTRIBUTE_FASTDATA
 	#	define ATTRIBUTE_MAY_ALIAS
+	#	define likely(x)			(x)
+	#	define unlikely(x)			(x)
 	#endif
 
 	#ifdef XPCC__CPU_AVR

--- a/src/xpcc/math/filter/fir_impl.hpp
+++ b/src/xpcc/math/filter/fir_impl.hpp
@@ -31,7 +31,7 @@
 #ifndef XPCC__FIR_IMPL_HPP
 #define XPCC__FIR_IMPL_HPP
 
-#define likely(x) __builtin_expect((x),1)
+#include <xpcc/architecture/utils.hpp>
 
 //#define FIR_DEBUG
 


### PR DESCRIPTION
These were already used in the FIR filter, this change only moves them where they belong.

These can help on the more powerful Cortex-M devices with a multi-stage pipeline, especially Cortex-M7 with its humongous 6-stage pipeline and Data and Instruction Caches.

The naming is the same as in the Linux kernel.
