### PR TITLE
Add generic flash latency computation for STM32 and LPC11.

### DIFF
--- a/examples/nucleo_f103rb/nucleo_f103rb.hpp
+++ b/examples/nucleo_f103rb/nucleo_f103rb.hpp
@@ -100,8 +100,8 @@ initialize()
 	ClockControl::enableInternalClock();	// 8MHz
 	// internal clock / 2 * 16 = 64MHz, => 64/1.5 = 42.6 => bad for USB
 	ClockControl::enablePll(ClockControl::PllSource::InternalClock, ClockControl::UsbPrescaler::Div1_5, 16);
-	// set flash latency to 2 otherwise the controller crashes
-	FLASH->ACR |= FLASH_ACR_PRFTBE | 2;
+	// set flash latency for 64MHz
+	ClockControl::setFlashLatency(MHz64);
 	// switch system clock to PLL output
 	ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
 	ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);

--- a/examples/stm32f072_discovery/stm32f072_discovery.hpp
+++ b/examples/stm32f072_discovery/stm32f072_discovery.hpp
@@ -67,8 +67,8 @@ initialize()
 {
 	// Enable the interal 48MHz clock
 	ClockControl::enableInternalClockMHz48();
-	// set flash latency to 1 otherwise the controller crashes
-	FLASH->ACR |= FLASH_ACR_PRFTBE | 1;
+	// set flash latency for 48MHz
+	ClockControl::setFlashLatency(MHz48);
 	// Switch to the 48MHz clock
 	ClockControl::enableSystemClock(ClockControl::SystemClockSource::InternalClockMHz48);
 	// update frequencies for busy-wait delay functions

--- a/src/xpcc/architecture/platform/driver/clock/generic/common_clock.hpp
+++ b/src/xpcc/architecture/platform/driver/clock/generic/common_clock.hpp
@@ -53,6 +53,7 @@ enum Frequency
 	MHz30       =   30 * MHz1,
 	MHz32       =   32 * MHz1,
 	MHz36       =   36 * MHz1,
+	MHz40       =   40 * MHz1,
 	MHz42       =   42 * MHz1,
 	MHz48       =   48 * MHz1,
 	MHz50       =   50 * MHz1,

--- a/src/xpcc/architecture/platform/driver/clock/generic/static.macros
+++ b/src/xpcc/architecture/platform/driver/clock/generic/static.macros
@@ -197,6 +197,7 @@ public:
 	{
 		StartupError err =  {{ src.name }}<{{ template }}>::enable(waitCycles);
 		if (err != StartupError::None) return err;
+		ClockControl::setFlashLatency(OutputFrequency);
 		if(ClockControl::enable{{ s.name }}(
 				ClockControl::{{ s.name }}Source::{{ src.name }}, waitCycles))
 			return StartupError::None;

--- a/src/xpcc/architecture/platform/driver/clock/generic/static.macros
+++ b/src/xpcc/architecture/platform/driver/clock/generic/static.macros
@@ -76,14 +76,14 @@ public:
 
 
 %% if target is stm32f2 or target is stm32f4
-			ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
-			ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div2);
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div2);
 %% elif target is stm32f1 and target.name == '100'
-			ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div1);
-			ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div1);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
 %% elif target is stm32f1 or target is stm32f3
-			ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
-			ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
 %% endif
 
 		return StartupError::None;

--- a/src/xpcc/architecture/platform/driver/clock/lpc/clock.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/lpc/clock.hpp.in
@@ -134,6 +134,21 @@ namespace xpcc
 			}
 
 			static inline uint32_t
+			setFlashLatency(const uint32_t CPU_Frequency, const uint16_t /*mV*/ = 3300)
+			{
+				if (CPU_Frequency <= MHz20) {
+					LPC_FLASHCTRL->FLASHCFG = 0;
+				}
+				else if (CPU_Frequency <= MHz40) {
+					LPC_FLASHCTRL->FLASHCFG = 1;
+				}
+				else {
+					LPC_FLASHCTRL->FLASHCFG = 2;
+				}
+				return MHz50;
+			}
+
+			static inline uint32_t
 			getCpuFrequency()
 			{
 				return xpcc::clock::fcpu;

--- a/src/xpcc/architecture/platform/driver/clock/stm32/clock.cpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/clock.cpp.in
@@ -1,5 +1,5 @@
 // coding: utf-8
-/* Copyright (c) 2011, Roboterclub Aachen e.V.
+/* Copyright (c) 2011-2016, Roboterclub Aachen e.V.
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -7,7 +7,6 @@
  */
 // ----------------------------------------------------------------------------
 
-#include "../../../device.hpp"
 #include "clock.hpp"
 
 namespace xpcc

--- a/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
@@ -1,5 +1,5 @@
 // coding: utf-8
-/* Copyright (c) 2011, Roboterclub Aachen e.V.
+/* Copyright (c) 2011-2016, Roboterclub Aachen e.V.
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -10,10 +10,14 @@
 #ifndef XPCC_STM32_CLOCK_HPP
 #define XPCC_STM32_CLOCK_HPP
 
+/**
+ * @ingroup 	{{target.string}}
+ * @defgroup	{{target.string}}_clock System Clock
+ */
+
 #include <stdint.h>
 #include "../../../device.hpp"
 #include "../generic/common_clock.hpp"
-// #include "static.hpp"
 
 using namespace xpcc::clock;
 
@@ -23,6 +27,17 @@ namespace xpcc
 namespace stm32
 {
 
+/**
+ * Clock Control for STM32 devices.
+ *
+ * This class abstracts access to clock settings on the STM32.
+ * You need to use this class to enable internal and external clock
+ * sources & outputs, set PLL parameters and AHB & APB prescalers.
+ * Don't forget to set the flash latencies.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		{{target.string}}_clock
+ */
 class ClockControl
 {
 public:

--- a/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
@@ -357,7 +357,9 @@ public:
 	 * Does nothing if CPU frequency is too high for the available
 	 * voltage.
 	 *
-	 * @returns maximum CPU frequency for voltage or `0` if CPU frequency is too high for voltage
+	 * @returns maximum CPU frequency for voltage.
+	 * @retval	<=CPU_Frequency flash latency has been set correctly.
+	 * @retval	>CPU_Frequency requested frequency too high for voltage.
 	 */
 	static uint32_t
 	setFlashLatency(const uint32_t CPU_Frequency, const uint16_t mV = 3300);

--- a/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/clock.hpp.in
@@ -338,6 +338,16 @@ public:
 %% endif
 
 public:
+	/** Set flash latency for CPU frequency and voltage.
+	 * Does nothing if CPU frequency is too high for the available
+	 * voltage.
+	 *
+	 * @returns maximum CPU frequency for voltage or `0` if CPU frequency is too high for voltage
+	 */
+	static uint32_t
+	setFlashLatency(const uint32_t CPU_Frequency, const uint16_t mV = 3300);
+
+public:
 	static inline uint32_t
 	getCpuFrequency()
 	{

--- a/src/xpcc/architecture/platform/driver/clock/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/driver.xml
@@ -2,11 +2,13 @@
 <!DOCTYPE rca SYSTEM "../../xml/driver.dtd">
 <rca version="1.0">
 	<driver type="clock" name="stm32">
-		<template device-family="f1|f3|f4">static.hpp.in</template>
+		<template>latency.cpp.in</template>
 		<template>clock.cpp.in</template>
 		<template>clock.hpp.in</template>
-		<static device-family="f1|f3|f4">pll_calculator.hpp</static>
 		<static>type_ids.hpp</static>
+
+		<template device-family="f1|f3|f4">static.hpp.in</template>
+		<static device-family="f1|f3|f4">pll_calculator.hpp</static>
 
 		<usbprescaler device-name="042|048|070|072|078|102|103|302|303|373">True</usbprescaler>
 		<pllprediv device-family="f0|f3">True</pllprediv>

--- a/src/xpcc/architecture/platform/driver/clock/stm32/latency.cpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/latency.cpp.in
@@ -1,0 +1,282 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+* ------------------------------------------------------------------------ */
+
+#include "clock.hpp"
+
+%% if target is stm32f0
+/*
+For the stm32f0xx devices, the maximum frequency of the SYSCLK and HCLK is 48 MHz,
+PCLK2 48 MHz and PCLK1 48 MHz. The maximum frequency should be adapted accordingly:
++---------------+----------------+
+| Latency       | HCLK clock     |
+|               | frequency (MHz)|
+|---------------|----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  24|
+|---------------|----------------|
+|1WS(2CPU cycle)|24 < HCLK <=  48|
+|---------------|----------------|
+|2WS(3CPU cycle)|48 < HCLK <=  72|
++---------------+----------------+
+*/
+	%% set table = {3600: [24, 48]}
+%% elif target is stm32f1 or target is stm32f3
+	%% if target.name in ["100"]
+/*
+For the stm32f100 devices, the maximum frequency of the SYSCLK and HCLK is 24 MHz,
+PCLK2 24 MHz and PCLK1 24 MHz.
++---------------+----------------+
+| Latency       | HCLK clock     |
+|               | frequency (MHz)|
+|---------------|----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  24|
++---------------+----------------+
+*/
+		%% set table = {3600: [24]}
+	%% else
+/*
+For the f1xx & f3xx devices, the maximum frequency of the SYSCLK and HCLK is 72 MHz,
+PCLK2 72 MHz and PCLK1 36 MHz. The maximum frequency should be adapted accordingly:
++---------------+----------------+
+| Latency       | HCLK clock     |
+|               | frequency (MHz)|
+|---------------|----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  24|
+|---------------|----------------|
+|1WS(2CPU cycle)|24 < HCLK <=  48|
+|---------------|----------------|
+|2WS(3CPU cycle)|48 < HCLK <=  72|
++---------------+----------------+
+*/
+		%% set table = {3600: [24, 48, 72]}
+	%% endif
+%% elif target is stm32f2
+/*
+For the stm32f2xx devices, the maximum frequency of the SYSCLK and HCLK is 120 MHz,
+PCLK2 60 MHz and PCLK1 30 MHz. Depending on the device voltage range, the maximum
+frequency should be adapted accordingly:
++---------------+---------------------------------------------------------------------+
+| Latency       |                HCLK clock frequency (MHz)                           |
+|               |---------------------------------------------------------------------|
+|               | voltage range  | voltage range  |  voltage range  |  voltage range  |
+|               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  |  2.1 V - 2.4 V  |  1.8 V - 2.1 V  |
+|---------------|----------------|----------------|-----------------|-----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  30| 0 < HCLK <=  24|  0 < HCLK <=  18|  0 < HCLK <=  16|
+|---------------|----------------|----------------|-----------------|-----------------|
+|1WS(2CPU cycle)|30 < HCLK <=  60|24 < HCLK <=  48| 18 < HCLK <=  36| 16 < HCLK <=  32|
+|---------------|----------------|----------------|-----------------|-----------------|
+|2WS(3CPU cycle)|60 < HCLK <=  90|48 < HCLK <=  72| 36 < HCLK <=  54| 32 < HCLK <=  48|
+|---------------|----------------|----------------|-----------------|-----------------|
+|3WS(4CPU cycle)|90 < HCLK <= 120|72 < HCLK <=  96| 54 < HCLK <=  72| 48 < HCLK <=  64|
+|---------------|----------------|----------------|-----------------|-----------------|
+|4WS(5CPU cycle)|      NA        |96 < HCLK <= 120| 72 < HCLK <=  90| 64 < HCLK <=  80|
+|---------------|----------------|----------------|-----------------|-----------------|
+|5WS(6CPU cycle)|      NA        |      NA        | 90 < HCLK <= 108| 80 < HCLK <=  96|
+|---------------|----------------|----------------|-----------------|-----------------|
+|6WS(7CPU cycle)|      NA        |      NA        |108 < HCLK <= 120| 96 < HCLK <= 112|
+|---------------|----------------|----------------|-----------------|-----------------|
+|7WS(8CPU cycle)|      NA        |      NA        |       NA        |112 < HCLK <= 120|
++---------------+----------------+----------------+-----------------+-----------------+
+*/
+	{% set table = {
+		3600: [30, 60, 90, 120],
+		2700: [24, 48, 72, 96, 120],
+		2400: [18, 36, 54, 72, 90, 108, 120],
+		2100: [16, 32, 48, 64, 80, 96, 112, 120] }
+	%}
+%% elif target is stm32f4
+	%% if target.name in ["410", "411"]
+/*
+For the 410 & 411 devices, the maximum frequency of the SYSCLK and HCLK is 100 MHz,
+PCLK2 100 MHz and PCLK1 50 MHz. Depending on the device voltage range, the maximum
+frequency should be adapted accordingly:
++---------------+---------------------------------------------------------------------+
+| Latency       |                HCLK clock frequency (MHz)                           |
+|               |---------------------------------------------------------------------|
+|               | voltage range  | voltage range  |  voltage range  |  voltage range  |
+|               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  |  2.1 V - 2.4 V  |  1.71V - 2.1 V  |
+|---------------|----------------|----------------|-----------------|-----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  30| 0 < HCLK <=  24|  0 < HCLK <=  18|  0 < HCLK <=  16|
+|---------------|----------------|----------------|-----------------|-----------------|
+|1WS(2CPU cycle)|30 < HCLK <=  60|24 < HCLK <=  48| 18 < HCLK <=  36| 16 < HCLK <=  32|
+|---------------|----------------|----------------|-----------------|-----------------|
+|2WS(3CPU cycle)|60 < HCLK <=  90|48 < HCLK <=  72| 36 < HCLK <=  54| 32 < HCLK <=  48|
+|---------------|----------------|----------------|-----------------|-----------------|
+|3WS(4CPU cycle)|90 < HCLK <= 100|72 < HCLK <=  96| 54 < HCLK <=  72| 48 < HCLK <=  64|
+|---------------|----------------|----------------|-----------------|-----------------|
+|4WS(5CPU cycle)|      NA        |96 < HCLK <= 100| 72 < HCLK <=  90| 64 < HCLK <=  80|
+|---------------|----------------|----------------|-----------------|-----------------|
+|5WS(6CPU cycle)|      NA        |      NA        | 90 < HCLK <= 100| 80 < HCLK <=  96|
+|---------------|----------------|----------------|-----------------|-----------------|
+|6WS(7CPU cycle)|      NA        |      NA        |       NA        | 96 < HCLK <= 100|
++---------------+----------------+----------------+-----------------+-----------------+
+*/
+		{% set table = {
+			3600: [30, 60, 90, 100],
+			2700: [24, 48, 72, 96, 100],
+			2400: [18, 36, 54, 72, 90, 100],
+			2100: [16, 32, 48, 64, 80, 96, 100] }
+		%}
+	%% elif target.name in ["401"]
+/*
+For the 401 devices, the maximum frequency of the SYSCLK and HCLK is 84 MHz,
+PCLK2 84 MHz and PCLK1 42 MHz. Depending on the device voltage range, the maximum
+frequency should be adapted accordingly:
++---------------+---------------------------------------------------------------------+
+| Latency       |                HCLK clock frequency (MHz)                           |
+|               |---------------------------------------------------------------------|
+|               | voltage range  | voltage range  |  voltage range  |  voltage range  |
+|               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  |  2.1 V - 2.4 V  |  1.71V - 2.1 V  |
+|---------------|----------------|----------------|-----------------|-----------------|
+|0WS(1CPU cycle)| 0 < HCLK <=  30| 0 < HCLK <=  24|  0 < HCLK <=  18|  0 < HCLK <=  16|
+|---------------|----------------|----------------|-----------------|-----------------|
+|1WS(2CPU cycle)|30 < HCLK <=  60|24 < HCLK <=  48| 18 < HCLK <=  36| 16 < HCLK <=  32|
+|---------------|----------------|----------------|-----------------|-----------------|
+|2WS(3CPU cycle)|60 < HCLK <=  84|48 < HCLK <=  72| 36 < HCLK <=  54| 32 < HCLK <=  48|
+|---------------|----------------|----------------|-----------------|-----------------|
+|3WS(4CPU cycle)|      NA        |72 < HCLK <=  84| 54 < HCLK <=  72| 48 < HCLK <=  64|
+|---------------|----------------|----------------|-----------------|-----------------|
+|4WS(5CPU cycle)|      NA        |      NA        | 72 < HCLK <=  84| 64 < HCLK <=  80|
+|---------------|----------------|----------------|-----------------|-----------------|
+|5WS(6CPU cycle)|      NA        |      NA        |       NA        | 80 < HCLK <=  84|
++---------------+----------------+----------------+-----------------+-----------------+
+*/
+		{% set table = {
+			3600: [30, 60, 84],
+			2700: [24, 48, 72, 84],
+			2400: [18, 36, 54, 72, 84],
+			2100: [16, 32, 48, 64, 80, 84] }
+		%}
+	%% elif target.name in ["405", "407", "415", "417"]
+/*
+For the 405, 407, 415, 417 devices, the maximum frequency of the SYSCLK and HCLK is
+168 MHz, PCLK2 84 MHz and PCLK1 42 MHz. Depending on the device voltage range, the
+maximum frequency should be adapted accordingly:
++---------------+---------------------------------------------------------------------+
+| Latency       |                HCLK clock frequency (MHz)                           |
+|               |---------------------------------------------------------------------|
+|               | voltage range  | voltage range  |  voltage range  |  voltage range  |
+|               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  |  2.1 V - 2.4 V  |  1.8 V - 2.1 V  |
+|---------------|----------------|----------------|-----------------|-----------------|
+|0WS(1CPU cycle)|  0< HCLK <=  30|  0< HCLK <=  24|  0 < HCLK <=  22|  0 < HCLK <=  20|
+|---------------|----------------|----------------|-----------------|-----------------|
+|1WS(2CPU cycle)| 30< HCLK <=  60| 24< HCLK <=  48| 22 < HCLK <=  44| 20 < HCLK <=  40|
+|---------------|----------------|----------------|-----------------|-----------------|
+|2WS(3CPU cycle)| 60< HCLK <=  90| 48< HCLK <=  72| 44 < HCLK <=  66| 40 < HCLK <=  60|
+|---------------|----------------|----------------|-----------------|-----------------|
+|3WS(4CPU cycle)| 90< HCLK <= 120| 72< HCLK <=  96| 66 < HCLK <=  88| 60 < HCLK <=  80|
+|---------------|----------------|----------------|-----------------|-----------------|
+|4WS(5CPU cycle)|120< HCLK <= 150| 96< HCLK <= 120| 88 < HCLK <= 110| 80 < HCLK <= 100|
+|---------------|----------------|----------------|-----------------|-----------------|
+|5WS(6CPU cycle)|150< HCLK <= 168|120< HCLK <= 144|110 < HCLK <= 132|100 < HCLK <= 120|
+|---------------|----------------|----------------|-----------------|-----------------|
+|6WS(7CPU cycle)|      NA        |144< HCLK <= 168|132 < HCLK <= 154|120 < HCLK <= 140|
+|---------------|----------------|----------------|-----------------|-----------------|
+|7WS(8CPU cycle)|      NA        |      NA        |154 < HCLK <= 168|140 < HCLK <= 160|
++---------------+----------------+----------------+-----------------+-----------------+
+*/
+		{% set table = {
+			3600: [30, 60, 90, 120, 150, 168],
+			2700: [24, 48, 72, 96, 120, 144, 168],
+			2400: [22, 44, 66, 88, 110, 132, 154, 168],
+			2100: [20, 40, 60, 80, 100, 120, 140, 160] }
+		%}
+	%% elif target.name in ["427", "429", "437", "439", "446", "469", "479"]
+/*
+For the 427, 429, 437, 439, 446, 469, 479 devices, the maximum frequency of the
+SYSCLK and HCLK is 180 MHz, PCLK2 90 MHz and PCLK1 45 MHz. Depending on the device
+voltage range, the maximum frequency should be adapted accordingly:
++---------------+---------------------------------------------------------------------+
+| Latency       |                HCLK clock frequency (MHz)                           |
+|               |---------------------------------------------------------------------|
+|               | voltage range  | voltage range  |  voltage range  |  voltage range  |
+|               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  |  2.1 V - 2.4 V  |  1.8 V - 2.1 V  |
+|---------------|----------------|----------------|-----------------|-----------------|
+|0WS(1CPU cycle)|  0< HCLK <=  30|  0< HCLK <=  24|  0 < HCLK <=  22|  0 < HCLK <=  20|
+|---------------|----------------|----------------|-----------------|-----------------|
+|1WS(2CPU cycle)| 30< HCLK <=  60| 24< HCLK <=  48| 22 < HCLK <=  44| 20 < HCLK <=  40|
+|---------------|----------------|----------------|-----------------|-----------------|
+|2WS(3CPU cycle)| 60< HCLK <=  90| 48< HCLK <=  72| 44 < HCLK <=  66| 40 < HCLK <=  60|
+|---------------|----------------|----------------|-----------------|-----------------|
+|3WS(4CPU cycle)| 90< HCLK <= 120| 72< HCLK <=  96| 66 < HCLK <=  88| 60 < HCLK <=  80|
+|---------------|----------------|----------------|-----------------|-----------------|
+|4WS(5CPU cycle)|120< HCLK <= 150| 96< HCLK <= 120| 88 < HCLK <= 110| 80 < HCLK <= 100|
+|---------------|----------------|----------------|-----------------|-----------------|
+|5WS(6CPU cycle)|150< HCLK <= 180|120< HCLK <= 144|110 < HCLK <= 132|100 < HCLK <= 120|
+|---------------|----------------|----------------|-----------------|-----------------|
+|6WS(7CPU cycle)|      NA        |144< HCLK <= 168|132 < HCLK <= 154|120 < HCLK <= 140|
+|---------------|----------------|----------------|-----------------|-----------------|
+|7WS(8CPU cycle)|      NA        |168< HCLK <= 180|154 < HCLK <= 176|140 < HCLK <= 160|
+|---------------|----------------|----------------|-----------------|-----------------|
+|8WS(9CPU cycle)|      NA        |      NA        |176 < HCLK <= 180|160 < HCLK <= 168|
++---------------+----------------+----------------+-----------------+-----------------+
+*/
+		{% set table = {
+			3600: [30, 60, 90, 120, 150, 180],
+			2700: [24, 48, 72, 96, 120, 144, 168, 180],
+			2400: [22, 44, 66, 88, 110, 132, 154, 176, 180],
+			2100: [20, 40, 60, 80, 100, 120, 140, 160, 168] }
+		%}
+	%% endif
+%% endif
+
+%% for mV, table_MHz in table.items()|sort
+static const uint32_t
+flash_latency_{{ mV }}[] =
+{
+	%% for mhz in table_MHz
+	{{ mhz * 1000000 }},
+	%% endfor
+};
+%% endfor
+
+uint32_t
+xpcc::stm32::ClockControl::setFlashLatency(const uint32_t CPU_Frequency, const uint16_t mV)
+{
+	const uint32_t *lut(flash_latency_3600);
+	uint8_t lut_size(sizeof(flash_latency_3600) / sizeof(uint32_t));
+%% if table|length > 1
+	// find the right table for the voltage
+	%% for mV in (table|sort)[:-1]
+	{% if not loop.first %}else {% endif %}if (mV < {{ mV }}) {
+		lut = flash_latency_{{ mV }};
+		lut_size = sizeof(flash_latency_{{ mV }}) / sizeof(uint32_t);
+	}
+	%% endfor
+%% else
+	(void) mV;
+%% endif
+	// find the next highest frequency in the table
+	uint8_t latency(0);
+	uint32_t max_freq(0);
+	while (latency < lut_size)
+	{
+		if (CPU_Frequency <= (max_freq = lut[latency]))
+			goto set_latency;	// horrible, but effective
+		latency++;
+	}
+
+	return 0;
+
+set_latency:
+%% if target.name != "100"
+	uint32_t acr = FLASH->ACR & ~FLASH_ACR_LATENCY;
+	// set flash latency
+	acr |= latency;
+%% if target is stm32f2 or target is stm32f4
+	// enable flash prefetch and data and instruction cache
+	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
+%% elif target is stm32f7
+	// enable flash prefetch and flash accelerator
+	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
+%% else
+	// enable flash prefetch
+	acr |= FLASH_ACR_PRFTBE;
+%% endif
+	FLASH->ACR = acr;
+%% endif
+	return max_freq;
+}

--- a/src/xpcc/architecture/platform/driver/clock/stm32/latency.cpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/latency.cpp.in
@@ -236,47 +236,52 @@ flash_latency_{{ mV }}[] =
 uint32_t
 xpcc::stm32::ClockControl::setFlashLatency(const uint32_t CPU_Frequency, const uint16_t mV)
 {
+%% if target.name != "100"
 	const uint32_t *lut(flash_latency_3600);
 	uint8_t lut_size(sizeof(flash_latency_3600) / sizeof(uint32_t));
-%% if table|length > 1
+	%% if table|length > 1
 	// find the right table for the voltage
-	%% for mV in (table|sort)[:-1]
+		%% for mV in (table|sort)[:-1]
 	{% if not loop.first %}else {% endif %}if (mV < {{ mV }}) {
 		lut = flash_latency_{{ mV }};
 		lut_size = sizeof(flash_latency_{{ mV }}) / sizeof(uint32_t);
 	}
-	%% endfor
-%% else
+		%% endfor
+	%% else
 	(void) mV;
-%% endif
+	%% endif
 	// find the next highest frequency in the table
 	uint8_t latency(0);
 	uint32_t max_freq(0);
 	while (latency < lut_size)
 	{
 		if (CPU_Frequency <= (max_freq = lut[latency]))
-			goto set_latency;	// horrible, but effective
+			break;
 		latency++;
 	}
 
-	return 0;
-
-set_latency:
-%% if target.name != "100"
-	uint32_t acr = FLASH->ACR & ~FLASH_ACR_LATENCY;
-	// set flash latency
-	acr |= latency;
-%% if target is stm32f2 or target is stm32f4
-	// enable flash prefetch and data and instruction cache
-	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
-%% elif target is stm32f7
-	// enable flash prefetch and flash accelerator
-	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
+	if (CPU_Frequency <= max_freq)
+	{
+		uint32_t acr = FLASH->ACR & ~FLASH_ACR_LATENCY;
+		// set flash latency
+		acr |= latency;
+	%% if target is stm32f2 or target is stm32f4
+		// enable flash prefetch and data and instruction cache
+		acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
+	%% elif target is stm32f7
+		// enable flash prefetch and flash accelerator
+		acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
+	%% else
+		// enable flash prefetch
+		acr |= FLASH_ACR_PRFTBE;
+	%% endif
+		FLASH->ACR = acr;
+	}
 %% else
-	// enable flash prefetch
-	acr |= FLASH_ACR_PRFTBE;
+	(void) CPU_Frequency;
+	(void) mV;
+	uint32_t max_freq(MHz24);
 %% endif
-	FLASH->ACR = acr;
-%% endif
+
 	return max_freq;
 }

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
@@ -32,16 +32,6 @@
 
 
 %% macro defines()
-%#
-#define FLASH_WAIT_STATE_0		0x0
-#define FLASH_WAIT_STATE_1		0x1
-#define FLASH_WAIT_STATE_2		0x2
-#define FLASH_WAIT_STATE_3		0x3
-#define FLASH_WAIT_STATE_4		0x4
-#define FLASH_WAIT_STATE_5		0x5
-#define FLASH_WAIT_STATE_6		0x6
-#define FLASH_WAIT_STATE_7		0x7
-%#
 %% endmacro
 
 %% macro appendInterrupts()
@@ -58,32 +48,6 @@
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
 	// Remap USB Interrupts
 	SYSCFG->CFGR1 |= SYSCFG_CFGR1_USB_IT_RMP;
-%% endif
-
-// TODO: Move this into SystemClock implementation
-%% if target is stm32f2
-	// prepare flash latency for working at 120MHz and supply voltage > 2.7
-	FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY) | FLASH_WAIT_STATE_3;
-%% elif target is stm32f3
-	// prepare flash latency for working at 72MHz and supply voltage > 2.7
-	FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY) | FLASH_ACR_LATENCY_1;
-%% elif target is stm32f4
-	// prepare flash latency for working at 168MHz and supply voltage > 2.7
-	FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY) | FLASH_WAIT_STATE_5;
-%% elif target is stm32f7
-	// prepare flash latency for working at 200MHz and supply voltage > 2.7
-	FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY) | FLASH_WAIT_STATE_6;
-%% endif
-
-%% if target is stm32f2 or target is stm32f4
-	// enable flash prefetch
-	FLASH->ACR |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
-%% elif target is stm32f3
-	// enable flash prefetch
-	FLASH->ACR |= FLASH_ACR_PRFTBE;
-%% elif target is stm32f7
-	// enable flash prefetch
-	FLASH->ACR |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
 %% endif
 
 %% if target is stm32f4


### PR DESCRIPTION
This adds the required look-up-tables and algorithm for computing and setting the flash latency for any frequency at any voltage for any STM32F target.

Example [generated table for STM32F407](https://gist.github.com/salkinium/2a3f740ab527f7c58928?ts=4).

Tested in hardware on:
- STM32F072, 
- STM32F100,
- STM32F103,
- STM32F303,
- STM32F407,
- STM32F429,
- LPC11C24.
