### PR TITLE
Remove core.cortex.0.vector_table_in_ram from examples.

### DIFF
--- a/examples/stm32f1_discovery/blink/project.cfg
+++ b/examples/stm32f1_discovery/blink/project.cfg
@@ -6,8 +6,5 @@ device = stm32f100rbt6b
 clock = 24000000
 buildpath = ${xpccpath}/build/stm32f1_discovery/${name}
 
-[parameters]
-core.cortex.0.vector_table_in_ram = true
-
 [openocd]
 configfile = board/stm32vldiscovery.cfg

--- a/examples/stm32f3_discovery/blink/project.cfg
+++ b/examples/stm32f3_discovery/blink/project.cfg
@@ -6,8 +6,5 @@ device = stm32f303vc
 clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
-[parameters]
-core.cortex.0.vector_table_in_ram = true
-
 [openocd]
 configfile = board/stm32f3discovery.cfg

--- a/examples/stm32f4_discovery/blink/project.cfg
+++ b/examples/stm32f4_discovery/blink/project.cfg
@@ -6,8 +6,5 @@ device = stm32f407vg
 clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
-[parameters]
-core.cortex.0.vector_table_in_ram = true
-
 [openocd]
 configfile = board/stm32f4discovery.cfg

--- a/examples/stm32f4_discovery/display/hd44780/project.cfg
+++ b/examples/stm32f4_discovery/display/hd44780/project.cfg
@@ -7,7 +7,6 @@ clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/display/${name}
 
 [parameters]
-core.cortex.0.vector_table_in_ram = true
 uart.stm32.2.tx_buffer = 200
 
 [openocd]

--- a/examples/stm32f7_discovery/blink/project.cfg
+++ b/examples/stm32f7_discovery/blink/project.cfg
@@ -7,8 +7,5 @@ clock = 216000000
 buildpath = ${xpccpath}/build/stm32f7_discovery/${name}
 extrasources = ['../stm32f7_discovery.cpp']
 
-[parameters]
-core.cortex.0.vector_table_in_ram = true
-
 [openocd]
 configfile = board/stm32f7discovery.cfg


### PR DESCRIPTION
There should be a separate example for placing the vector table in RAM.
