### PR TITLE
Travis CI: Enable container-based virtualization environment

### DIFF
--- a/.travis.dep.sh
+++ b/.travis.dep.sh
@@ -1,0 +1,30 @@
+cd $HOME/cache
+if [ ! -d "$HOME/cache/avr8-gnu-toolchain-linux_x86" ]; then
+	echo "Downloading AVR toolchain..."
+	wget http://www.atmel.com/images/avr8-gnu-toolchain-3.4.5.1522-linux.any.x86.tar.gz -O avr8.tar.gz
+	tar -xzf avr8.tar.gz
+	rm avr8.tar.gz
+fi
+if [ ! -d "$HOME/cache/gcc-arm-none-eabi-4_9-2015q3" ]; then
+	echo "Downloading Cortex-M toolchain..."
+	wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2 -O cortex_m.tar.bz2
+	tar -xjf cortex_m.tar.bz2
+	rm cortex_m.tar.bz2
+fi
+if [ ! -d "$HOME/cache/boost1.54-1.54.0" ]; then
+	echo "Downloading and building libboost1.54 package..."
+	mkdir cd $HOME/cache
+	wget http://box.xpcc.io/libboost1.54-dev-src.tar.gz
+	tar -xzf libboost1.54-dev-src.tar.gz
+	rm libboost1.54-dev-src.tar.gz
+	cd boost1.54-1.54.0
+	./bootstrap.sh
+	./b2
+fi
+if [ ! -d "$HOME/cache/boost" ]; then
+	echo "Installing libboost1.54 package..."
+	mkdir $HOME/cache/boost
+	cd $HOME/cache/boost1.54-1.54.0
+	./b2 --prefix=$HOME/cache/boost install > /dev/null
+fi
+cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,19 +40,21 @@ cache:
  directories:
   - $HOME/cache
 
+# these are ordered by longest running time, so that all instances complete
+# within the longest running instances, which is the first.
 env:
+ - TEST_SUITE="check=examples examples=stm32f4_discovery"
+ - TEST_SUITE="check=examples examples=stm32f3_discovery"
  - TEST_SUITE="unittest"
- - TEST_SUITE="check=devices"
- - TEST_SUITE="check=examples examples=arduino_uno"
  - TEST_SUITE="check=examples examples=avr"
+ - TEST_SUITE="check=devices"
  - TEST_SUITE="check=examples examples=linux"
+ - TEST_SUITE="check=examples examples=stm32f429_discovery"
+ - TEST_SUITE="check=examples examples=stm32f1_discovery"
+# - TEST_SUITE="check=examples examples=stm32f7_discovery"
  - TEST_SUITE="check=examples examples=lpcxpresso"
  - TEST_SUITE="check=examples examples=stm32"
- - TEST_SUITE="check=examples examples=stm32f1_discovery"
- - TEST_SUITE="check=examples examples=stm32f3_discovery"
- - TEST_SUITE="check=examples examples=stm32f4_discovery"
- - TEST_SUITE="check=examples examples=stm32f429_discovery"
-# - TEST_SUITE="check=examples examples=stm32f7_discovery"
+ - TEST_SUITE="check=examples examples=arduino_uno"
  - TEST_SUITE="check=examples examples=stm32f4_loa_v2b"
  - TEST_SUITE="check=examples examples=unittest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,44 @@
 language: cpp
 compiler: gcc
+sudo: false
+
+addons:
+ apt:
+  sources:
+   - ubuntu-toolchain-r-test
+  packages:
+   - scons
+   - python
+   - python-jinja2
+   - python-lxml
+   - libsdl1.2-dev
+   - libsdl-image1.2-dev
+   - libgtkmm-2.4-dev
+   - g++-4.8
+   - lib32z1
+   - lib32ncurses5
+   - lib32bz2-1.0
 
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -y software-properties-common
- - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
- - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
- - sudo add-apt-repository -y ppa:mapnik/boost
- - sudo apt-get update -qq
- - sudo apt-get install -y scons python python-jinja2 python-lxml
- - sudo apt-get install -y libsdl1.2-dev libsdl-image1.2-dev libgtkmm-2.4-dev
- - sudo apt-get install -y gcc-arm-none-eabi g++-4.8
- - sudo apt-get install -y libboost1.49-dev libboost-system1.49-dev libboost-thread1.49-dev
  - export CC=gcc-4.8
  - export CXX=g++-4.8
- - wget http://www.atmel.com/images/avr8-gnu-toolchain-3.4.5.1522-linux.any.x86.tar.gz -O avr8.tar.gz
- - tar -zxf avr8.tar.gz
- - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86/bin"
+ - bash .travis.dep.sh
+ - export LD_LIBRARY_PATH="$HOME/cache/boost/lib:$LD_LIBRARY_PATH"
+ - export CXXFLAGS="-isystem$HOME/cache/boost/include"
+ - export LDFLAGS="-L$HOME/cache/boost/lib"
+ - export PATH="$HOME/cache/avr8-gnu-toolchain-linux_x86/bin:$HOME/cache/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH"
+ - echo $PATH
+ - ls -l $HOME/cache/avr8-gnu-toolchain-linux_x86/bin
+ - ls -l $HOME/cache/gcc-arm-none-eabi-4_9-2015q3/bin
+ - ls -l $HOME/cache/boost
+ - which avr-g++
+ - avr-g++ --version
+ - which arm-none-eabi-g++
+ - arm-none-eabi-g++ --version
+
+cache:
+ directories:
+  - $HOME/cache
 
 env:
  - TEST_SUITE="unittest"

--- a/scons/site_tools/hosted.py
+++ b/scons/site_tools/hosted.py
@@ -101,5 +101,12 @@ def generate(env, **kw):
 		"-Woverloaded-virtual",
 	]
 
+	if 'CXXFLAGS' in os.environ:
+		flags = "".join(os.environ['CXXFLAGS'])
+		env['CXXFLAGS'].append(flags)
+	if 'LDFLAGS' in os.environ:
+		flags = "".join(os.environ['LDFLAGS'])
+		env['LINKFLAGS'] = flags
+
 def exists(env):
 	return env.Detect('g++')


### PR DESCRIPTION
Our current CI is running in the (legacy) standard virtualization environment, which does not have as [much computational resources as the container-based one](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments).
Furthermore caching of directories is not available for public repositories, which means that for every instance in our unittests at least the AVR toolchain has to be downloaded again from Atmels servers, which adds time.

This feature enables the container-based environment and the use of the cache for toolchains and boost.
Since `sudo` is not available and [only whitelisted packages are allowed](https://github.com/travis-ci/apt-package-whitelist), we have to download both the AVR and Cortex-M toolchains, as well as build the latest boost package from source.
The results are cached, so that this only has to happen once.

Total running time is reduced from ~90min to about ~52min, with the elapsed time reducing from ~30min to about ~14min.
So the CI runs about twice as fast now, which is a great improvement us and also for Travis CI.
