### PR TITLE
[driver] CAN: move bit timing calculations to separate file

### DIFF
--- a/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
+++ b/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
@@ -1,0 +1,96 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_COMMON_CAN_BIT_TIMINGS_HPP
+#define XPCC_COMMON_CAN_BIT_TIMINGS_HPP
+
+#include <xpcc/architecture/interface.hpp>
+
+#include "../../clock/generic/common_clock.hpp"
+
+namespace xpcc
+{
+
+/**
+ * CAN Bit Timing
+ *
+ * Example for CAN bit timing:
+ *   CLK on APB1 = 36 MHz
+ *   BaudRate = 125 kBPs = 1 / NominalBitTime
+ *   NominalBitTime = 8uS = tq + tBS1 + tBS2
+ * with:
+ *   tBS1 = tq * (TS1[3:0] + 1) = 12 * tq
+ *   tBS2 = tq * (TS2[2:0] + 1) = 5 * tq
+ *   tq = (BRP[9:0] + 1) * tPCLK
+ * where tq refers to the Time quantum
+ *   tPCLK = time period of the APB clock = 1 / 36 MHz
+ *
+ * STM32F1xx   tPCLK = 1 / 36 MHz
+ * STM32F20x   tPCLK = 1 / 30 MHz
+ * STM32F40x   tPCLK = 1 / 42 MHz
+ *
+ *
+ * @author	Kevin Laeufer
+ * @ingroup	can
+ */
+template<int32_t Clk, int32_t Bitrate>
+class CanBitTiming
+{
+private:
+	static constexpr uint16_t calculatePrescaler(uint8_t bs1, uint8_t bs2) {
+		return Clk / (Bitrate * (1 + bs1 + bs2));
+	}
+
+	struct CanBitTimingConfguration {
+		uint8_t bs1;	// 1-16
+		uint8_t bs2;	// 1-8
+		uint8_t sjw;
+		uint16_t prescaler;
+	};
+
+	static constexpr uint8_t calcBS1() {
+		return (Clk ==  xpcc::clock::MHz8)? 11 :
+		       (Clk == xpcc::clock::MHz48)? 11 :
+		       (Clk == xpcc::clock::MHz30)? 10 :
+		       (Clk == xpcc::clock::MHz36)? 12 :
+		       (Clk == xpcc::clock::MHz42)? 14 : 0;
+	}
+
+	static constexpr uint8_t calcBS2() {
+		return (Clk ==  xpcc::clock::MHz8)?  4 :
+		       (Clk == xpcc::clock::MHz48)?  4 :
+		       (Clk == xpcc::clock::MHz30)?  4 :
+		       (Clk == xpcc::clock::MHz36)?  5 :
+		       (Clk == xpcc::clock::MHz42)?  6 : 0;
+	}
+
+	static constexpr CanBitTimingConfguration calculateBestConfig() {
+		return { calcBS1(), calcBS2(), 1, calculatePrescaler(calcBS1(), calcBS2()) };
+	}
+
+	static constexpr CanBitTimingConfguration BestConfig = calculateBestConfig();
+
+public:
+	static constexpr uint8_t getBS1() { return BestConfig.bs1; }
+	static constexpr uint8_t getBS2() { return BestConfig.bs2; }
+	static constexpr uint8_t getSJW() { return BestConfig.sjw; }
+	static constexpr uint8_t getPrescaler() { return BestConfig.prescaler; }
+
+private:
+	// check assertions
+	static_assert(getBS1() > 0 and getBS2() > 0,
+		"Unsupported frequency for Can peripheral. "
+		"Only 8MHz, 30 Mhz, 36 MHz, 42 MHz and 48 MHz are supported at the moment.");
+	static_assert(getPrescaler() > 0, "CAN bitrate is too high for standard bit timings!");
+};
+
+}	// namespace xpcc
+
+#endif // XPCC_COMMON_CAN_BIT_TIMINGS_HPP
+

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -15,6 +15,7 @@
 #include "../../../type_ids.hpp"
 
 #include "../../clock/generic/common_clock.hpp"
+#include "../generic/can_bit_timings.hpp"
 #include "error_code.hpp"
 #include "can_filter.hpp"
 
@@ -103,39 +104,15 @@ public:
 	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
 				bool overwriteOnOverrun = true)
 	{
-		/* Example for CAN bit timing:
-		 *   CLK on APB1 = 36 MHz
-		 *   BaudRate = 125 kBPs = 1 / NominalBitTime
-		 *   NominalBitTime = 8uS = tq + tBS1 + tBS2
-		 * with:
-		 *   tBS1 = tq * (TS1[3:0] + 1) = 12 * tq
-		 *   tBS2 = tq * (TS2[2:0] + 1) = 5 * tq
-		 *   tq = (BRP[9:0] + 1) * tPCLK
-		 * where tq refers to the Time quantum
-		 *   tPCLK = time period of the APB clock = 1 / 36 MHz
-		 *
-		 * STM32F1xx   tPCLK = 1 / 36 MHz
-		 * STM32F20x   tPCLK = 1 / 30 MHz
-		 * STM32F40x   tPCLK = 1 / 42 MHz
-		 */
-		constexpr uint8_t bs1 = (SystemClock::Can{{ id }} ==  MHz8)? 11 :
-								(SystemClock::Can{{ id }} == MHz48)? 11 :
-								(SystemClock::Can{{ id }} == MHz30)? 10 :
-								(SystemClock::Can{{ id }} == MHz36)? 12 :
-								(SystemClock::Can{{ id }} == MHz42)? 14 : 0;
-		constexpr uint8_t bs2 = (SystemClock::Can{{ id }} ==  MHz8)?  4 :
-								(SystemClock::Can{{ id }} == MHz48)?  4 :
-								(SystemClock::Can{{ id }} == MHz30)?  4 :
-								(SystemClock::Can{{ id }} == MHz36)?  5 :
-								(SystemClock::Can{{ id }} == MHz42)?  6 : 0;
-		constexpr uint16_t prescaler = 	SystemClock::Can{{ id }} /
-								(bitrate * (1 + bs1 + bs2));
-		static_assert(bs1 > 0 and bs2 > 0,
-				"Unsupported frequency for Can peripheral. "
-				"Only 8MHz, 30 Mhz, 36 MHz, 42 MHz and 48 MHz are supported at the moment.");
-		static_assert(prescaler > 0, "CAN bitrate is too high for standard bit timings!");
+		using Timings = CanBitTiming<SystemClock::Can{{ id }}, bitrate>;
 
-		return initializeWithPrescaler(prescaler, bs1, bs2, interruptPriority, startupMode, overwriteOnOverrun);
+		return initializeWithPrescaler(
+			Timings::getPrescaler(),
+			Timings::getBS1(),
+			Timings::getBS2(),
+			interruptPriority,
+			startupMode,
+			overwriteOnOverrun);
 	}
 
 	/**

--- a/src/xpcc/architecture/platform/test/can_bit_timings_test.cpp
+++ b/src/xpcc/architecture/platform/test/can_bit_timings_test.cpp
@@ -1,0 +1,69 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include "can_bit_timings_test.hpp"
+
+#include "../driver/clock/generic/common_clock.hpp"
+#include "../driver/can/generic/can_bit_timings.hpp"
+
+using namespace xpcc;
+using namespace xpcc::clock;
+
+#define TEST_TIMING(clk, bitrate, bs1, bs2, prescaler) \
+	TEST_ASSERT_EQUALS((xpcc::CanBitTiming<clk, Can::Bitrate::bitrate>::getBS1()), bs1); \
+	TEST_ASSERT_EQUALS((xpcc::CanBitTiming<clk, Can::Bitrate::bitrate>::getBS2()), bs2); \
+	TEST_ASSERT_EQUALS((xpcc::CanBitTiming<clk, Can::Bitrate::bitrate>::getPrescaler()), prescaler);
+
+void
+CanBitTimingsTest::testPrecalculatedValues()
+{
+	// this tests some timings, that were calculated by hand
+	// and used in xpcc from 2011 through 2015
+	//
+	// This is the old code:
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	//		constexpr uint8_t bs1 = (SystemClock::Can{{ id }} ==  MHz8)? 11 :
+	//							(SystemClock::Can{{ id }} == MHz48)? 11 :
+	//							(SystemClock::Can{{ id }} == MHz30)? 10 :
+	//							(SystemClock::Can{{ id }} == MHz36)? 12 :
+	//							(SystemClock::Can{{ id }} == MHz42)? 14 : 0;
+	//	constexpr uint8_t bs2 = (SystemClock::Can{{ id }} ==  MHz8)?  4 :
+	//							(SystemClock::Can{{ id }} == MHz48)?  4 :
+	//							(SystemClock::Can{{ id }} == MHz30)?  4 :
+	//							(SystemClock::Can{{ id }} == MHz36)?  5 :
+	//							(SystemClock::Can{{ id }} == MHz42)?  6 : 0;
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+	TEST_TIMING(MHz8,  kBps125, 11, 4,  4);
+	TEST_TIMING(MHz8,  kBps250, 11, 4,  2);
+	TEST_TIMING(MHz8,  kBps500, 11, 4,  1);
+	// @ 8MHZ MBps1 was not supported (resulted in prescaler = 0)
+
+	TEST_TIMING(MHz48, kBps125, 11, 4, 24);
+	TEST_TIMING(MHz48, kBps250, 11, 4, 12);
+	TEST_TIMING(MHz48, kBps500, 11, 4,  6);
+	TEST_TIMING(MHz48,   MBps1, 11, 4,  3);
+
+	TEST_TIMING(MHz30, kBps125, 10, 4, 16);
+	TEST_TIMING(MHz30, kBps250, 10, 4,  8);
+	TEST_TIMING(MHz30, kBps500, 10, 4,  4);
+	TEST_TIMING(MHz30,   MBps1, 10, 4,  2);
+
+	TEST_TIMING(MHz36, kBps125, 12, 5, 16);
+	TEST_TIMING(MHz36, kBps250, 12, 5,  8);
+	TEST_TIMING(MHz36, kBps500, 12, 5,  4);
+	TEST_TIMING(MHz36,   MBps1, 12, 5,  2);
+
+	TEST_TIMING(MHz42, kBps125, 14, 6, 16);
+	TEST_TIMING(MHz42, kBps250, 14, 6,  8);
+	TEST_TIMING(MHz42, kBps500, 14, 6, 4 );
+	TEST_TIMING(MHz42,   MBps1, 14, 6,  2);
+
+}
+

--- a/src/xpcc/architecture/platform/test/can_bit_timings_test.hpp
+++ b/src/xpcc/architecture/platform/test/can_bit_timings_test.hpp
@@ -1,0 +1,17 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+class CanBitTimingsTest : public unittest::TestSuite
+{
+public:
+	void
+	testPrecalculatedValues();
+};


### PR DESCRIPTION
This is similar to how we do baudrate calculation for
UART in the stm32 driver.

As CAN seems to be very standardized, with bs1 and bs2 values
defined in the standard, the CAN calculations are placed in
generic.

This commit also adds unittests for all precalculated values,
thus we can move to calculating these values on the fly
without the risk of introducing new bugs.
