### PR TITLE
[ui] Make line drawing symmetric

### DIFF
--- a/src/xpcc/ui/display/buffered_graphic_display_impl.hpp
+++ b/src/xpcc/ui/display/buffered_graphic_display_impl.hpp
@@ -5,7 +5,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -42,7 +42,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::clear()
 			this->buffer[x][y] = 0;
 		}
 	}
-	
+
 	// reset the cursor
 	this->cursor = glcd::Point(0, 0);
 }
@@ -55,11 +55,11 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawHorizontalLine(
 		uint16_t length)
 {
 	const uint16_t y = start.getY() / 8;
-	
+
 	if (this->foregroundColor == glcd::Color::black())
 	{
 		const uint8_t mask = 1 << (start.getY() & 0x07);
-		for (uint_fast16_t x = start.getX(); x < static_cast<uint16_t>(start.getX() + length); ++x) {
+		for (uint_fast16_t x = start.getX(); x <= static_cast<uint16_t>(start.getX() + length); ++x) {
 			if( x < Width && y < Height ) {
 				this->buffer[x][y] |= mask;
 			}
@@ -67,7 +67,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawHorizontalLine(
 	}
 	else {
 		const uint8_t mask = ~(1 << (start.getY() & 0x07));
-		for (uint_fast16_t x = start.getX(); x < static_cast<uint16_t>(start.getX() + length); ++x) {
+		for (uint_fast16_t x = start.getX(); x <= static_cast<uint16_t>(start.getX() + length); ++x) {
 			if( x < Width && y < Height ) {
 				this->buffer[x][y] &= mask;
 			}
@@ -86,7 +86,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawImageRaw(glcd::Point upperLeft,
 	{
 		uint16_t row = upperLeft.getY() / 8;
 		uint16_t rowCount = (height + 7) / 8;	// always round up
-		
+
 		if ((height & 0x07) == 0)
 		{
 			for (uint_fast16_t i = 0; i < width; i++)
@@ -104,7 +104,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawImageRaw(glcd::Point upperLeft,
 			return;
 		}
 	}
-	
+
 	GraphicDisplay::drawImageRaw(upperLeft, width, height, data);
 }
 

--- a/src/xpcc/ui/display/graphic_display.cpp
+++ b/src/xpcc/ui/display/graphic_display.cpp
@@ -117,7 +117,7 @@ xpcc::GraphicDisplay::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 			yStep = -1;
 		}
 
-		for (int_fast16_t x = x1; x < x2; ++x)
+		for (int_fast16_t x = x1; x <= x2; ++x)
 		{
 			if (steep) {
 				(this->*draw)(y, x);
@@ -137,7 +137,7 @@ xpcc::GraphicDisplay::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 void
 xpcc::GraphicDisplay::drawHorizontalLine(glcd::Point start, uint16_t length)
 {
-	for (int_fast16_t i = start.getX(); i < static_cast<int16_t>(start.getX() + length); ++i) {
+	for (int_fast16_t i = start.getX(); i <= static_cast<int16_t>(start.getX() + length); ++i) {
 		(this->*draw)(i, start.getY());
 	}
 }
@@ -145,7 +145,7 @@ xpcc::GraphicDisplay::drawHorizontalLine(glcd::Point start, uint16_t length)
 void
 xpcc::GraphicDisplay::drawVerticalLine(glcd::Point start, uint16_t length)
 {
-	for (int_fast16_t i = start.getY(); i < static_cast<int16_t>(start.getY() + length); ++i) {
+	for (int_fast16_t i = start.getY(); i <= static_cast<int16_t>(start.getY() + length); ++i) {
 		(this->*draw)(start.getX(), i);
 	}
 }


### PR DESCRIPTION
This commit makes line drawing "symmetric", which means that the pixels at both the start and end
coordinates are part of the line. Previously the "end" pixel was left out. (Which isn't always the
second coordinate, because the line drawing routine may swap them. This caused the start of the line
to shift pixels depending on where the end was.)

One consequence of this commit is that now a line is always
visible (at least 1 pixel).
