### PR TITLE
Add Nucleo-F103RB blinky example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ env:
  - TEST_SUITE="check=examples examples=arduino_uno"
  - TEST_SUITE="check=examples examples=stm32f4_loa_v2b"
  - TEST_SUITE="check=examples examples=stm32f469_discovery"
+ - TEST_SUITE="check=examples examples=nucleo_f103rb"
  - TEST_SUITE="check=examples examples=unittest"
 
 script: "scons $TEST_SUITE"

--- a/examples/nucleo_f103rb/blink/SConstruct
+++ b/examples/nucleo_f103rb/blink/SConstruct
@@ -1,0 +1,31 @@
+
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+sources = env.FindFiles('.').sources + ['../nucleo_f103rb.cpp']
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+hexfile = env.Hex(program)
+binfile = env.Bin(program)
+
+env.Alias('program', env.OpenOcd(program))
+env.Alias('remote', env.OpenOcdRemote(hexfile))
+env.Alias('build', [hexfile, binfile, env.Listing(program)])
+env.Alias('all', ['build', 'size'])
+
+env.Default('all')

--- a/examples/nucleo_f103rb/blink/main.cpp
+++ b/examples/nucleo_f103rb/blink/main.cpp
@@ -1,0 +1,27 @@
+#include "../nucleo_f103rb.hpp"
+
+using namespace Board;
+
+MAIN_FUNCTION
+{
+	Board::initialize();
+
+	// Use the logging streams to print some messages.
+	// Change XPCC_LOG_LEVEL above to enable or disable these messages
+	XPCC_LOG_DEBUG   << "debug"   << xpcc::endl;
+	XPCC_LOG_INFO    << "info"    << xpcc::endl;
+	XPCC_LOG_WARNING << "warning" << xpcc::endl;
+	XPCC_LOG_ERROR   << "error"   << xpcc::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		Led::toggle();
+		xpcc::delayMilliseconds(Button::read() ? 100 : 500);
+
+		XPCC_LOG_INFO << "loop: " << counter++ << xpcc::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f103rb/blink/openocd.cfg
+++ b/examples/nucleo_f103rb/blink/openocd.cfg
@@ -1,0 +1,1 @@
+source [find board/st_nucleo_f103rb.cfg]

--- a/examples/nucleo_f103rb/blink/project.cfg
+++ b/examples/nucleo_f103rb/blink/project.cfg
@@ -1,0 +1,22 @@
+[general]
+name = blink
+
+[build]
+device = stm32f103rb
+clock = 64000000
+buildpath = ${xpccpath}/build/nucleo_f103rb/${name}
+
+[program]
+tool = openocd
+
+[parameters]
+uart.stm32.2.tx_buffer = 2048
+
+[openocd]
+configfile = openocd.cfg
+commands =
+  init
+  reset init
+  flash write_image erase $SOURCE
+  reset run
+  shutdown

--- a/examples/nucleo_f103rb/nucleo_f103rb.cpp
+++ b/examples/nucleo_f103rb/nucleo_f103rb.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "nucleo_f103rb.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);

--- a/examples/nucleo_f103rb/nucleo_f103rb.hpp
+++ b/examples/nucleo_f103rb/nucleo_f103rb.hpp
@@ -1,0 +1,133 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+//
+// NUCLEO-F103RB
+// Nucleo kit for STM32F103RB
+// http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF259875
+//
+
+#ifndef XPCC_STM32_NUCLEO_F103RB_HPP
+#define XPCC_STM32_NUCLEO_F103RB_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F103RB running at 64MHz generated from the internal 8MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = 64000000;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	// manual clock tree for APB1
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+	static constexpr uint32_t Timer2 = Apb1 * 2;
+	static constexpr uint32_t Timer3 = Apb1 * 2;
+	static constexpr uint32_t Timer4 = Apb1 * 2;
+	static constexpr uint32_t Timer5 = Apb1 * 2;
+	static constexpr uint32_t Timer6 = Apb1 * 2;
+	static constexpr uint32_t Timer7 = Apb1 * 2;
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Can1   = Apb1;
+
+	// manual clock tree for APB2
+	static constexpr uint32_t Adc1   = Apb2;
+	static constexpr uint32_t Adc2   = Apb2;
+	static constexpr uint32_t Adc3   = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Timer1 = Apb2 * 1;
+	static constexpr uint32_t Timer8 = Apb2 * 1;
+};
+
+// Arduino Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA4;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+
+using D0  = GpioA3;
+using D1  = GpioA2;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB10;
+using D7  = GpioA8;
+using D8  = GpioA9;
+using D9  = GpioC7;
+using D10 = GpioB6;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+
+using Button = xpcc::GpioInverted<GpioInputC13>;
+using Led = D13;
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+
+inline void
+initialize()
+{
+	ClockControl::enableInternalClock();	// 8MHz
+	// internal clock / 2 * 16 = 64MHz, => 64/1.5 = 42.6 => bad for USB
+	ClockControl::enablePll(ClockControl::PllSource::InternalClock, ClockControl::UsbPrescaler::Div1_5, 16);
+	// set flash latency to 2 otherwise the controller crashes
+	FLASH->ACR |= FLASH_ACR_PRFTBE | 2;
+	// switch system clock to PLL output
+	ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+	ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+	// APB1 has max. 36MHz
+	ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
+	ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+	// update frequencies for busy-wait delay functions
+	xpcc::clock::fcpu        = systemClock::Frequency;
+	xpcc::clock::fcpu_kHz    = systemClock::Frequency / 1000;
+	xpcc::clock::fcpu_MHz    = systemClock::Frequency / 1000000;
+	xpcc::clock::ns_per_loop = std::round(1000000000.f / systemClock::Frequency * 3.f);
+
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	stlink::Tx::connect(stlink::Uart::Tx);
+	stlink::Rx::connect(stlink::Uart::Rx, Gpio::InputType::PullUp);
+	stlink::Uart::initialize<systemClock, 115200>(12);
+
+	Led::setOutput(xpcc::Gpio::Low);
+
+	Button::setInput();
+	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	Button::enableExternalInterrupt();
+//	Button::enableExternalInterruptVector(12);
+}
+
+}
+
+#endif	// XPCC_STM32_NUCLEO_F103RB_HPP

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f103_b.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f103_b.ld
@@ -1,0 +1,7 @@
+MEMORY
+{
+	ROM (rx)  : ORIGIN = 0x08000000, LENGTH = 128k
+	RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 20k
+}
+
+INCLUDE stm32_ram.ld


### PR DESCRIPTION
Adds a blinky example for the NUCLEO-F103RB which blinks the LED and prints a counter in a loop.

@Sh4rK: I ran into the same problem you had with higher clock frequencies. It turns out that the `ClockControl` code does not set the Flash Latency correctly, this has to be done manually. [For >48MHz  you need 2 wait states.](https://github.com/roboterclubaachen/xpcc/blob/develop/examples/nucleo_f103rb/nucleo_f103rb.hpp?ts=4#L104)
This is a stupid design flaw of `ClockControl`, I'll have to change that.
