### PR TITLE
Add support for STM32F072

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ env:
  - TEST_SUITE="check=examples examples=linux"
  - TEST_SUITE="check=examples examples=stm32f429_discovery"
  - TEST_SUITE="check=examples examples=stm32f1_discovery"
+ - TEST_SUITE="check=examples examples=stm32f072_discovery"
 # - TEST_SUITE="check=examples examples=stm32f7_discovery"
  - TEST_SUITE="check=examples examples=lpcxpresso"
  - TEST_SUITE="check=examples examples=stm32"

--- a/examples/stm32f072_discovery/blink/SConstruct
+++ b/examples/stm32f072_discovery/blink/SConstruct
@@ -1,0 +1,29 @@
+
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+files = env.FindFiles('.')
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = files.sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+hexfile = env.Hex(program)
+
+env.Alias('program', env.OpenOcd(program))
+env.Alias('build', [hexfile, env.Listing(program)])
+env.Alias('all', ['build', 'size'])
+
+env.Default('all')

--- a/examples/stm32f072_discovery/blink/main.cpp
+++ b/examples/stm32f072_discovery/blink/main.cpp
@@ -1,0 +1,19 @@
+#include "../stm32f072_discovery.hpp"
+
+using namespace Board;
+
+MAIN_FUNCTION
+{
+	Board::initialize();
+
+	LedUp::set();
+	LedDown::set();
+
+	while (1) {
+		LedRight::toggle();
+		LedUp::toggle();
+		LedLeft::toggle();
+		LedDown::toggle();
+		xpcc::delayMilliseconds(1000);
+	}
+}

--- a/examples/stm32f072_discovery/blink/openocd.cfg
+++ b/examples/stm32f072_discovery/blink/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2.cfg]
+source [find target/stm32f0x_stlink.cfg]
+
+reset_config srst_only
+
+init
+reset init

--- a/examples/stm32f072_discovery/blink/project.cfg
+++ b/examples/stm32f072_discovery/blink/project.cfg
@@ -1,0 +1,24 @@
+
+[general]
+name = blink
+
+[scons]
+regenerate = false
+
+[build]
+device = stm32f072rb
+clock = 8000000
+buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
+
+[program]
+tool = openocd
+
+[defines]
+CORTEX_VECTORS_RAM = 0
+
+[openocd]
+configfile = openocd.cfg
+commands =
+  flash write_image erase $SOURCE
+  reset run
+  shutdown

--- a/examples/stm32f072_discovery/blink/project.cfg
+++ b/examples/stm32f072_discovery/blink/project.cfg
@@ -7,7 +7,7 @@ regenerate = false
 
 [build]
 device = stm32f072rb
-clock = 8000000
+clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [program]

--- a/examples/stm32f072_discovery/can/SConstruct
+++ b/examples/stm32f072_discovery/can/SConstruct
@@ -1,0 +1,29 @@
+
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+files = env.FindFiles('.')
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = files.sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+hexfile = env.Hex(program)
+
+env.Alias('program', env.OpenOcd(program))
+env.Alias('build', [hexfile, env.Listing(program)])
+env.Alias('all', ['build', 'size'])
+
+env.Default('all')

--- a/examples/stm32f072_discovery/can/main.cpp
+++ b/examples/stm32f072_discovery/can/main.cpp
@@ -70,7 +70,7 @@ MAIN_FUNCTION
 	// Initialize Can
 	GpioInputB8::connect(Can1::Rx, Gpio::InputType::PullUp);
 	GpioOutputB9::connect(Can1::Tx, Gpio::OutputType::PushPull);
-	Can1::initialize<Board::DefaultSystemClock, Can1::Bitrate::kBps500>(9);
+	Can1::initialize<Board::DefaultSystemClock, Can1::Bitrate::kBps125>(9);
 
 	XPCC_LOG_INFO << "Setting up Filter for Can ..." << xpcc::endl;
 	// Receive every message

--- a/examples/stm32f072_discovery/can/main.cpp
+++ b/examples/stm32f072_discovery/can/main.cpp
@@ -1,0 +1,119 @@
+#include "../stm32f072_discovery.hpp"
+#include <xpcc/processing.hpp>
+#include <xpcc/debug/logger.hpp>
+
+/**
+ * Example of CAN Hardware on STM32 F0 Discovery Board.
+ *
+ * Connect PB8 / PB9 to a CAN transceiver which is connected to a CAN bus.
+ *
+ */
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Usart1, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::DEBUG
+
+static void
+displayMessage(const xpcc::can::Message& message)
+{
+	static uint32_t receiveCounter = 0;
+	receiveCounter++;
+
+	XPCC_LOG_INFO<< "id  =" << message.getIdentifier();
+	if (message.isExtended()) {
+		XPCC_LOG_INFO<< " extended";
+	}
+	else {
+		XPCC_LOG_INFO<< " standard";
+	}
+	if (message.isRemoteTransmitRequest()) {
+		XPCC_LOG_INFO<< ", rtr";
+	}
+	XPCC_LOG_INFO<< xpcc::endl;
+
+	XPCC_LOG_INFO<< "dlc =" << message.getLength() << xpcc::endl;
+	if (!message.isRemoteTransmitRequest())
+	{
+		XPCC_LOG_INFO << "data=";
+		for (uint32_t i = 0; i < message.getLength(); ++i) {
+			XPCC_LOG_INFO<< xpcc::hex << message.data[i] << xpcc::ascii << ' ';
+		}
+		XPCC_LOG_INFO<< xpcc::endl;
+	}
+	XPCC_LOG_INFO<< "# received=" << receiveCounter << xpcc::endl;
+}
+
+// ----------------------------------------------------------------------------
+MAIN_FUNCTION
+{
+	Board::initialize();
+
+	Board::LedUp::set();
+
+	// Initialize Usart
+	GpioOutputA9::connect(Usart1::Tx);
+	GpioInputA10::connect(Usart1::Rx, Gpio::InputType::PullUp);
+	Usart1::initialize<Board::DefaultSystemClock, 115200>(12);
+
+	XPCC_LOG_INFO << "CAN Test Program" << xpcc::endl;
+
+	XPCC_LOG_INFO << "Initializing Can ..." << xpcc::endl;
+	// Initialize Can
+	GpioInputB8::connect(Can1::Rx, Gpio::InputType::PullUp);
+	GpioOutputB9::connect(Can1::Tx, Gpio::OutputType::PushPull);
+	Can1::initialize<Board::DefaultSystemClock, Can1::Bitrate::kBps500>(9);
+
+	XPCC_LOG_INFO << "Setting up Filter for Can ..." << xpcc::endl;
+	// Receive every message
+	CanFilter::setFilter(0, CanFilter::FIFO0,
+			CanFilter::ExtendedIdentifier(0),
+			CanFilter::ExtendedFilterMask(0));
+
+	// Send a message
+	XPCC_LOG_INFO << "Sending message on Can ..." << xpcc::endl;
+	xpcc::can::Message msg1(1, 1);
+	msg1.setExtended(true);
+	msg1.data[0] = 0x11;
+	Can1::sendMessage(msg1);
+
+	xpcc::ShortPeriodicTimer pTimer(1000);
+
+	const auto silent    = static_cast<bool>(CAN->BTR & CAN_BTR_SILM);
+	const auto loop_back = static_cast<bool>(CAN->BTR & CAN_BTR_LBKM);
+	XPCC_LOG_INFO << "Can silent mode: " << silent << xpcc::endl;
+	XPCC_LOG_INFO << "Can loop back mode: " << loop_back << xpcc::endl;
+
+	while (1)
+	{
+		if (Can1::isMessageAvailable())
+		{
+			XPCC_LOG_INFO << "Can: Message is available..." << xpcc::endl;
+			xpcc::can::Message message;
+			Can1::getMessage(message);
+			displayMessage(message);
+		}
+
+		if (pTimer.execute()) {
+			Board::LedUp::toggle();
+
+			static uint8_t idx = 0;
+			xpcc::can::Message msg1(1, 1);
+			msg1.setExtended(true);
+			msg1.data[0] = idx;
+			Can1::sendMessage(msg1);
+
+			++idx;
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32f072_discovery/can/openocd.cfg
+++ b/examples/stm32f072_discovery/can/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2.cfg]
+source [find target/stm32f0x_stlink.cfg]
+
+reset_config srst_only
+
+init
+reset init

--- a/examples/stm32f072_discovery/can/project.cfg
+++ b/examples/stm32f072_discovery/can/project.cfg
@@ -1,0 +1,24 @@
+
+[general]
+name = can
+
+[scons]
+regenerate = false
+
+[build]
+device = stm32f072rb
+clock = 8000000
+buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
+
+[program]
+tool = openocd
+
+[defines]
+CORTEX_VECTORS_RAM = 0
+
+[openocd]
+configfile = openocd.cfg
+commands =
+  flash write_image erase $SOURCE
+  reset run
+  shutdown

--- a/examples/stm32f072_discovery/can/project.cfg
+++ b/examples/stm32f072_discovery/can/project.cfg
@@ -7,7 +7,7 @@ regenerate = false
 
 [build]
 device = stm32f072rb
-clock = 8000000
+clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [program]

--- a/examples/stm32f072_discovery/rotation/SConstruct
+++ b/examples/stm32f072_discovery/rotation/SConstruct
@@ -1,0 +1,29 @@
+
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+files = env.FindFiles('.')
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = files.sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+hexfile = env.Hex(program)
+
+env.Alias('program', env.OpenOcd(program))
+env.Alias('build', [hexfile, env.Listing(program)])
+env.Alias('all', ['build', 'size'])
+
+env.Default('all')

--- a/examples/stm32f072_discovery/rotation/main.cpp
+++ b/examples/stm32f072_discovery/rotation/main.cpp
@@ -1,0 +1,76 @@
+#include "../stm32f072_discovery.hpp"
+#include <xpcc/processing.hpp>
+#include <xpcc/math.hpp>
+
+using namespace Board;
+
+// maps arbitrary gpios to a bit
+using LedRing = xpcc::SoftwareGpioPort<
+	Board::LedUp,		// 3
+	Board::LedRight,	// 2
+	Board::LedDown,		// 1
+	Board::LedLeft		// 0
+	>;
+
+// create the data object
+Board::l3g::Gyroscope::Data data;
+// and hand it to the sensor driver
+Board::l3g::Gyroscope gyro(data);
+
+
+class ReaderThread : public xpcc::pt::Protothread
+{
+public:
+	bool
+	update()
+	{
+		PT_BEGIN();
+
+		// initialize with limited range of 250 degrees per second
+		PT_CALL(gyro.configure(gyro.Scale::Dps250));
+
+		while (true)
+		{
+			// read out the sensor
+			PT_CALL(gyro.readRotation());
+
+			// update the moving average
+			averageZ.update(gyro.getData().getZ());
+
+			{
+				float value = averageZ.getValue();
+				// normalize rotation and scale by 5 leds
+				uint16_t leds = abs(value / 200 * 5);
+				leds = (1 << abs(leds)) - 1;
+
+				LedRing::write(leds);
+			}
+
+			// repeat every 5 ms
+			this->timeout.restart(5);
+			PT_WAIT_UNTIL(this->timeout.isExpired());
+		}
+
+		PT_END();
+	}
+
+private:
+	xpcc::ShortTimeout timeout;
+	xpcc::filter::MovingAverage<float, 25> averageZ;
+};
+
+ReaderThread reader;
+
+
+MAIN_FUNCTION
+{
+	Board::initialize();
+	Board::initializeL3g();
+
+	while (1)
+	{
+		reader.update();
+	}
+
+	return 0;
+}

--- a/examples/stm32f072_discovery/rotation/openocd.cfg
+++ b/examples/stm32f072_discovery/rotation/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2.cfg]
+source [find target/stm32f0x_stlink.cfg]
+
+reset_config srst_only
+
+init
+reset init

--- a/examples/stm32f072_discovery/rotation/project.cfg
+++ b/examples/stm32f072_discovery/rotation/project.cfg
@@ -1,0 +1,24 @@
+
+[general]
+name = rotation
+
+[scons]
+regenerate = false
+
+[build]
+device = stm32f072rb
+clock = 8000000
+buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
+
+[program]
+tool = openocd
+
+[defines]
+CORTEX_VECTORS_RAM = 0
+
+[openocd]
+configfile = openocd.cfg
+commands =
+  flash write_image erase $SOURCE
+  reset run
+  shutdown

--- a/examples/stm32f072_discovery/rotation/project.cfg
+++ b/examples/stm32f072_discovery/rotation/project.cfg
@@ -7,7 +7,7 @@ regenerate = false
 
 [build]
 device = stm32f072rb
-clock = 8000000
+clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [program]

--- a/examples/stm32f072_discovery/stm32f072_discovery.hpp
+++ b/examples/stm32f072_discovery/stm32f072_discovery.hpp
@@ -32,6 +32,7 @@ namespace Board
 struct DummyClock {
 	static constexpr int Frequency = 8 * 1000 * 1000;
 	static constexpr int Usart1 = Frequency;
+	static constexpr int Can1 = Frequency;
 	static constexpr int Spi2 = Frequency;
 };
 

--- a/examples/stm32f072_discovery/stm32f072_discovery.hpp
+++ b/examples/stm32f072_discovery/stm32f072_discovery.hpp
@@ -1,0 +1,106 @@
+// coding: utf-8
+/* Copyright (c) 2013, Roboterclub Aachen e.V.
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+*/
+// ----------------------------------------------------------------------------
+
+//
+// 32F072DISCOVERY
+// Discovery kit for STM32F072 series
+// http://www.st.com/web/en/catalog/tools/FM116/SC959/SS1532/PF259724
+//
+
+#ifndef XPCC_STM32_F072_DISCOVERY_HPP
+#define XPCC_STM32_F072_DISCOVERY_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/driver/inertial/l3gd20.hpp>
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F072 running at 48MHz generated from the internal 48MHz clock
+// TODO: enable once clock driver is implemented
+//using DefaultSystemClock = SystemClock<InternalClock<MHz48>, MHz48>;
+
+struct DummyClock {
+	static constexpr int Frequency = 8 * 1000 * 1000;
+	static constexpr int Usart1 = Frequency;
+	static constexpr int Spi2 = Frequency;
+};
+
+using DefaultSystemClock = DummyClock;
+
+using LedUp    = GpioOutputC6;
+using LedDown  = GpioOutputC7;
+using LedLeft  = GpioOutputC8;
+using LedRight = GpioOutputC9;
+using Button   = GpioInputA0;
+
+
+namespace l3g
+{
+using Int1 = GpioInputC1;	// MEMS_INT1 [L3GD20_INT1]: GPXTI0
+using Int2 = GpioInputC2;	// MEMS_INT2 [L3GD20_DRDY/INT2]: GPXTI1
+
+using Cs   = GpioOutputC0;		// CS_I2C/SPI [L3GD20_CS_I2C/SPI]
+using Sck  = GpioOutputB13;	// SPI2_SCK [L3GD20_SCL/SPC]
+using Mosi = GpioOutputB15;	// SPI2_MISO [L3GD20_SDA/SDI/SDO]
+using Miso = GpioInputB14;	// SPI2_MISO [L3GD20_SA0/SDO]
+
+using SpiMaster = SpiMaster2;
+using Transport = xpcc::Lis3TransportSpi< SpiMaster, Cs >;
+using Gyroscope = xpcc::L3gd20< Transport >;
+}
+
+inline void
+initialize()
+{
+	// TODO: enable once clock driver is implemented
+	// DefaultSystemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<DefaultSystemClock>();
+
+	LedUp::setOutput(xpcc::Gpio::Low);
+	LedDown::setOutput(xpcc::Gpio::Low);
+	LedLeft::setOutput(xpcc::Gpio::Low);
+	LedRight::setOutput(xpcc::Gpio::Low);
+
+	Button::setInput();
+	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	Button::enableExternalInterrupt();
+//	Button::enableExternalInterruptVector(12);
+}
+
+
+inline void
+initializeL3g()
+{
+	l3g::Int1::setInput();
+	l3g::Int1::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	l3g::Int1::enableExternalInterrupt();
+//	l3g::Int1::enableExternalInterruptVector(12);
+
+	l3g::Int2::setInput();
+	l3g::Int2::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	l3g::Int2::enableExternalInterrupt();
+//	l3g::Int2::enableExternalInterruptVector(12);
+
+	l3g::Cs::setOutput(xpcc::Gpio::High);
+
+	l3g::Sck::connect(l3g::SpiMaster::Sck);
+	l3g::Mosi::connect(l3g::SpiMaster::Mosi);
+	l3g::Miso::connect(l3g::SpiMaster::Miso);
+
+	l3g::SpiMaster::initialize<DefaultSystemClock, 4000000>();
+	l3g::SpiMaster::setDataMode(l3g::SpiMaster::DataMode::Mode3);
+}
+
+} // namespace Board
+
+#endif	// XPCC_STM32_F072_DISCOVERY_HPP

--- a/examples/stm32f072_discovery/uart/SConstruct
+++ b/examples/stm32f072_discovery/uart/SConstruct
@@ -1,0 +1,29 @@
+
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+files = env.FindFiles('.')
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = files.sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+hexfile = env.Hex(program)
+
+env.Alias('program', env.OpenOcd(program))
+env.Alias('build', [hexfile, env.Listing(program)])
+env.Alias('all', ['build', 'size'])
+
+env.Default('all')

--- a/examples/stm32f072_discovery/uart/main.cpp
+++ b/examples/stm32f072_discovery/uart/main.cpp
@@ -1,0 +1,34 @@
+#include "../stm32f072_discovery.hpp"
+
+// ----------------------------------------------------------------------------
+/**
+ * Very basic example of USART usage.
+ * The ASCII sequence 'A', 'B', 'C, ... , 'Z', 'A', 'B', 'C', ...
+ * is printed with 9600 baud, 8N1 at pin PA9.
+ */
+MAIN_FUNCTION
+{
+	Board::initialize();
+
+	Board::LedUp::set();
+
+	// Enable USART 1
+	GpioOutputA9::connect(Usart1::Tx);
+	GpioInputA10::connect(Usart1::Rx, Gpio::InputType::PullUp);
+	Usart1::initialize<Board::DefaultSystemClock, 9600>(12);
+
+	while (1)
+	{
+		static uint8_t c = 'A';
+		Board::LedUp::toggle();
+		Board::LedDown::toggle();
+		Usart1::write(c);
+		++c;
+		if (c > 'Z') {
+			c = 'A';
+		}
+		xpcc::delayMilliseconds(500);
+	}
+
+	return 0;
+}

--- a/examples/stm32f072_discovery/uart/openocd.cfg
+++ b/examples/stm32f072_discovery/uart/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2.cfg]
+source [find target/stm32f0x_stlink.cfg]
+
+reset_config srst_only
+
+init
+reset init

--- a/examples/stm32f072_discovery/uart/project.cfg
+++ b/examples/stm32f072_discovery/uart/project.cfg
@@ -1,0 +1,17 @@
+[general]
+name = uart
+
+[build]
+device = stm32f072rb
+clock = 8000000
+buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
+
+[program]
+tool = openocd
+
+[openocd]
+configfile = openocd.cfg
+commands =
+  flash write_image erase $SOURCE
+  reset run
+  shutdown

--- a/examples/stm32f072_discovery/uart/project.cfg
+++ b/examples/stm32f072_discovery/uart/project.cfg
@@ -3,7 +3,7 @@ name = uart
 
 [build]
 device = stm32f072rb
-clock = 8000000
+clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [program]

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
@@ -1,0 +1,440 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<rca version="1.0">
+  <!-- WARNING: This file is generated automatically, do not edit!
+ 		Please modify the xpcc/tools/device_file_generator code instead and rebuild this file.
+ 		Be aware, that regenerated files might have a different composition due to technical reasons. -->
+  <device platform="stm32" family="f0" name="072" pin_id="c|r|v" size_id="8|b">
+    <flash device-size-id="8">65536</flash>
+    <flash device-size-id="b">131072</flash>
+    <ram>16384</ram>
+    <core>cortex-m0</core>
+    <linkerscript device-size-id="b">stm32f0xx_b.ld</linkerscript>
+    <pin-count device-pin-id="v">100</pin-count>
+    <pin-count device-pin-id="c">48</pin-count>
+    <pin-count device-pin-id="r">64</pin-count>
+    <header>stm32f0xx.h</header>
+    <define>STM32F072xB</define>
+    <driver type="core" name="cortex">
+      <memory device-size-id="8" access="rx" start="0x8000000" name="flash" size="64"/>
+      <memory device-size-id="b" access="rx" start="0x8000000" name="flash" size="128"/>
+      <memory access="rwx" start="0x20000000" name="sram1" size="16"/>
+      <vector position="0" name="WWDG"/>
+      <vector position="1" name="PVD_VDDIO2"/>
+      <vector position="2" name="RTC"/>
+      <vector position="3" name="FLASH"/>
+      <vector position="4" name="RCC_CRS"/>
+      <vector position="5" name="EXTI0_1"/>
+      <vector position="6" name="EXTI2_3"/>
+      <vector position="7" name="EXTI4_15"/>
+      <vector position="8" name="TSC"/>
+      <vector position="9" name="DMA1_Channel1"/>
+      <vector position="10" name="DMA1_Channel2_3"/>
+      <vector position="11" name="DMA1_Channel4_5_6_7"/>
+      <vector position="12" name="ADC1_COMP"/>
+      <vector position="13" name="TIM1_BRK_UP_TRG_COM"/>
+      <vector position="14" name="TIM1_CC"/>
+      <vector position="15" name="TIM2"/>
+      <vector position="16" name="TIM3"/>
+      <vector position="17" name="TIM6_DAC"/>
+      <vector position="18" name="TIM7"/>
+      <vector position="19" name="TIM14"/>
+      <vector position="20" name="TIM15"/>
+      <vector position="21" name="TIM16"/>
+      <vector position="22" name="TIM17"/>
+      <vector position="23" name="I2C1"/>
+      <vector position="24" name="I2C2"/>
+      <vector position="25" name="SPI1"/>
+      <vector position="26" name="SPI2"/>
+      <vector position="27" name="USART1"/>
+      <vector position="28" name="USART2"/>
+      <vector position="29" name="USART3_4"/>
+      <vector position="30" name="CEC_CAN"/>
+      <vector position="31" name="USB"/>
+    </driver>
+    <!-- <driver type="adc" name="stm32f0"/> -->
+    <driver type="can" name="stm32" instances="1"/>
+    <!-- <driver type="clock" name="stm32"/> -->
+    <driver type="i2c" name="stm32" instances="1,2"/>
+    <driver type="spi" name="stm32" instances="1,2"/>
+    <driver type="spi" name="stm32_uart" instances="1,2,3,4"/>
+    <driver type="timer" name="stm32" instances="1,2,3,6,7,14,15,16,17"/>
+    <driver type="uart" name="stm32" instances="1,2,3,4"/>
+    <driver type="usb" name="stm32_fs"/>
+    <driver type="gpio" name="stm32">
+      <gpio port="A" id="0">
+        <af id="1" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="4" peripheral="Uart4" name="Tx" type="out"/>
+        <af id="4" peripheral="UartSpiMaster4" name="Mosi" type="out"/>
+        <!-- <af peripheral="Adc" name="Channel0" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="1">
+        <af id="1" peripheral="Uart2" name="De"/>
+        <af id="1" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="2" peripheral="Timer2" name="Channel2"/>
+        <af id="4" peripheral="Uart4" name="Rx" type="in"/>
+        <af id="4" peripheral="UartSpiMaster4" name="Miso" type="in"/>
+        <af id="5" peripheral="Timer15" name="Channel1N"/>
+        <!-- <af peripheral="Adc" name="Channel1" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="2">
+        <af id="0" peripheral="Timer15" name="Channel1"/>
+        <af id="1" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="1" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="2" peripheral="Timer2" name="Channel3"/>
+        <!-- <af peripheral="Adc" name="Channel2" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="3">
+        <af id="0" peripheral="Timer15" name="Channel2"/>
+        <af id="1" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="2" peripheral="Timer2" name="Channel4"/>
+        <!-- <af peripheral="Adc" name="Channel3" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="4">
+        <af id="0" peripheral="SpiMaster1" name="Nss"/>
+        <af id="1" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="1" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="4" peripheral="Timer14" name="Channel1"/>
+        <!-- <af peripheral="Adc" name="Channel4" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="5">
+        <af id="0" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <!-- <af peripheral="Adc" name="Channel5" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="6">
+        <af id="0" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="1" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="4" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="5" peripheral="Timer16" name="Channel1"/>
+        <!-- <af peripheral="Adc" name="Channel6" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="7">
+        <af id="0" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="1" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer1" name="Channel1N"/>
+        <af id="4" peripheral="Timer14" name="Channel1"/>
+        <af id="5" peripheral="Timer17" name="Channel1"/>
+        <!-- <af peripheral="Adc" name="Channel7" type="analog"/> -->
+      </gpio>
+      <gpio port="A" id="8">
+        <!-- <af id="0" peripheral="MCO" type="out"/> -->
+        <af id="1" peripheral="Uart1" name="Ck" type="out"/>
+        <af id="1" peripheral="UartSpiMaster1" name="Sck" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel1"/>
+      </gpio>
+      <gpio port="A" id="9">
+        <af id="0" peripheral="Timer15" name="BreakIn" type="in"/>
+        <af id="1" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel2"/>
+      </gpio>
+      <gpio port="A" id="10">
+        <af id="0" peripheral="Timer17" name="BreakIn" type="in"/>
+        <af id="1" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="2" peripheral="Timer1" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="11">
+        <af id="1" peripheral="Uart1" name="Cts" type="in"/>
+        <af id="2" peripheral="Timer1" name="Channel4"/>
+        <af id="4" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio port="A" id="12">
+        <af id="1" peripheral="Uart1" name="De"/>
+        <af id="1" peripheral="Uart1" name="Rts" type="out"/>
+        <af id="2" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+        <af id="4" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio port="A" id="13"/>
+      <gpio port="A" id="14">
+        <af id="1" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="1" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="A" id="15">
+        <af id="0" peripheral="SpiMaster1" name="Nss"/>
+        <af id="1" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="4" peripheral="Uart4" name="De"/>
+        <af id="4" peripheral="Uart4" name="Rts" type="out"/>
+      </gpio>
+      <gpio port="B" id="0">
+        <af id="1" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer1" name="Channel2N"/>
+        <af id="4" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <!-- <af peripheral="Adc" name="Channel8" type="analog"/> -->
+      </gpio>
+      <gpio port="B" id="1">
+        <af id="0" peripheral="Timer14" name="Channel1"/>
+        <af id="1" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer1" name="Channel3N"/>
+        <af id="4" peripheral="Uart3" name="De"/>
+        <af id="4" peripheral="Uart3" name="Rts" type="out"/>
+        <!-- <af peripheral="Adc" name="Channel9" type="analog"/> -->
+      </gpio>
+      <gpio port="B" id="2"/>
+      <gpio port="B" id="3">
+        <af id="0" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="2" peripheral="Timer2" name="Channel2"/>
+      </gpio>
+      <gpio port="B" id="4">
+        <af id="0" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="1" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="Timer17" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="5">
+        <af id="0" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="1" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer16" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="6">
+        <af id="0" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="1" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="2" peripheral="Timer16" name="Channel1N"/>
+      </gpio>
+      <gpio port="B" id="7">
+        <af id="0" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="1" peripheral="I2cMaster1" name="Sda"/>
+        <af id="2" peripheral="Timer17" name="Channel1N"/>
+        <af id="4" peripheral="Uart4" name="Cts" type="in"/>
+      </gpio>
+      <gpio port="B" id="8">
+        <af id="1" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="2" peripheral="Timer16" name="Channel1"/>
+        <af id="4" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio port="B" id="9">
+        <af id="1" peripheral="I2cMaster1" name="Sda"/>
+        <af id="2" peripheral="Timer17" name="Channel1"/>
+        <af id="4" peripheral="Can1" name="Tx" type="out"/>
+        <af id="5" peripheral="SpiMaster2" name="Nss"/>
+      </gpio>
+      <gpio port="B" id="10">
+        <af id="1" peripheral="I2cMaster2" name="Scl" type="out"/>
+        <af id="2" peripheral="Timer2" name="Channel3"/>
+        <af id="4" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="B" id="11">
+        <af id="1" peripheral="I2cMaster2" name="Sda"/>
+        <af id="2" peripheral="Timer2" name="Channel4"/>
+        <af id="4" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio port="B" id="12">
+        <af id="0" peripheral="SpiMaster2" name="Nss"/>
+        <af id="2" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="4" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af id="5" peripheral="Timer15" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="13">
+        <af id="0" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel1N"/>
+        <af id="4" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="5" peripheral="I2cMaster2" name="Scl" type="out"/>
+      </gpio>
+      <gpio port="B" id="14">
+        <af id="0" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <af id="1" peripheral="Timer15" name="Channel1"/>
+        <af id="2" peripheral="Timer1" name="Channel2N"/>
+        <af id="4" peripheral="Uart3" name="De"/>
+        <af id="4" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="5" peripheral="I2cMaster2" name="Sda"/>
+      </gpio>
+      <gpio port="B" id="15">
+        <af id="0" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <af id="1" peripheral="Timer15" name="Channel2"/>
+        <af id="2" peripheral="Timer1" name="Channel3N"/>
+        <af id="3" peripheral="Timer15" name="Channel1N"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="0">
+        <!-- <af peripheral="Adc" name="Channel10" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="1">
+        <!-- <af peripheral="Adc" name="Channel11" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="2">
+        <af id="1" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <!-- <af peripheral="Adc" name="Channel12" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="3">
+        <af id="1" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <!-- <af peripheral="Adc" name="Channel13" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="4">
+        <af id="1" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="1" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <!-- <af peripheral="Adc" name="Channel14" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="5">
+        <af id="1" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="1" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <!-- <af peripheral="Adc" name="Channel15" type="analog"/> -->
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="6">
+        <af id="0" peripheral="Timer3" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="7">
+        <af id="0" peripheral="Timer3" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="8">
+        <af id="0" peripheral="Timer3" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="9">
+        <af id="0" peripheral="Timer3" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="10">
+        <af id="0" peripheral="Uart4" name="Tx" type="out"/>
+        <af id="0" peripheral="UartSpiMaster4" name="Mosi" type="out"/>
+        <af id="1" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="1" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="11">
+        <af id="0" peripheral="Uart4" name="Rx" type="in"/>
+        <af id="0" peripheral="UartSpiMaster4" name="Miso" type="in"/>
+        <af id="1" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="1" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="12">
+        <af id="0" peripheral="Uart4" name="Ck" type="out"/>
+        <af id="0" peripheral="UartSpiMaster4" name="Sck" type="out"/>
+        <af id="1" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="1" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="C" id="13"/>
+      <gpio port="C" id="14"/>
+      <gpio port="C" id="15"/>
+      <gpio device-pin-id="v" port="D" id="0">
+        <af id="0" peripheral="Can1" name="Rx" type="in"/>
+        <af id="1" peripheral="SpiMaster2" name="Nss"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="1">
+        <af id="0" peripheral="Can1" name="Tx" type="out"/>
+        <af id="1" peripheral="SpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="D" id="2">
+        <af id="0" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+        <af id="1" peripheral="Uart3" name="De"/>
+        <af id="1" peripheral="Uart3" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="3">
+        <af id="0" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="1" peripheral="SpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="4">
+        <af id="0" peripheral="Uart2" name="De"/>
+        <af id="0" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="1" peripheral="SpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="5">
+        <af id="0" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="6">
+        <af id="0" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="7">
+        <af id="0" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="0" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="8">
+        <af id="0" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="9">
+        <af id="0" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="10">
+        <af id="0" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="0" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="11">
+        <af id="0" peripheral="Uart3" name="Cts" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="12">
+        <af id="0" peripheral="Uart3" name="De"/>
+        <af id="0" peripheral="Uart3" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="13"/>
+      <gpio device-pin-id="v" port="D" id="14"/>
+      <gpio device-pin-id="v" port="D" id="15"/>
+      <gpio device-pin-id="v" port="E" id="0">
+        <af id="0" peripheral="Timer16" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="1">
+        <af id="0" peripheral="Timer17" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="2">
+        <af id="0" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="3">
+        <af id="0" peripheral="Timer3" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="4">
+        <af id="0" peripheral="Timer3" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="5">
+        <af id="0" peripheral="Timer3" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="6">
+        <af id="0" peripheral="Timer3" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="7">
+        <af id="0" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="8">
+        <af id="0" peripheral="Timer1" name="Channel1N"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="9">
+        <af id="0" peripheral="Timer1" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="10">
+        <af id="0" peripheral="Timer1" name="Channel2N"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="11">
+        <af id="0" peripheral="Timer1" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="12">
+        <af id="0" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="SpiMaster1" name="Nss"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="13">
+        <af id="0" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="SpiMaster1" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="14">
+        <af id="0" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="SpiMaster1" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="15">
+        <af id="0" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="1" peripheral="SpiMaster1" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="F" id="0"/>
+      <gpio port="F" id="1"/>
+      <gpio device-pin-id="v" port="F" id="2"/>
+      <gpio device-pin-id="v" port="F" id="3"/>
+      <gpio device-pin-id="v" port="F" id="6"/>
+      <gpio device-pin-id="v" port="F" id="9">
+        <af id="0" peripheral="Timer15" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="F" id="10">
+        <af id="0" peripheral="Timer15" name="Channel2"/>
+      </gpio>
+    </driver>
+  </device>
+</rca>

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
@@ -14,7 +14,7 @@
 #include "can_{{ id }}.hpp"
 #include <xpcc_config.hpp>
 
-%% if target is stm32f3
+%% if target is stm32f3 or target is stm32f0
 	%% set reg = 'CAN'
 %% else
 	%% set reg = 'CAN' ~ id
@@ -26,7 +26,7 @@
 #define CAN_BTR_TS2_POS		20
 #define CAN_BTR_TS1_POS		16
 
-%% if target is stm32f0 or target is stm32f3
+%% if target is stm32f3
 #	define	CAN1_TX_IRQHandler		USB_HP_CAN1_TX_IRQHandler
 #	define	CAN1_RX0_IRQHandler		USB_LP_CAN1_RX0_IRQHandler
 #	define	CAN1_TX_IRQn			USB_HP_CAN1_TX_IRQn
@@ -98,6 +98,17 @@ xpcc::stm32::Can{{ id }}::initializeWithPrescaler(
 	// FIFO1 Overrun, FIFO0 Overrun
 	{{ reg }}->IER = CAN_IER_FOVIE1 | CAN_IER_FOVIE0;
 
+%% if parameters.tx_buffer > 0
+	{{ reg }}->IER |= CAN_IER_TMEIE;
+%% endif
+
+%% if target is stm32f0
+	// Set vector priority
+	NVIC_SetPriority(CEC_CAN_IRQn, interruptPriority);
+
+	// Register Interrupts at the NVIC
+	nvicEnableInterrupt(CEC_CAN_IRQn);
+%% else
 	// Set vector priority
 	NVIC_SetPriority({{ reg }}_RX0_IRQn, interruptPriority);
 	NVIC_SetPriority({{ reg }}_RX1_IRQn, interruptPriority);
@@ -106,11 +117,13 @@ xpcc::stm32::Can{{ id }}::initializeWithPrescaler(
 	nvicEnableInterrupt({{ reg }}_RX0_IRQn);
 	nvicEnableInterrupt({{ reg }}_RX1_IRQn);
 
-%% if parameters.tx_buffer > 0
-	{{ reg }}->IER |= CAN_IER_TMEIE;
+	%% if parameters.tx_buffer > 0
 	nvicEnableInterrupt({{ reg }}_TX_IRQn);
 	NVIC_SetPriority({{ reg }}_TX_IRQn, interruptPriority);
+	%% endif
 %% endif
+
+
 
 %% if parameters.rx_buffer > 0
 	{{ reg }}->IER |= CAN_IER_FMPIE1 | CAN_IER_FMPIE0;
@@ -279,6 +292,31 @@ extern "C" void
 %% endif
 }
 
+%% if target is stm32f0
+// On stm32f0, ST has decided to use only one interrupt vector for all
+// CAN interrupts. In order to avoide duplicate code, we try to determine
+// the interrupt source and call the correct interrupts function defined above.
+// Sources for the different interrupts are specified in the Reference Manual
+// in the "bxCAN interrupts" section.
+extern "C" void
+CEC_CAN_IRQHandler()
+{
+	if({{ reg }}->TSR & (CAN_TSR_RQCP0 | CAN_TSR_RQCP1 | CAN_TSR_RQCP2)) {
+		{{ reg }}_TX_IRQHandler();
+	}
+
+	if({{ reg }}->RF0R & (CAN_RF0R_FMP0 | CAN_RF0R_FULL0 | CAN_RF0R_FOVR0)) {
+		{{ reg }}_RX0_IRQHandler();
+	}
+
+	if({{ reg }}->RF1R & (CAN_RF1R_FMP1 | CAN_RF1R_FULL1 | CAN_RF1R_FOVR1)) {
+		{{ reg }}_RX1_IRQHandler();
+	}
+
+	// TODO: we do not handle status changes at the moment.
+}
+%% endif
+
 // ----------------------------------------------------------------------------
 void
 xpcc::stm32::Can{{ id }}::setMode(Mode mode)
@@ -423,8 +461,10 @@ xpcc::stm32::Can{{ id }}::enableStatusChangeInterrupt(
 		uint32_t interruptEnable,
 		uint32_t interruptPriority)
 {
+%% if not target is stm32f0
 	NVIC_SetPriority({{ reg }}_SCE_IRQn, interruptPriority);
 	nvicEnableInterrupt({{ reg }}_SCE_IRQn);
-	
+
+%% endif
 	{{ reg }}->IER = interruptEnable | ({{ reg }}->IER & 0x000000ff);
 }

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -18,7 +18,7 @@
 #include "error_code.hpp"
 #include "can_filter.hpp"
 
-%% if target is stm32f3
+%% if target is stm32f3 or target is stm32f0
 	%% set reg = 'CAN'
 %% else
 	%% set reg = 'CAN' ~ id

--- a/src/xpcc/architecture/platform/driver/can/stm32/can_filter.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can_filter.cpp.in
@@ -9,7 +9,7 @@
 
 #include "can_filter.hpp"
 
-%% if target is stm32f3
+%% if target is stm32f3 or target is stm32f0
 	%% set reg = 'CAN'
 %% else
 	%% set reg = 'CAN1'

--- a/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
@@ -188,16 +188,26 @@ private:
 	/// Alternate Function register mask.
 	static constexpr uint32_t af_mask  = 0xf << af_offset;
 	/// ExternalInterruptIRQ
-%% if pin|int in range(0,5)
-	%% if target is stm32f3 and pin|int == 2
-	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI2_TSC_IRQn;
-	%% else
-	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI{{pin}}_IRQn;
+%% if target is stm32f0
+	%% if pin|int in range(0,2)
+	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI0_1_IRQn;
+	%% elif pin|int in range(2,4)
+	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI2_3_IRQn;
+	%% elif pin|int in range(4,16)
+	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI4_15_IRQn;
 	%% endif
-%% elif pin|int in range(5,10)
+%% else
+	%% if pin|int in range(0,5)
+		%% if target is stm32f3 and pin|int == 2
+	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI2_TSC_IRQn;
+		%% else
+	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI{{pin}}_IRQn;
+		%% endif
+	%% elif pin|int in range(5,10)
 	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI9_5_IRQn;
-%% elif pin|int in range(10,16)
+	%% elif pin|int in range(10,16)
 	static constexpr IRQn_Type ExternalInterruptIRQ = EXTI15_10_IRQn;
+	%% endif
 %% endif
 
 	ALWAYS_INLINE static void

--- a/src/xpcc/architecture/platform/driver/timer/stm32/advanced.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/advanced.cpp.in
@@ -267,6 +267,12 @@ xpcc::stm32::Timer{{ id }}::enableInterruptVector(Interrupt interrupt, bool enab
 {
 	if (enable)
 	{
+%% if target is stm32f0
+		if(interrupt & (Interrupt::Update | Interrupt::Break | Interrupt::COM | Interrupt::Trigger)) {
+			NVIC_SetPriority(TIM{{ id }}_BRK_UP_TRG_COM_IRQn, priority);
+			nvicEnableInterrupt(TIM{{ id }}_BRK_UP_TRG_COM_IRQn);
+		}
+%% else
 		if (interrupt & Interrupt::Update) {
 			NVIC_SetPriority(TIM{{ id }}_UP_IRQn, priority);
 			nvicEnableInterrupt(TIM{{ id }}_UP_IRQn);
@@ -281,7 +287,7 @@ xpcc::stm32::Timer{{ id }}::enableInterruptVector(Interrupt interrupt, bool enab
 			NVIC_SetPriority(TIM{{ id }}_TRG_COM_IRQn, priority);
 			nvicEnableInterrupt(TIM{{ id }}_TRG_COM_IRQn);
 		}	
-		
+%% endif
 		if (interrupt & 
 				(Interrupt::CaptureCompare1 | Interrupt::CaptureCompare2 |
 				 Interrupt::CaptureCompare3 | Interrupt::CaptureCompare4)) {
@@ -291,6 +297,11 @@ xpcc::stm32::Timer{{ id }}::enableInterruptVector(Interrupt interrupt, bool enab
 	}
 	else
 	{
+%% if target is stm32f0
+		if(interrupt & (Interrupt::Update | Interrupt::Break | Interrupt::COM | Interrupt::Trigger)) {
+			nvicDisableInterrupt(TIM{{ id }}_BRK_UP_TRG_COM_IRQn);
+		}
+%% else
 		if (interrupt & Interrupt::Update) {
 			nvicDisableInterrupt(TIM{{ id }}_UP_IRQn);
 		}
@@ -302,7 +313,7 @@ xpcc::stm32::Timer{{ id }}::enableInterruptVector(Interrupt interrupt, bool enab
 		if (interrupt & (Interrupt::COM | Interrupt::Trigger)) {
 			nvicDisableInterrupt(TIM{{ id }}_TRG_COM_IRQn);
 		}
-		
+%% endif
 		if (interrupt & 
 				(Interrupt::CaptureCompare1 | Interrupt::CaptureCompare2 |
 				 Interrupt::CaptureCompare3 | Interrupt::CaptureCompare4)) {

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
@@ -23,7 +23,7 @@
 %% set irq_name = "8_BRK_TIM12"
 %% elif id == 13
 %% set irq_name = "8_UP_TIM13"
-%% elif id == 14
+%% elif id == 14 and not target is stm32f0
 %% set irq_name = "8_TRG_COM_TIM14"
 %% else
 %% set irq_name = id

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
@@ -6,7 +6,7 @@
  * license. See the file `LICENSE` for the full license governing this code.
  */
 // ----------------------------------------------------------------------------
-%% if id in [1, 2, 3, 6]
+%% if id in [1, 2, 3, 6] or target is stm32f0
 %%	set uart = "Usart"
 %% elif id in [4, 5, 7, 8]
 %%	set uart = "Uart"

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
@@ -6,7 +6,7 @@
  * license. See the file `LICENSE` for the full license governing this code.
  */
 // ----------------------------------------------------------------------------
-%% if id in [1, 2, 3, 6]
+%% if id in [1, 2, 3, 6] or target is stm32f0
 %%	set uart = "Usart"
 %% elif id in [4, 5, 7, 8]
 %%	set uart = "Uart"

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
@@ -6,7 +6,7 @@
  * license. See the file `LICENSE` for the full license governing this code.
  */
 // ----------------------------------------------------------------------------
-%% if id in [1, 2, 3, 6]
+%% if id in [1, 2, 3, 6] or target is stm32f0
 %%	set uart = "Usart"
 %% elif id in [4, 5, 7, 8]
 %%	set uart = "Uart"

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
@@ -7,7 +7,7 @@
  */
 // ----------------------------------------------------------------------------
 %#
-%% if id in [1, 2, 3, 6]
+%% if id in [1, 2, 3, 6] or target is stm32f0
 %%	set uart = "Usart"
 %% elif id in [4, 5, 7, 8]
 %%	set uart = "Uart"
@@ -223,15 +223,20 @@ xpcc::stm32::{{ name }}::isTransmitRegisterEmpty()
 void
 xpcc::stm32::{{ name }}::enableInterruptVector(bool enable, uint32_t priority)
 {
+%% if target is stm32f0 and id in [3,4]
+	%%set irq = "USART3_4"
+%% else
+	%% set irq = peripheral
+%% endif
 	if (enable) {
 		// Set priority for the interrupt vector
-		NVIC_SetPriority({{ peripheral }}_IRQn, priority);
+		NVIC_SetPriority({{ irq }}_IRQn, priority);
 
 		// register IRQ at the NVIC
-		NVIC_EnableIRQ({{ peripheral }}_IRQn);
+		NVIC_EnableIRQ({{ irq }}_IRQn);
 	}
 	else {
-		NVIC_DisableIRQ({{ peripheral }}_IRQn);
+		NVIC_DisableIRQ({{ irq }}_IRQn);
 	}
 }
 

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f0xx_b.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f0xx_b.ld
@@ -1,0 +1,8 @@
+
+MEMORY
+{
+	ROM (rx)      : ORIGIN = 0x08000000, LENGTH = 128k
+	RAM (rwx)     : ORIGIN = 0x20000000, LENGTH =  16k	/* Main internal SRAM1 */
+}
+
+INCLUDE stm32_ram.ld


### PR DESCRIPTION
All examples have been tested with the STM32F072 Discovery board.

The Adc and the Clock driver are currently disabled.
The Adc is somewhat different from the one used on the STM32F3 (it uses similar registers, but comes with a very reduced feature set). If someone needs support it should not be to hard to write a driver for it or integrate it with an existing one.
For the clock driver I'm still waiting for the new system to be added, as the HSI48 oscillator just would not fit within the old one.

Peripherals without an example are untested, but as we do not have any special testing procedure and they are basically identical to other STM32 ip, I feel we should have them enabled in case people want to test them out.
