### PR TITLE
[platform] Add support for STM32F103

### DIFF
--- a/src/xpcc/architecture/platform/devices/stm32/stm32f103-c_r_t_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f103-c_r_t_v-8_b.xml
@@ -1,0 +1,388 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<rca version="1.0">
+  <!-- WARNING: This file is generated automatically, do not edit!
+ 		Please modify the xpcc/tools/device_file_generator code instead and rebuild this file.
+ 		Be aware, that regenerated files might have a different composition due to technical reasons. -->
+  <device platform="stm32" family="f1" name="103" pin_id="c|r|t|v" size_id="8|b">
+    <flash>65536</flash>
+    <ram>20480</ram>
+    <core>cortex-m3</core>
+    <linkerscript device-size-id="8">stm32f103_8.ld</linkerscript>
+    <linkerscript device-size-id="b">stm32f103_b.ld</linkerscript>
+    <pin-count device-pin-id="v">100</pin-count>
+    <pin-count device-pin-id="t">36</pin-count>
+    <pin-count device-pin-id="c">48</pin-count>
+    <pin-count device-pin-id="r">64</pin-count>
+    <header>stm32f1xx.h</header>
+    <define>STM32F103xB</define>
+    <driver type="core" name="cortex">
+      <memory access="rx" start="0x8000000" name="flash" size="64"/>
+      <memory access="rwx" start="0x20000000" name="sram1" size="20"/>
+      <vector position="0" name="WWDG"/>
+      <vector position="1" name="PVD"/>
+      <vector position="2" name="TAMPER"/>
+      <vector position="3" name="RTC"/>
+      <vector position="4" name="FLASH"/>
+      <vector position="5" name="RCC"/>
+      <vector position="6" name="EXTI0"/>
+      <vector position="7" name="EXTI1"/>
+      <vector position="8" name="EXTI2"/>
+      <vector position="9" name="EXTI3"/>
+      <vector position="10" name="EXTI4"/>
+      <vector position="11" name="DMA1_Channel1"/>
+      <vector position="12" name="DMA1_Channel2"/>
+      <vector position="13" name="DMA1_Channel3"/>
+      <vector position="14" name="DMA1_Channel4"/>
+      <vector position="15" name="DMA1_Channel5"/>
+      <vector position="16" name="DMA1_Channel6"/>
+      <vector position="17" name="DMA1_Channel7"/>
+      <vector position="18" name="ADC1_2"/>
+      <vector position="19" name="USB_HP_CAN1_TX"/>
+      <vector position="20" name="USB_LP_CAN1_RX0"/>
+      <vector position="21" name="CAN1_RX1"/>
+      <vector position="22" name="CAN1_SCE"/>
+      <vector position="23" name="EXTI9_5"/>
+      <vector position="24" name="TIM1_BRK"/>
+      <vector position="25" name="TIM1_UP"/>
+      <vector position="26" name="TIM1_TRG_COM"/>
+      <vector position="27" name="TIM1_CC"/>
+      <vector position="28" name="TIM2"/>
+      <vector position="29" name="TIM3"/>
+      <vector position="30" name="TIM4"/>
+      <vector position="31" name="I2C1_EV"/>
+      <vector position="32" name="I2C1_ER"/>
+      <vector position="33" name="I2C2_EV"/>
+      <vector position="34" name="I2C2_ER"/>
+      <vector position="35" name="SPI1"/>
+      <vector position="36" name="SPI2"/>
+      <vector position="37" name="USART1"/>
+      <vector position="38" name="USART2"/>
+      <vector position="39" name="USART3"/>
+      <vector position="40" name="EXTI15_10"/>
+      <vector position="41" name="RTC_Alarm"/>
+      <vector position="42" name="USBWakeUp"/>
+    </driver>
+    <driver type="adc" name="stm32f1" instances="1,2"/>
+    <driver type="can" name="stm32" instances="1"/>
+    <driver type="clock" name="stm32"/>
+    <driver type="i2c" name="stm32" instances="1"/>
+    <driver device-pin-id="c|r|v" type="i2c" name="stm32" instances="2"/>
+    <driver type="spi" name="stm32" instances="1"/>
+    <driver device-pin-id="c|r|v" type="spi" name="stm32" instances="2"/>
+    <driver type="spi" name="stm32_uart" instances="1,2"/>
+    <driver device-pin-id="c|r|v" type="spi" name="stm32_uart" instances="3"/>
+    <driver type="timer" name="stm32" instances="1,2,3,4"/>
+    <driver type="uart" name="stm32" instances="1,2"/>
+    <driver device-pin-id="c|r|v" type="uart" name="stm32" instances="3"/>
+    <driver type="usb" name="stm32_fs"/>
+    <driver type="gpio" name="stm32f1">
+      <gpio port="A" id="0">
+        <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af peripheral="Adc1" name="Channel0" type="analog"/>
+        <af peripheral="Adc2" name="Channel0" type="analog"/>
+      </gpio>
+      <gpio port="A" id="1">
+        <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel1" type="analog"/>
+        <af peripheral="Adc2" name="Channel1" type="analog"/>
+      </gpio>
+      <gpio port="A" id="2">
+        <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel2" type="analog"/>
+        <af peripheral="Adc2" name="Channel2" type="analog"/>
+      </gpio>
+      <gpio port="A" id="3">
+        <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel3" type="analog"/>
+        <af peripheral="Adc2" name="Channel3" type="analog"/>
+      </gpio>
+      <gpio port="A" id="4">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Nss"/>
+        <af id="3,1,0" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af peripheral="Adc1" name="Channel4" type="analog"/>
+        <af peripheral="Adc2" name="Channel4" type="analog"/>
+      </gpio>
+      <gpio port="A" id="5">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af peripheral="Adc1" name="Channel5" type="analog"/>
+        <af peripheral="Adc2" name="Channel5" type="analog"/>
+      </gpio>
+      <gpio port="A" id="6">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel6" type="analog"/>
+        <af peripheral="Adc2" name="Channel6" type="analog"/>
+      </gpio>
+      <gpio port="A" id="7">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel7" type="analog"/>
+        <af peripheral="Adc2" name="Channel7" type="analog"/>
+      </gpio>
+      <gpio port="A" id="8">
+        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af peripheral="Uart1" name="Ck" type="out"/>
+        <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="A" id="9">
+        <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+      </gpio>
+      <gpio port="A" id="10">
+        <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="11">
+        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="13,3,0" peripheral="Can1" name="Rx" type="in"/>
+        <af peripheral="Uart1" name="Cts" type="in"/>
+      </gpio>
+      <gpio port="A" id="12">
+        <af id="6,3,0" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+        <af id="13,3,0" peripheral="Can1" name="Tx" type="out"/>
+        <af peripheral="Uart1" name="Rts" type="out"/>
+      </gpio>
+      <gpio port="A" id="13"/>
+      <gpio port="A" id="14"/>
+      <gpio port="A" id="15">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="B" id="0">
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel8" type="analog"/>
+        <af peripheral="Adc2" name="Channel8" type="analog"/>
+      </gpio>
+      <gpio port="B" id="1">
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel9" type="analog"/>
+        <af peripheral="Adc2" name="Channel9" type="analog"/>
+      </gpio>
+      <gpio port="B" id="2"/>
+      <gpio port="B" id="3">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+      </gpio>
+      <gpio port="B" id="4">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="5">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+      </gpio>
+      <gpio port="B" id="6">
+        <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="7">
+        <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
+        <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="8">
+        <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="13,3,2" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="9">
+        <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="13,3,2" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="10">
+        <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af peripheral="I2cMaster2" name="Scl" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="11">
+        <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af peripheral="I2cMaster2" name="Sda"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="12">
+        <af id="4,3,0" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af peripheral="SpiMaster2" name="Nss"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="13">
+        <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af peripheral="SpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="14">
+        <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af peripheral="SpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="B" id="15">
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af peripheral="SpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="0">
+        <af peripheral="Adc1" name="Channel10" type="analog"/>
+        <af peripheral="Adc2" name="Channel10" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="1">
+        <af peripheral="Adc1" name="Channel11" type="analog"/>
+        <af peripheral="Adc2" name="Channel11" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="2">
+        <af peripheral="Adc1" name="Channel12" type="analog"/>
+        <af peripheral="Adc2" name="Channel12" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="v" port="C" id="3">
+        <af peripheral="Adc1" name="Channel13" type="analog"/>
+        <af peripheral="Adc2" name="Channel13" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="4">
+        <af peripheral="Adc1" name="Channel14" type="analog"/>
+        <af peripheral="Adc2" name="Channel14" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="5">
+        <af peripheral="Adc1" name="Channel15" type="analog"/>
+        <af peripheral="Adc2" name="Channel15" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="6">
+        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="7">
+        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="8">
+        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="9">
+        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="10">
+        <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="11">
+        <af id="4,3,1" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="12">
+        <af id="4,3,1" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r|v" port="C" id="13"/>
+      <gpio device-pin-id="c|r|v" port="C" id="14"/>
+      <gpio device-pin-id="c|r|v" port="C" id="15"/>
+      <gpio port="D" id="0">
+        <af device-pin-id="v" id="13,3,3" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio port="D" id="1">
+        <af device-pin-id="v" id="13,3,3" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="D" id="2">
+        <af peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="3">
+        <af id="3,1,1" peripheral="Uart2" name="Cts" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="4">
+        <af id="3,1,1" peripheral="Uart2" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="5">
+        <af id="3,1,1" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="6">
+        <af id="3,1,1" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="7">
+        <af id="3,1,1" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="8">
+        <af id="4,3,3" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="9">
+        <af id="4,3,3" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="10">
+        <af id="4,3,3" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="11">
+        <af id="4,3,3" peripheral="Uart3" name="Cts" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="12">
+        <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="13">
+        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="14">
+        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="15">
+        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="0">
+        <af peripheral="Timer4" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="1"/>
+      <gpio device-pin-id="v" port="E" id="2"/>
+      <gpio device-pin-id="v" port="E" id="3"/>
+      <gpio device-pin-id="v" port="E" id="4"/>
+      <gpio device-pin-id="v" port="E" id="5"/>
+      <gpio device-pin-id="v" port="E" id="6"/>
+      <gpio device-pin-id="v" port="E" id="7">
+        <af id="6,3,3" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="8">
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="9">
+        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="10">
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="11">
+        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="12">
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="13">
+        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="14">
+        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="15">
+        <af id="6,3,3" peripheral="Timer1" name="BreakIn" type="in"/>
+      </gpio>
+    </driver>
+  </device>
+</rca>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f103-r_v_z-c_d_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f103-r_v_z-c_d_e.xml
@@ -1,0 +1,580 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<rca version="1.0">
+  <!-- WARNING: This file is generated automatically, do not edit!
+ 		Please modify the xpcc/tools/device_file_generator code instead and rebuild this file.
+ 		Be aware, that regenerated files might have a different composition due to technical reasons. -->
+  <device platform="stm32" family="f1" name="103" pin_id="r|v|z" size_id="c|d|e">
+    <flash device-size-id="c">262144</flash>
+    <flash device-size-id="d">393216</flash>
+    <flash device-size-id="e">524288</flash>
+    <ram device-size-id="c">49152</ram>
+    <ram device-size-id="d|e">65536</ram>
+    <core>cortex-m3</core>
+	<linkerscript device-size-id="c">stm32f103_c.ld</linkerscript>
+    <pin-count device-pin-id="v">100</pin-count>
+    <pin-count device-pin-id="z">144</pin-count>
+    <pin-count device-pin-id="r">64</pin-count>
+    <header>stm32f1xx.h</header>
+    <define>STM32F103xE</define>
+    <driver type="core" name="cortex">
+      <memory device-size-id="c" access="rx" start="0x8000000" name="flash" size="256"/>
+      <memory device-size-id="d" access="rx" start="0x8000000" name="flash" size="384"/>
+      <memory device-size-id="e" access="rx" start="0x8000000" name="flash" size="512"/>
+      <memory device-size-id="c" access="rwx" start="0x20000000" name="sram1" size="48"/>
+      <memory device-size-id="d|e" access="rwx" start="0x20000000" name="sram1" size="64"/>
+      <vector position="0" name="WWDG"/>
+      <vector position="1" name="PVD"/>
+      <vector position="2" name="TAMPER"/>
+      <vector position="3" name="RTC"/>
+      <vector position="4" name="FLASH"/>
+      <vector position="5" name="RCC"/>
+      <vector position="6" name="EXTI0"/>
+      <vector position="7" name="EXTI1"/>
+      <vector position="8" name="EXTI2"/>
+      <vector position="9" name="EXTI3"/>
+      <vector position="10" name="EXTI4"/>
+      <vector position="11" name="DMA1_Channel1"/>
+      <vector position="12" name="DMA1_Channel2"/>
+      <vector position="13" name="DMA1_Channel3"/>
+      <vector position="14" name="DMA1_Channel4"/>
+      <vector position="15" name="DMA1_Channel5"/>
+      <vector position="16" name="DMA1_Channel6"/>
+      <vector position="17" name="DMA1_Channel7"/>
+      <vector position="18" name="ADC1_2"/>
+      <vector position="19" name="USB_HP_CAN1_TX"/>
+      <vector position="20" name="USB_LP_CAN1_RX0"/>
+      <vector position="21" name="CAN1_RX1"/>
+      <vector position="22" name="CAN1_SCE"/>
+      <vector position="23" name="EXTI9_5"/>
+      <vector position="24" name="TIM1_BRK"/>
+      <vector position="25" name="TIM1_UP"/>
+      <vector position="26" name="TIM1_TRG_COM"/>
+      <vector position="27" name="TIM1_CC"/>
+      <vector position="28" name="TIM2"/>
+      <vector position="29" name="TIM3"/>
+      <vector position="30" name="TIM4"/>
+      <vector position="31" name="I2C1_EV"/>
+      <vector position="32" name="I2C1_ER"/>
+      <vector position="33" name="I2C2_EV"/>
+      <vector position="34" name="I2C2_ER"/>
+      <vector position="35" name="SPI1"/>
+      <vector position="36" name="SPI2"/>
+      <vector position="37" name="USART1"/>
+      <vector position="38" name="USART2"/>
+      <vector position="39" name="USART3"/>
+      <vector position="40" name="EXTI15_10"/>
+      <vector position="41" name="RTC_Alarm"/>
+      <vector position="42" name="USBWakeUp"/>
+      <vector position="43" name="TIM8_BRK"/>
+      <vector position="44" name="TIM8_UP"/>
+      <vector position="45" name="TIM8_TRG_COM"/>
+      <vector position="46" name="TIM8_CC"/>
+      <vector position="47" name="ADC3"/>
+      <vector position="48" name="FSMC"/>
+      <vector position="49" name="SDIO"/>
+      <vector position="50" name="TIM5"/>
+      <vector position="51" name="SPI3"/>
+      <vector position="52" name="UART4"/>
+      <vector position="53" name="UART5"/>
+      <vector position="54" name="TIM6"/>
+      <vector position="55" name="TIM7"/>
+      <vector position="56" name="DMA2_Channel1"/>
+      <vector position="57" name="DMA2_Channel2"/>
+      <vector position="58" name="DMA2_Channel3"/>
+      <vector position="59" name="DMA2_Channel4_5"/>
+    </driver>
+    <driver type="adc" name="stm32f1" instances="1,2,3"/>
+    <driver type="can" name="stm32" instances="1"/>
+    <driver type="clock" name="stm32"/>
+    <driver device-pin-id="v|z" type="fsmc" name="stm32"/>
+    <driver type="i2c" name="stm32" instances="1,2"/>
+    <driver type="spi" name="stm32" instances="1,2,3"/>
+    <driver type="spi" name="stm32_uart" instances="1,2,3,4,5"/>
+    <driver type="timer" name="stm32" instances="1,2,3,4,5,6,7,8"/>
+    <driver type="uart" name="stm32" instances="1,2,3,4,5"/>
+    <driver type="usb" name="stm32_fs"/>
+    <driver type="gpio" name="stm32f1">
+      <gpio port="A" id="0">
+        <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af peripheral="Adc1" name="Channel0" type="analog"/>
+        <af peripheral="Adc2" name="Channel0" type="analog"/>
+        <af peripheral="Adc3" name="Channel0" type="analog"/>
+        <af peripheral="Timer5" name="Channel1"/>
+        <af peripheral="Timer8" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="A" id="1">
+        <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel1" type="analog"/>
+        <af peripheral="Adc2" name="Channel1" type="analog"/>
+        <af peripheral="Adc3" name="Channel1" type="analog"/>
+        <af peripheral="Timer5" name="Channel2"/>
+      </gpio>
+      <gpio port="A" id="2">
+        <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel2" type="analog"/>
+        <af peripheral="Adc2" name="Channel2" type="analog"/>
+        <af peripheral="Adc3" name="Channel2" type="analog"/>
+        <af peripheral="Timer5" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="3">
+        <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel3" type="analog"/>
+        <af peripheral="Adc2" name="Channel3" type="analog"/>
+        <af peripheral="Adc3" name="Channel3" type="analog"/>
+        <af peripheral="Timer5" name="Channel4"/>
+      </gpio>
+      <gpio port="A" id="4">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Nss"/>
+        <af id="3,1,0" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="3,1,0" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="28,1,1" peripheral="SpiMaster3" name="Nss"/>
+        <af peripheral="Adc1" name="Channel4" type="analog"/>
+        <af peripheral="Adc2" name="Channel4" type="analog"/>
+      </gpio>
+      <gpio port="A" id="5">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af peripheral="Adc1" name="Channel5" type="analog"/>
+        <af peripheral="Adc2" name="Channel5" type="analog"/>
+      </gpio>
+      <gpio port="A" id="6">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel6" type="analog"/>
+        <af peripheral="Adc2" name="Channel6" type="analog"/>
+        <af peripheral="Timer8" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="A" id="7">
+        <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel7" type="analog"/>
+        <af peripheral="Adc2" name="Channel7" type="analog"/>
+        <af peripheral="Timer8" name="Channel1N"/>
+      </gpio>
+      <gpio port="A" id="8">
+        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af peripheral="ClockOutput" type="out"/>
+        <af peripheral="Uart1" name="Ck" type="out"/>
+        <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="A" id="9">
+        <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+      </gpio>
+      <gpio port="A" id="10">
+        <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="11">
+        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="13,3,0" peripheral="Can1" name="Rx" type="in"/>
+        <af peripheral="Uart1" name="Cts" type="in"/>
+      </gpio>
+      <gpio port="A" id="12">
+        <af id="6,3,0" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+        <af id="13,3,0" peripheral="Can1" name="Tx" type="out"/>
+        <af peripheral="Uart1" name="Rts" type="out"/>
+      </gpio>
+      <gpio port="A" id="13"/>
+      <gpio port="A" id="14"/>
+      <gpio port="A" id="15">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="28,1,0" peripheral="SpiMaster3" name="Nss"/>
+      </gpio>
+      <gpio port="B" id="0">
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel8" type="analog"/>
+        <af peripheral="Adc2" name="Channel8" type="analog"/>
+        <af peripheral="Timer8" name="Channel2N"/>
+      </gpio>
+      <gpio port="B" id="1">
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel9" type="analog"/>
+        <af peripheral="Adc2" name="Channel9" type="analog"/>
+        <af peripheral="Timer8" name="Channel3N"/>
+      </gpio>
+      <gpio port="B" id="2"/>
+      <gpio port="B" id="3">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="28,1,0" peripheral="SpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="B" id="4">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="28,1,0" peripheral="SpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio port="B" id="5">
+        <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="28,1,0" peripheral="SpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="B" id="6">
+        <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="7">
+        <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
+        <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+        <af device-pin-id="v|z" peripheral="Fsmc" name="Nl"/>
+      </gpio>
+      <gpio port="B" id="8">
+        <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="13,3,2" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio port="B" id="9">
+        <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="13,3,2" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio port="B" id="10">
+        <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af peripheral="I2cMaster2" name="Scl" type="out"/>
+      </gpio>
+      <gpio port="B" id="11">
+        <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af peripheral="I2cMaster2" name="Sda"/>
+      </gpio>
+      <gpio port="B" id="12">
+        <af id="4,3,0" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,0" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af peripheral="SpiMaster2" name="Nss"/>
+      </gpio>
+      <gpio port="B" id="13">
+        <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af peripheral="SpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="B" id="14">
+        <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af peripheral="SpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio port="B" id="15">
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af peripheral="SpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="C" id="0">
+        <af peripheral="Adc1" name="Channel10" type="analog"/>
+        <af peripheral="Adc2" name="Channel10" type="analog"/>
+        <af peripheral="Adc3" name="Channel10" type="analog"/>
+      </gpio>
+      <gpio port="C" id="1">
+        <af peripheral="Adc1" name="Channel11" type="analog"/>
+        <af peripheral="Adc2" name="Channel11" type="analog"/>
+        <af peripheral="Adc3" name="Channel11" type="analog"/>
+      </gpio>
+      <gpio port="C" id="2">
+        <af peripheral="Adc1" name="Channel12" type="analog"/>
+        <af peripheral="Adc2" name="Channel12" type="analog"/>
+        <af peripheral="Adc3" name="Channel12" type="analog"/>
+      </gpio>
+      <gpio port="C" id="3">
+        <af peripheral="Adc1" name="Channel13" type="analog"/>
+        <af peripheral="Adc2" name="Channel13" type="analog"/>
+        <af peripheral="Adc3" name="Channel13" type="analog"/>
+      </gpio>
+      <gpio port="C" id="4">
+        <af peripheral="Adc1" name="Channel14" type="analog"/>
+        <af peripheral="Adc2" name="Channel14" type="analog"/>
+      </gpio>
+      <gpio port="C" id="5">
+        <af peripheral="Adc1" name="Channel15" type="analog"/>
+        <af peripheral="Adc2" name="Channel15" type="analog"/>
+      </gpio>
+      <gpio port="C" id="6">
+        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+        <af peripheral="Timer8" name="Channel1"/>
+      </gpio>
+      <gpio port="C" id="7">
+        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+        <af peripheral="Timer8" name="Channel2"/>
+      </gpio>
+      <gpio port="C" id="8">
+        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+        <af peripheral="Timer8" name="Channel3"/>
+      </gpio>
+      <gpio port="C" id="9">
+        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+        <af peripheral="Timer8" name="Channel4"/>
+      </gpio>
+      <gpio port="C" id="10">
+        <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="28,1,1" peripheral="SpiMaster3" name="Sck" type="out"/>
+        <af peripheral="Uart4" name="Tx" type="out"/>
+      </gpio>
+      <gpio port="C" id="11">
+        <af id="4,3,1" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="28,1,1" peripheral="SpiMaster3" name="Miso" type="in"/>
+        <af peripheral="Uart4" name="Rx" type="in"/>
+      </gpio>
+      <gpio port="C" id="12">
+        <af id="4,3,1" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,1" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af id="28,1,1" peripheral="SpiMaster3" name="Mosi" type="out"/>
+        <af peripheral="Uart5" name="Tx" type="out"/>
+      </gpio>
+      <gpio port="C" id="13"/>
+      <gpio port="C" id="14"/>
+      <gpio port="C" id="15"/>
+      <gpio port="D" id="0">
+        <af device-pin-id="v|z" id="13,3,3" peripheral="Can1" name="Rx" type="in"/>
+        <af device-pin-id="v|z" peripheral="Fsmc" name="D2"/>
+      </gpio>
+      <gpio port="D" id="1">
+        <af device-pin-id="v|z" id="13,3,3" peripheral="Can1" name="Tx" type="out"/>
+        <af device-pin-id="v|z" peripheral="Fsmc" name="D3"/>
+      </gpio>
+      <gpio port="D" id="2">
+        <af peripheral="Timer3" name="ExternalTrigger" type="in"/>
+        <af peripheral="Uart5" name="Rx" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="3">
+        <af id="3,1,1" peripheral="Uart2" name="Cts" type="in"/>
+        <af peripheral="Fsmc" name="Clk"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="4">
+        <af id="3,1,1" peripheral="Uart2" name="Rts" type="out"/>
+        <af peripheral="Fsmc" name="Noe"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="5">
+        <af id="3,1,1" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af peripheral="Fsmc" name="Nwe"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="6">
+        <af id="3,1,1" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af peripheral="Fsmc" name="Nwait"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="7">
+        <af id="3,1,1" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="3,1,1" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af peripheral="Fsmc" name="Nce2"/>
+        <af peripheral="Fsmc" name="Ne1"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="8">
+        <af id="4,3,3" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af peripheral="Fsmc" name="D13"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="9">
+        <af id="4,3,3" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af peripheral="Fsmc" name="D14"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="10">
+        <af id="4,3,3" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="4,3,3" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af peripheral="Fsmc" name="D15"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="11">
+        <af id="4,3,3" peripheral="Uart3" name="Cts" type="in"/>
+        <af peripheral="Fsmc" name="A16"/>
+        <af peripheral="Fsmc" name="Cle"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="12">
+        <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af peripheral="Fsmc" name="A17"/>
+        <af peripheral="Fsmc" name="Ale"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="13">
+        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af peripheral="Fsmc" name="A18"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="14">
+        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af peripheral="Fsmc" name="D0"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="D" id="15">
+        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af peripheral="Fsmc" name="D1"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="0">
+        <af peripheral="Fsmc" name="Nbl0"/>
+        <af peripheral="Timer4" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="1">
+        <af peripheral="Fsmc" name="Nbl1"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="2">
+        <af peripheral="Fsmc" name="A23"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="3">
+        <af peripheral="Fsmc" name="A19"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="4">
+        <af peripheral="Fsmc" name="A20"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="5">
+        <af peripheral="Fsmc" name="A21"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="6">
+        <af peripheral="Fsmc" name="A22"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="7">
+        <af id="6,3,3" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+        <af peripheral="Fsmc" name="D4"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="8">
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+        <af peripheral="Fsmc" name="D5"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="9">
+        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+        <af peripheral="Fsmc" name="D6"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="10">
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+        <af peripheral="Fsmc" name="D7"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="11">
+        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+        <af peripheral="Fsmc" name="D8"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="12">
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+        <af peripheral="Fsmc" name="D9"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="13">
+        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+        <af peripheral="Fsmc" name="D10"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="14">
+        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+        <af peripheral="Fsmc" name="D11"/>
+      </gpio>
+      <gpio device-pin-id="v|z" port="E" id="15">
+        <af id="6,3,3" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af peripheral="Fsmc" name="D12"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="0">
+        <af peripheral="Fsmc" name="A0"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="1">
+        <af peripheral="Fsmc" name="A1"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="2">
+        <af peripheral="Fsmc" name="A2"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="3">
+        <af peripheral="Fsmc" name="A3"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="4">
+        <af peripheral="Fsmc" name="A4"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="5">
+        <af peripheral="Fsmc" name="A5"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="6">
+        <af peripheral="Adc3" name="Channel4" type="analog"/>
+        <af peripheral="Fsmc" name="Niord"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="7">
+        <af peripheral="Adc3" name="Channel5" type="analog"/>
+        <af peripheral="Fsmc" name="Nreg"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="8">
+        <af peripheral="Adc3" name="Channel6" type="analog"/>
+        <af peripheral="Fsmc" name="Niowr"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="9">
+        <af peripheral="Adc3" name="Channel7" type="analog"/>
+        <af peripheral="Fsmc" name="Cd"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="10">
+        <af peripheral="Adc3" name="Channel8" type="analog"/>
+        <af peripheral="Fsmc" name="Intr"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="11">
+        <af peripheral="Fsmc" name="Nios16"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="12">
+        <af peripheral="Fsmc" name="A6"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="13">
+        <af peripheral="Fsmc" name="A7"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="14">
+        <af peripheral="Fsmc" name="A8"/>
+      </gpio>
+      <gpio device-pin-id="z" port="F" id="15">
+        <af peripheral="Fsmc" name="A9"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="0">
+        <af peripheral="Fsmc" name="A10"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="1">
+        <af peripheral="Fsmc" name="A11"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="2">
+        <af peripheral="Fsmc" name="A12"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="3">
+        <af peripheral="Fsmc" name="A13"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="4">
+        <af peripheral="Fsmc" name="A14"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="5">
+        <af peripheral="Fsmc" name="A15"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="6">
+        <af peripheral="Fsmc" name="Int2"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="7">
+        <af peripheral="Fsmc" name="Int3"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="8"/>
+      <gpio device-pin-id="z" port="G" id="9">
+        <af peripheral="Fsmc" name="Nce3"/>
+        <af peripheral="Fsmc" name="Ne2"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="10">
+        <af peripheral="Fsmc" name="Nce4"/>
+        <af peripheral="Fsmc" name="Ne3"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="11">
+        <af peripheral="Fsmc" name="Nce4"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="12">
+        <af peripheral="Fsmc" name="Ne4"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="13">
+        <af peripheral="Fsmc" name="A24"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="14">
+        <af peripheral="Fsmc" name="A25"/>
+      </gpio>
+      <gpio device-pin-id="z" port="G" id="15"/>
+    </driver>
+  </device>
+</rca>

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f103_8.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f103_8.ld
@@ -1,0 +1,7 @@
+MEMORY
+{
+	ROM (rx)  : ORIGIN = 0x08000000, LENGTH = 64k
+	RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 20k
+}
+
+INCLUDE stm32_ram.ld

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f103_c.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f103_c.ld
@@ -1,0 +1,8 @@
+
+MEMORY
+{
+	ROM (rx)  : ORIGIN = 0x08000000, LENGTH = 256k
+	RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 48k
+}
+
+INCLUDE stm32_ram.ld


### PR DESCRIPTION
Hi,

I've tested this in my project with manual clock configuration, and it works as expected. I took the device description files from the experimental branch, but removed the clocktree as that's not used in develop, and missing from the rest of the devices too. I haven't yet added an example for this, but if needed, I can probably write a blinky.

Just for reference, in my project I configured the clock like this for 32MHz:

``` c++
ClockControl::enableInternalClock();
ClockControl::enablePll(ClockControl::PllSource::InternalClock, ClockControl::UsbPrescaler::Div1, 8);
ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div1);
ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
xpcc::clock::fcpu        = systemClock::Frequency;
xpcc::clock::fcpu_kHz    = systemClock::Frequency / 1000;
xpcc::clock::fcpu_MHz    = systemClock::Frequency / 1000000;
xpcc::clock::ns_per_loop = std::round(1000000000.f / systemClock::Frequency * 3.f);
```

And here's the dummy clock:

``` c++
// Dummy clock for devices
struct systemClock {
    static constexpr uint32_t Frequency = 32000000;
    static constexpr uint32_t Usart1 = Frequency;
    static constexpr uint32_t Can1 = Frequency;
    static constexpr uint32_t I2c2 = Frequency;
};
```

Also a note: `ClockControl::PllSource::InternalClock` should probably be renamed to something like `ClockControl::PllSource::InternalClockDiv2`. It confused me when I set the multiplier to 4, and I didn't get 32MHz.
