### PR TITLE
[driver] STM32: Gpio: remove mention of stm32f1 from generic driver

### DIFF
--- a/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
@@ -16,9 +16,7 @@
 #include <xpcc/math/utils/bit_operation.hpp>
 
 %% for instance in gpios | getAdcs
-	%% if target is stm32f1
-#include "../../adc/stm32f1/adc_{{instance}}.hpp"
-	%% elif target is stm32f3
+	%% if target is stm32f3
 #include "../../adc/stm32f3/adc_{{instance}}.hpp"
 	%% else
 #include "../../adc/stm32/adc_{{instance}}.hpp"


### PR DESCRIPTION
STM32F1 has its own Gpio driver.
