### PR TITLE
Use named struct instead of anonymous parameter list for drivers.

### DIFF
--- a/examples/stm32f4_discovery/display/nokia_5110/main.cpp
+++ b/examples/stm32f4_discovery/display/nokia_5110/main.cpp
@@ -45,8 +45,15 @@ namespace lcd
 // typedef xpcc::SoftwareSpiMaster< lcd::Clk, lcd::Din> mySpiMaster;
 typedef SpiMaster2 mySpiMaster;
 
+struct Connector {
+	using Spi = mySpiMaster;
+	using Ce = lcd::Ce;
+	using Dc = lcd::Dc;
+	using Reset = lcd::Reset;
+};
+
 // create a LCD object
-xpcc::Nokia5110< mySpiMaster, lcd::Ce, lcd::Dc, lcd::Reset > display;
+xpcc::Nokia5110< Connector > display;
 
 class ThreadOne : public xpcc::pt::Protothread
 {

--- a/src/xpcc/driver/display/nokia5110.hpp
+++ b/src/xpcc/driver/display/nokia5110.hpp
@@ -25,9 +25,14 @@ namespace xpcc
  *
  * \ingroup driver_display
  */
-template < typename Spi, typename Ce, typename Dc, typename Reset >
+template < class Connector >
 class Nokia5110 : public BufferedGraphicDisplay< 84, 48 >
 {
+using Spi = typename Connector::Spi;
+using Ce = typename Connector::Ce;
+using Dc = typename Connector::Dc;
+using Reset = typename Connector::Reset;
+
 public:
 	void
 	initialize();

--- a/src/xpcc/driver/display/nokia5110_impl.hpp
+++ b/src/xpcc/driver/display/nokia5110_impl.hpp
@@ -14,9 +14,9 @@
 namespace xpcc
 {
 
-template< typename Spi, typename Ce, typename Dc, typename Reset >
+template< class Connector >
 void
-Nokia5110< Spi, Ce, Dc, Reset >::initialize()
+Nokia5110< Connector >::initialize()
 {
 	Reset::set();
 
@@ -36,9 +36,9 @@ Nokia5110< Spi, Ce, Dc, Reset >::initialize()
 	// writeCommand(0x0d); // inverse
 }
 
-template< typename Spi, typename Ce, typename Dc, typename Reset >
+template< class Connector >
 void
-Nokia5110< Spi, Ce, Dc, Reset >::update()
+Nokia5110< Connector >::update()
 {
 	// goto 0, 0
 	writeCommand(0x80); // Column
@@ -54,9 +54,9 @@ Nokia5110< Spi, Ce, Dc, Reset >::update()
 	Ce::set();
 }
 
-template< typename Spi, typename Ce, typename Dc, typename Reset >
+template< class Connector >
 void
-Nokia5110< Spi, Ce, Dc, Reset >::writeCommand(uint8_t data)
+Nokia5110< Connector >::writeCommand(uint8_t data)
 {
 	Dc::reset(); // low = command
 	Ce::reset();


### PR DESCRIPTION
Via @strongly-typed:

Until now, not-so-long and long anonymous parameter lists were used to connect hardware drivers with the real hardware.

This is C-style as the order counts. If you swap Ce and Dc in the example above the code will compile and fail and it is hard to spot the error.

With a named struct as a single parameter each parameter has a distinguished name and is less error-prone. And the code is the documentation. Adding another parameter is simple, too.

The only downside is that default arguments cannot be defined.
