### PR TITLE
stm32f072: really use linker script for stm32f072x8 devices

### DIFF
--- a/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
@@ -10,6 +10,7 @@
     <ram>16384</ram>
     <core>cortex-m0</core>
     <linkerscript device-size-id="b">stm32f0xx_b.ld</linkerscript>
+    <linkerscript device-size-id="8">stm32f0xx_8.ld</linkerscript>
     <pin-count device-pin-id="v">100</pin-count>
     <pin-count device-pin-id="c">48</pin-count>
     <pin-count device-pin-id="r">64</pin-count>


### PR DESCRIPTION
The device file for stm32f072 didn't specify a linker script for ...x8 devices. I don't know if this was a mistake (or untested?) but it works now.
