### PR TITLE
Examples: Compile more examples for OSX

### DIFF
--- a/examples/linux/can_debugger/project.cfg
+++ b/examples/linux/can_debugger/project.cfg
@@ -2,5 +2,5 @@
 name = can_debugger
 
 [build]
-device = hosted/linux
+device = hosted
 buildpath = ${xpccpath}/build/linux/${name}

--- a/examples/linux/gui/basic/project_hosted.cfg
+++ b/examples/linux/gui/basic/project_hosted.cfg
@@ -2,7 +2,7 @@
 name = linux_gui_basic
 
 [build]
-device = hosted/linux
+device = hosted
 buildpath = ${xpccpath}/build/${name}
 
 [communication]

--- a/examples/linux/serial_interface/project.cfg
+++ b/examples/linux/serial_interface/project.cfg
@@ -2,5 +2,5 @@
 name = serial_interface
 
 [build]
-device = hosted/linux
+device = hosted
 buildpath = ${xpccpath}/build/linux/${name}

--- a/examples/linux/threads/project.cfg
+++ b/examples/linux/threads/project.cfg
@@ -3,6 +3,6 @@
 name = threads
 
 [build]
-device = hosted/linux
+device = hosted
 buildpath = ${xpccpath}/build/${name}
 

--- a/src/xpcc/processing/rtos/boost/build.cfg
+++ b/src/xpcc/processing/rtos/boost/build.cfg
@@ -1,3 +1,3 @@
 
 [build]
-target = linux
+target = hosted


### PR DESCRIPTION
Boost works with OSX so can_debugger, serial_interface, threads and GUI
can be compiled.
