### PR TITLE
[build] Fix building xpcc as a dependency

### DIFF
--- a/scons/site_tools/xpcc.py
+++ b/scons/site_tools/xpcc.py
@@ -150,8 +150,8 @@ def xpcc_library(env, buildpath=None):
 								  'templates/xpcc_config.hpp.in'),
 			substitutions = substitutions)
 
-	env.PrependUnique(LIBS = ['xpcc'])
-	env.PrependUnique(LIBPATH = [os.path.join(env['XPCC_BUILDPATH'], 'src')])
+	env.PrependUnique(LIBS = [library])
+	env.PrependUnique(LIBPATH = [os.path.join(env['XPCC_BUILDPATH'], 'src', 'xpcc', 'src')])
 
 	# restore original environment
 	env['XPCC_BUILDPATH'], env['XPCC_BASEPATH'] = backup


### PR DESCRIPTION
This fixes building xpcc as a dependency (e.g. xpcc is a subdirectory of the project). Previously the library didn't even build, and the path was also wrong.
