### PR TITLE
Fix delay loop timing for STM32F072 / Cortex-M0

### DIFF
--- a/examples/stm32f072_discovery/stm32f072_discovery.hpp
+++ b/examples/stm32f072_discovery/stm32f072_discovery.hpp
@@ -87,6 +87,7 @@ switchSystemClockToHSI48()
 	if(success) {
 		xpcc::clock::fcpu_MHz = 48;
 		xpcc::clock::fcpu_kHz = 48 * 1000;
+		xpcc::clock::ns_per_loop = 4000 / 48;	// ~83ns per delay loop
 	}
 
 	return success;

--- a/src/xpcc/architecture/platform/driver/core/cortex/delay.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/delay.cpp.in
@@ -10,7 +10,11 @@
 #include "../../../device.hpp"
 #include "../../clock/generic/common_clock.hpp"
 
-%% set loop = 3
+%% if target is cortex_m0
+	%% set loop = 4
+%% else
+	%% set loop = 3
+%% endif
 
 %% if target is stm32f3 and not noiccm is defined
 	%% set overhead = 29


### PR DESCRIPTION
The delay loop on the Cortex-M0 requires 4 cycles, not 3.
Fixes #65.
