### PR TITLE
Add Nucleo-F429ZI blinky example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ env:
  - TEST_SUITE="check=examples examples=stm32f469_discovery"
  - TEST_SUITE="check=examples examples=nucleo_f103rb"
  - TEST_SUITE="check=examples examples=nucleo_f411re"
+ - TEST_SUITE="check=examples examples=nucleo_f429zi"
  - TEST_SUITE="check=examples examples=unittest"
 
 script: "scons $TEST_SUITE"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Here is a list of supported **and tested** microcontrollers and development boar
 | STM32F407  | [STM32F4 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
 | STM32F411  | [STM32F411 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F429  | [STM32F429 Discovery][] | &#9733;&#9733;&#9733;&#9733;&#9733; |
+| STM32F429  | [STM32F429 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F469  | [STM32F469 Discovery][] | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F746  | [STM32F7 Discovery][]   | &#9733;&#9733;&#9733;&#9733;        |
 | LPC11C24   | [LPCxpresso][]          | &#9733;&#9733;                      |
@@ -221,6 +222,7 @@ Daniel Krebs ([@daniel-k](https://github.com/daniel-k)),
 [STM32F4 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF252419
 [STM32F411 Nucleo]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF260320
 [STM32F429 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF259090
+[STM32F429 Nucleo]: http://www.st.com/web/en/catalog/tools/PF262637
 [STM32F469 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
 [STM32F7 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF261641
 [LPCxpresso]: https://www.lpcware.com/LPCXpressoV1Boards

--- a/examples/nucleo_f429zi/blink/SConstruct
+++ b/examples/nucleo_f429zi/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/nucleo_f429zi/blink/main.cpp
+++ b/examples/nucleo_f429zi/blink/main.cpp
@@ -1,0 +1,29 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change XPCC_LOG_LEVEL above to enable or disable these messages
+	XPCC_LOG_DEBUG   << "debug"   << xpcc::endl;
+	XPCC_LOG_INFO    << "info"    << xpcc::endl;
+	XPCC_LOG_WARNING << "warning" << xpcc::endl;
+	XPCC_LOG_ERROR   << "error"   << xpcc::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		Leds::write(1 << (counter % Leds::width));
+		xpcc::delayMilliseconds(Button::read() ? 100 : 500);
+
+		XPCC_LOG_INFO << "loop: " << counter++ << xpcc::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f429zi/blink/project.cfg
+++ b/examples/nucleo_f429zi/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = nucleo_f429zi
+buildpath = ${xpccpath}/build/nucleo_f429zi/${name}

--- a/src/xpcc/architecture/platform/board/nucleo_f103rb/nucleo_f103rb.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f103rb/nucleo_f103rb.hpp
@@ -80,7 +80,7 @@ struct systemClock {
 		xpcc::clock::fcpu     = Frequency;
 		xpcc::clock::fcpu_kHz = Frequency / 1000;
 		xpcc::clock::fcpu_MHz = Frequency / 1000000;
-		xpcc::clock::ns_per_loop = 47; // 3000 / 64 = 46.875 = ~47ns per delay loop
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
 
 		return true;
 	}

--- a/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
@@ -31,7 +31,7 @@ struct systemClock {
 	static constexpr uint32_t Apb1 = Frequency / 2;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Adc1   = Apb2;
+	static constexpr uint32_t Adc    = Apb2;
 
 	static constexpr uint32_t Spi1   = Apb2;
 	static constexpr uint32_t Spi2   = Apb1;
@@ -144,4 +144,4 @@ initialize()
 
 }
 
-#endif	// XPCC_STM32_NUCLEO_F103RB_HPP
+#endif	// XPCC_STM32_NUCLEO_F411RE_HPP

--- a/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
@@ -81,7 +81,7 @@ struct systemClock {
 		xpcc::clock::fcpu     = Frequency;
 		xpcc::clock::fcpu_kHz = Frequency / 1000;
 		xpcc::clock::fcpu_MHz = Frequency / 1000000;
-		xpcc::clock::ns_per_loop = 31; // 3000 / 96 = 31.125 = ~31ns per delay loop
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
 
 		return true;
 	}

--- a/src/xpcc/architecture/platform/board/nucleo_f429zi/board.cfg
+++ b/src/xpcc/architecture/platform/board/nucleo_f429zi/board.cfg
@@ -1,0 +1,11 @@
+[build]
+device = stm32f429zi
+
+[parameters]
+uart.stm32.3.tx_buffer = 2048
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = B
+core.cortex.0.hardfault_handler_led_pin = 7
+
+[openocd]
+configfile = board/st_nucleo_f4.cfg

--- a/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.cpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "nucleo_f429zi.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);

--- a/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.hpp
@@ -1,0 +1,223 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+// NUCLEO-F429ZI
+// Nucleo kit for STM32F429ZI
+// http://www.st.com/web/en/catalog/tools/PF262637
+//
+
+#ifndef XPCC_STM32_NUCLEO_F429ZI_HPP
+#define XPCC_STM32_NUCLEO_F429ZI_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+
+using namespace xpcc::stm32;
+
+namespace Board
+{
+
+/// STM32F429 running at 180MHz from the external 8MHz STLink clock
+struct systemClock
+{
+	static constexpr uint32_t Frequency = MHz180;
+	static constexpr uint32_t Apb1 = Frequency / 4;
+	static constexpr uint32_t Apb2 = Frequency / 2;
+
+	static constexpr uint32_t Adc = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Spi4 = Apb2;
+	static constexpr uint32_t Spi5 = Apb2;
+	static constexpr uint32_t Spi6 = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+	static constexpr uint32_t Uart7  = Apb1;
+	static constexpr uint32_t Uart8  = Apb1;
+
+	static constexpr uint32_t Can1 = Apb1;
+	static constexpr uint32_t Can2 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 2;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalClock(); // 8 MHz
+		ClockControl::enablePll(
+			ClockControl::PllSource::ExternalClock,
+			4,      // 8MHz / N=4 -> 2MHz
+			180,    // 2MHz * M=180 -> 360MHz
+			2,      // 360MHz / P=2 -> 180MHz = F_cpu
+			7       // 360MHz / Q=7 -> ~51MHz = F_usb => bad for USB
+		);
+		ClockControl::setFlashLatency(Frequency);
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div2);
+		// update clock frequencies
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = std::round(3000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+using A0 = GpioA3;
+using A1 = GpioC0;
+using A2 = GpioC3;
+using A3 = GpioF3;
+using A4 = GpioF5;
+using A5 = GpioF10;
+// Zio Footprint
+using A6 = GpioB1;
+using A7 = GpioC2;
+using A8 = GpioF4;
+
+// Arduino Footprint
+using D0  = GpioG9;
+using D1  = GpioG14;
+using D2  = GpioF15;
+using D3  = GpioF13;
+using D4  = GpioF14;
+using D5  = GpioE11;
+using D6  = GpioE9;
+using D7  = GpioF13;
+using D8  = GpioF12;
+using D9  = GpioD15;
+using D10 = GpioD14;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+// Zio Footprint
+using D16 = GpioC6;
+using D17 = GpioB15;
+using D18 = GpioB13;
+using D19 = GpioB12;
+using D20 = GpioA15;
+using D21 = GpioC7;
+using D22 = GpioB5;
+using D23 = GpioB3;
+using D24 = GpioA4;
+using D25 = GpioB4;
+using D26 = GpioB6;
+using D27 = GpioB2;
+using D28 = GpioD13;
+using D29 = GpioD12;
+using D30 = GpioD11;
+using D31 = GpioE2;
+using D32 = GpioA0;
+using D33 = GpioB0;
+using D34 = GpioE0;
+using D35 = GpioB11;
+using D36 = GpioB10;
+using D37 = GpioE15;
+using D38 = GpioE14;
+using D39 = GpioE12;
+using D40 = GpioE10;
+using D41 = GpioE7;
+using D42 = GpioE8;
+using D43 = GpioC8;
+using D44 = GpioC9;
+using D45 = GpioC10;
+using D46 = GpioC11;
+using D47 = GpioC12;
+using D48 = GpioD2;
+using D49 = GpioG2;
+using D50 = GpioG3;
+using D51 = GpioD7;
+using D52 = GpioD6;
+using D53 = GpioD5;
+using D54 = GpioD4;
+using D55 = GpioD3;
+using D56 = GpioE2;
+using D57 = GpioE4;
+using D58 = GpioE5;
+using D59 = GpioE6;
+using D60 = GpioE3;
+using D61 = GpioF8;
+using D62 = GpioF7;
+using D63 = GpioF9;
+using D64 = GpioG1;
+using D65 = GpioG0;
+using D66 = GpioD1;
+using D67 = GpioD0;
+using D68 = GpioF0;
+using D69 = GpioF1;
+using D70 = GpioF2;
+using D71 = GpioA7;
+using D72 = xpcc::GpioUnused;
+
+using Button = GpioInputC13;
+
+using LedGreen = GpioOutputB0;	// LED1 [Green]
+using LedBlue = GpioOutputB7;	// LED2 [Blue]
+using LedRed = GpioOutputB14;	// LED3 [Red]
+using Leds = xpcc::SoftwareGpioPort< LedRed, LedBlue, LedGreen >;
+
+namespace stlink
+{
+using Tx = GpioOutputD8;
+using Rx = GpioInputD9;
+using Uart = Usart3;
+}
+
+
+inline void
+initialize()
+{
+    systemClock::enable();
+    xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+    stlink::Tx::connect(stlink::Uart::Tx);
+    stlink::Rx::connect(stlink::Uart::Rx, Gpio::InputType::PullUp);
+    stlink::Uart::initialize<systemClock, 115200>(12);
+
+    LedGreen::setOutput(xpcc::Gpio::Low);
+    LedBlue::setOutput(xpcc::Gpio::Low);
+    LedRed::setOutput(xpcc::Gpio::Low);
+
+    Button::setInput();
+    Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+    Button::enableExternalInterrupt();
+//  Button::enableExternalInterruptVector(12);
+}
+
+}
+
+#endif  // XPCC_STM32_NUCLEO_F429ZI_HPP

--- a/src/xpcc/architecture/platform/board/stm32f1_discovery/stm32f1_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f1_discovery/stm32f1_discovery.hpp
@@ -24,9 +24,83 @@ using namespace xpcc::stm32;
 namespace Board
 {
 
-/// STM32F100 running at 24MHz generated from the external 8MHz crystal
+
 /// supplied by the on-board st-link
-using systemClock = SystemClock<Pll<ExternalCrystal<MHz8>, MHz24> >;
+/* SystemClock generator is only available for selected STM32F1 devices.
+ * The idea is that it is generated automatically for you like the rest of the
+ * HAL, however, xpcc does not have this capability yet. See PR #36.
+ */
+// using systemClock = SystemClock<Pll<ExternalCrystal<MHz8>, MHz24> >;
+
+// Instead this manual implementation of the system clock is used:
+/// STM32F100 running at 24MHz generated from the external 8MHz crystal
+struct systemClock {
+	static constexpr uint32_t Frequency = 24 * MHz1;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc = Apb2;
+
+	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can2   = Apb1;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalCrystal();	// 8MHz
+		ClockControl::enablePll(
+			ClockControl::PllSource::ExternalCrystal,
+			3,
+			1
+		);
+		// set flash latency for 24MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		// APB1 has max. 24MHz
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div1);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
 
 
 using Button = GpioInputA0;	// Blue PushButton

--- a/src/xpcc/architecture/platform/board/stm32f429_discovery/stm32f429_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f429_discovery/stm32f429_discovery.hpp
@@ -23,9 +23,79 @@ using namespace xpcc::stm32;
 namespace Board
 {
 
-/// STM32F429 running at 168MHz (USB Clock qt 48MHz) generated from the
-/// external on-board 8MHz crystal
-using systemClock = SystemClock<Pll<ExternalCrystal<MHz8>, MHz168, MHz48> >;
+/// STM32F429 running at 180MHz from the external 8MHz crystal
+struct systemClock
+{
+	static constexpr uint32_t Frequency = MHz180;
+	static constexpr uint32_t Apb1 = Frequency / 4;
+	static constexpr uint32_t Apb2 = Frequency / 2;
+
+	static constexpr uint32_t Adc = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Spi4 = Apb2;
+	static constexpr uint32_t Spi5 = Apb2;
+	static constexpr uint32_t Spi6 = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+	static constexpr uint32_t Uart7  = Apb1;
+	static constexpr uint32_t Uart8  = Apb1;
+
+	static constexpr uint32_t Can1 = Apb1;
+	static constexpr uint32_t Can2 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 2;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalCrystal(); // 8 MHz
+		ClockControl::enablePll(
+			ClockControl::PllSource::ExternalCrystal,
+			4,      // 8MHz / N=4 -> 2MHz
+			180,    // 2MHz * M=180 -> 360MHz
+			2,      // 360MHz / P=2 -> 180MHz = F_cpu
+			7       // 360MHz / Q=7 -> ~51MHz = F_usb => bad for USB
+		);
+		ClockControl::setFlashLatency(Frequency);
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div2);
+		// update clock frequencies
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
 
 
 using Button = GpioInputA0;
@@ -185,7 +255,7 @@ initializeL3g()
 	l3g::Mosi::connect(l3g::SpiMaster::Mosi);
 	l3g::Miso::connect(l3g::SpiMaster::Miso);
 
-	l3g::SpiMaster::initialize<systemClock, MHz10>();
+	l3g::SpiMaster::initialize<systemClock, 11250000ul>();
 	l3g::SpiMaster::setDataMode(l3g::SpiMaster::DataMode::Mode3);
 }
 

--- a/src/xpcc/architecture/platform/board/stm32f4_discovery/stm32f4_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f4_discovery/stm32f4_discovery.hpp
@@ -25,9 +25,91 @@ using namespace xpcc::stm32;
 namespace Board
 {
 
-/// STM32F4 running at 168MHz (USB Clock qt 48MHz) generated from the
-/// external on-board 8MHz crystal
-using systemClock = SystemClock<Pll<ExternalCrystal<MHz8>, MHz168, MHz48> >;
+/* SystemClock generator is only available for selected STM32F4 devices.
+ * The idea is that it is generated automatically for you like the rest of the
+ * HAL, however, xpcc does not have this capability yet. See PR #36.
+ */
+// using systemClock = SystemClock<Pll<ExternalCrystal<MHz8>, MHz168, MHz48> >;
+
+// Instead this manual implementation of the system clock is used:
+/// STM32F407 running at 168MHz generated from the external 8MHz crystal
+struct systemClock {
+	static constexpr uint32_t Frequency = 168 * MHz1;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 4;
+	static constexpr uint32_t Apb2 = Frequency / 2;
+
+	static constexpr uint32_t Adc = Apb2;
+
+	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can2   = Apb1;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+	static constexpr uint32_t Spi4   = Apb2;
+	static constexpr uint32_t Spi5   = Apb2;
+	static constexpr uint32_t Spi6   = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+	static constexpr uint32_t Uart7  = Apb1;
+	static constexpr uint32_t Uart8  = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+	static constexpr uint32_t I2c3   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 2;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalCrystal();	// 8MHz
+		ClockControl::enablePll(
+			ClockControl::PllSource::ExternalCrystal,
+			4,		// 8MHz / N=2 -> 2MHz
+			168,	// 2MHz * M=168 -> 336MHz
+			2,		// 336MHz / P=2 -> 168MHz = F_cpu
+			7		// 336MHz / Q=7 -> 48MHz = F_usb
+		);
+		// set flash latency for 168MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		// APB1 has max. 42MHz
+		// APB2 has max. 84MHz
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div2);
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
 
 
 using Button = GpioInputA0;


### PR DESCRIPTION
Adds a board config with example for the Nucleo-144 F429ZI target.

cc @strongly-typed: I couldn't get the board programmed, due to what I think is a bug in the STLink firmware. Can you try this?
