### PR TITLE
[io] add overloaded printf functions that takes a va_list

### DIFF
--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -15,6 +15,8 @@
 #include <xpcc/architecture/detect.hpp>
 #include <xpcc/architecture/utils.hpp>
 
+#include <stdarg.h>	// va_list
+
 #include "iodevice.hpp"
 #include "iodevice_wrapper.hpp"
 
@@ -438,6 +440,9 @@ public :
 	 */
 	IOStream&
 	printf(const char* fmt, ...);
+
+	IOStream&
+	vprintf(const char *fmt, va_list vlist);
 
 protected :
 	void

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -19,6 +19,15 @@ xpcc::IOStream::printf(const char *fmt, ...)
 	va_list ap;
 	va_start(ap, fmt);
 
+	this->vprintf(fmt, ap);
+
+	va_end(ap);
+	return *this;
+}
+
+xpcc::IOStream&
+xpcc::IOStream::vprintf(const char *fmt, va_list ap)
+{
 	unsigned char c;
 
 	// for all chars in format (fmt)
@@ -162,7 +171,6 @@ xpcc::IOStream::printf(const char *fmt, ...)
 		}
 	}
 
-	va_end(ap);
 	return *this;
 }
 


### PR DESCRIPTION
This is very similar to std::vprinf:
http://en.cppreference.com/w/cpp/io/c/vfprintf

It makes it possible for a varargs function to
relay its arguments to printf.
