### PR TITLE
[driver] STM32: CAN: add precalculated bit timings for 48MHz

### DIFF
--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -119,10 +119,12 @@ public:
 		 * STM32F40x   tPCLK = 1 / 42 MHz
 		 */
 		constexpr uint8_t bs1 = (SystemClock::Can{{ id }} ==  MHz8)? 11 :
+								(SystemClock::Can{{ id }} == MHz48)? 11 :
 								(SystemClock::Can{{ id }} == MHz30)? 10 :
 								(SystemClock::Can{{ id }} == MHz36)? 12 :
 								(SystemClock::Can{{ id }} == MHz42)? 14 : 0;
 		constexpr uint8_t bs2 = (SystemClock::Can{{ id }} ==  MHz8)?  4 :
+								(SystemClock::Can{{ id }} == MHz48)?  4 :
 								(SystemClock::Can{{ id }} == MHz30)?  4 :
 								(SystemClock::Can{{ id }} == MHz36)?  5 :
 								(SystemClock::Can{{ id }} == MHz42)?  6 : 0;
@@ -130,7 +132,7 @@ public:
 								(bitrate * (1 + bs1 + bs2));
 		static_assert(bs1 > 0 and bs2 > 0,
 				"Unsupported frequency for Can peripheral. "
-				"Only 30 Mhz, 36 MHz and 42 MHz are supported at the moment.");
+				"Only 8MHz, 30 Mhz, 36 MHz, 42 MHz and 48 MHz are supported at the moment.");
 		static_assert(prescaler > 0, "CAN bitrate is too high for standard bit timings!");
 
 		return initializeWithPrescaler(prescaler, bs1, bs2, interruptPriority, startupMode, overwriteOnOverrun);


### PR DESCRIPTION
Tested in hardware on a STM32F072 running at 48MHz with a CAN bitrate of 125kBps
