### PR TITLE
[driver] Timer: STM32: check for stm32f1

### DIFF
--- a/src/xpcc/architecture/platform/driver/timer/stm32/advanced.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/advanced.hpp.in
@@ -354,20 +354,20 @@ public:
 	static inline void
 	setCompareValue(uint32_t channel, uint16_t value)
 	{
-%% if target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7
-		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
-%% else
+%% if target is stm32f1
 		*(&TIM{{ id }}->CCR1 + ((channel - 1) * 2)) = value;
+%% else
+		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
 %% endif
 	}
 
 	static inline uint16_t
 	getCompareValue(uint32_t channel)
 	{
-%% if target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7
-		return *(&TIM{{ id }}->CCR1 + (channel - 1));
-%% else
+%% if target is stm32f1
 		return *(&TIM{{ id }}->CCR1 + ((channel - 1) * 2));
+%% else
+		return *(&TIM{{ id }}->CCR1 + (channel - 1));
 %% endif
 	}
 

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
@@ -346,20 +346,20 @@ public:
 	static inline void
 	setCompareValue(uint32_t channel, Value value)
 	{
-%% if target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7
-		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
-%% else
+%% if target is stm32f1
 		*(&TIM{{ id }}->CCR1 + ((channel - 1) * 2)) = value;
+%% else
+		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
 %% endif
 	}
 
 	static inline Value
 	getCompareValue(uint32_t channel)
 	{
-%% if target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7
-		return *(&TIM{{ id }}->CCR1 + (channel - 1));
-%% else
+%% if target is stm32f1
 		return *(&TIM{{ id }}->CCR1 + ((channel - 1) * 2));
+%% else
+		return *(&TIM{{ id }}->CCR1 + (channel - 1));
 %% endif
 	}
 


### PR DESCRIPTION
All "modern" stm32, i.e., stm32f0, stm32f3, stm32f4
have the same behavior.
Only the stm32f1 HAL apparently declares CC1 to be
a uin16_t.
