### PR TITLE
[driver] STM32: Uart: name all files uart to prevent confusion

### DIFF
--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -54,8 +54,7 @@
 		%%	set uart = "Uart"
 	%% endif
 
-#include "../../uart/stm32/{{ uart | lower }}_{{ id }}.hpp"
-#include "../../uart/stm32/{{ uart | lower }}_hal_{{ id }}.hpp"
+#include "../../uart/stm32/uart_{{ id }}.hpp"
 
 extern "C" void {{ uart | upper ~ id }}_IRQHandler(void);
 

--- a/src/xpcc/architecture/platform/driver/spi/stm32_uart/uart_spi_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/stm32_uart/uart_spi_master.hpp.in
@@ -11,7 +11,7 @@
 #define XPCC_STM32_UART_SPI_MASTER{{ id }}_HPP
 
 #include <xpcc/architecture/interface/spi_master.hpp>
-#include "../../uart/stm32/usart_hal_{{ id }}.hpp"
+#include "../../uart/stm32/uart_hal_{{ id }}.hpp"
 #include "type_ids.hpp"
 
 namespace xpcc

--- a/src/xpcc/architecture/platform/driver/uart/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/driver.xml
@@ -3,15 +3,11 @@
 <rca version="1.0">
 	<driver type="uart" name="stm32">
 		<!-- UartHal -->
-		<template instances="1,2,3,6" out="usart_hal_{{id}}.hpp">uart_hal.hpp.in</template>
-		<template instances="1,2,3,6" out="usart_hal_{{id}}_impl.hpp">uart_hal_impl.hpp.in</template>
-		<template instances="4,5,7,8" out="uart_hal_{{id}}.hpp">uart_hal.hpp.in</template>
-		<template instances="4,5,7,8" out="uart_hal_{{id}}_impl.hpp">uart_hal_impl.hpp.in</template>
+		<template instances="1,2,3,4,5,6,7,8" out="uart_hal_{{id}}.hpp">uart_hal.hpp.in</template>
+		<template instances="1,2,3,4,5,6,7,8" out="uart_hal_{{id}}_impl.hpp">uart_hal_impl.hpp.in</template>
 		<!-- Uart -->
-		<template instances="1,2,3,6" out="usart_{{id}}.hpp">uart.hpp.in</template>
-		<template instances="1,2,3,6" out="usart_{{id}}.cpp">uart.cpp.in</template>
-		<template instances="4,5,7,8" out="uart_{{id}}.hpp">uart.hpp.in</template>
-		<template instances="4,5,7,8" out="uart_{{id}}.cpp">uart.cpp.in</template>
+		<template instances="1,2,3,4,5,6,7,8" out="uart_{{id}}.hpp">uart.hpp.in</template>
+		<template instances="1,2,3,4,5,6,7,8" out="uart_{{id}}.cpp">uart.cpp.in</template>
 		<template>uart_base.hpp.in</template>
 		<template>type_ids.hpp.in</template>
 		<template>uart_baudrate.hpp.in</template>

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
@@ -16,8 +16,8 @@
 %% set hal = uart ~ "Hal" ~ id
 
 #include "../../../device.hpp"
-#include "{{ uart | lower }}_hal_{{ id }}.hpp"
-#include "{{ uart | lower }}_{{ id }}.hpp"
+#include "uart_hal_{{ id }}.hpp"
+#include "uart_{{ id }}.hpp"
 
 %% if parameters.buffered
 #include <xpcc/architecture/driver/atomic.hpp>

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
@@ -13,14 +13,14 @@
 %% endif
 %% set hal = uart ~ "Hal" ~ id
 
-#ifndef XPCC_STM32_{{ uart | upper }}_{{ id }}_HPP
-#define XPCC_STM32_{{ uart | upper }}_{{ id }}_HPP
+#ifndef XPCC_STM32_UART_{{ id }}_HPP
+#define XPCC_STM32_UART_{{ id }}_HPP
 
 #include <xpcc/architecture/interface/uart.hpp>
 #include "../../../type_ids.hpp"
 #include "uart_base.hpp"
 #include "uart_baudrate.hpp"
-#include "{{ uart | lower }}_hal_{{ id }}.hpp"
+#include "uart_hal_{{ id }}.hpp"
 
 namespace xpcc
 {
@@ -116,4 +116,4 @@ template< 	class SystemClock, uint32_t baudrate,
 
 }	// namespace xpcc
 
-#endif // XPCC_STM32_{{ uart | upper }}_{{ id }}_HPP
+#endif // XPCC_STM32_UART_{{ id }}_HPP

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
@@ -12,8 +12,8 @@
 %%	set uart = "Uart"
 %% endif
 
-#ifndef XPCC_STM32_{{ uart | upper }}HAL_{{ id }}_HPP
-#define XPCC_STM32_{{ uart | upper }}HAL_{{ id }}_HPP
+#ifndef XPCC_STM32_UARTHAL_{{ id }}_HPP
+#define XPCC_STM32_UARTHAL_{{ id }}_HPP
 
 #include <stdint.h>
 #include "../../../type_ids.hpp"
@@ -180,6 +180,6 @@ public:
 
 }	// namespace xpcc
 
-#include "{{ uart | lower }}_hal_{{ id }}_impl.hpp"
+#include "uart_hal_{{ id }}_impl.hpp"
 
-#endif // XPCC_STM32_{{ uart | upper }}HAL_{{ id }}_HPP
+#endif // XPCC_STM32_UARTHAL_{{ id }}_HPP

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
@@ -16,7 +16,7 @@
 %% set name = uart ~ "Hal" ~ id
 %% set peripheral = uart | upper ~ id
 
-#ifndef XPCC_STM32_{{ uart | upper }}HAL_{{ id }}_HPP
+#ifndef XPCC_STM32_UARTHAL_{{ id }}_HPP
 #	error 	"Don't include this file directly, use" \
 #			"'{{ uart | lower }}_hal_{{ id }}.hpp' instead!"
 #endif


### PR DESCRIPTION
Naming all files generated by the driver the same
cleans up the code and makes it easier to cope with
STM32F0 where all UART IPs are called USART.

As these files are not supposed to be included by the user directly
and all class names are kept the same, this should not
impact any existing code.
