### PR TITLE
Add heap sections to linkerscript and better memory usage printout

### DIFF
--- a/scons/site_tools/helper.py
+++ b/scons/site_tools/helper.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
-# 
+#
 # Copyright (c) 2009, Roboterclub Aachen e.V.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #     * Redistributions of source code must retain the above copyright
 #       notice, this list of conditions and the following disclaimer.
 #     * Redistributions in binary form must reproduce the above copyright
@@ -14,7 +14,7 @@
 #     * Neither the name of the Roboterclub Aachen e.V. nor the
 #       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY ROBOTERCLUB AACHEN E.V. ''AS IS'' AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -46,7 +46,7 @@ import subprocess
 # .debug_aranges      3360           0
 # (...)
 # Total             285915
-# 
+#
 # Try to match the lines (name, size, address) to get the size of the
 # individual regions
 filter = re.compile('^(?P<section>[.]\w+)\s*(?P<size>\d+)\s*(?P<addr>\d+)$')
@@ -60,15 +60,15 @@ ramSectionNames = ['.vectors', '.fastcode', '.fastdata', '.data', '.bss', '.noin
 
 def size_action(target, source, env):
 	cmd = [env['SIZE'], '-A', str(source[0])]
-	
+
 	# Run the default nm command (`arm-none-eabi-nm` in this case)
 	p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 	stdout, stderr = p.communicate()
-	
+
 	if stderr is not None:
 		env.Error("Error while running %s" % ' '.join(cmd))
 		Exit(1)
-	
+
 	flashSize = 0
 	ramSize = 0
 	flashSections = {}
@@ -83,18 +83,18 @@ def size_action(target, source, env):
 			if section in ramSectionNames:
 				ramSize += int(match.group('size'))
 				ramSections[section] = 1
-	
+
 	# create lists of the used sections for Flash and RAM
 	flashSections = flashSections.keys()
 	flashSections.sort()
 	ramSections = ramSections.keys()
 	ramSections.sort()
-	
+
 	flashPercentage = flashSize / float(env['DEVICE_SIZE']['flash']) * 100.0
 	ramPercentage = ramSize / float(env['DEVICE_SIZE']['ram']) * 100.0
-	
+
 	device = env['ARM_DEVICE']
-	
+
 	print """Memory Usage
 ------------
 Device: %s
@@ -111,7 +111,7 @@ Data:    %7d bytes (%2.1f%% Full)
 def show_size(env, source, alias='__size'):
 	if env['ARCHITECTURE'] == 'avr8':
 		# use the raw output of the size tool
-		action = Action("$SIZE %s" % source[0].path, 
+		action = Action("$SIZE %s" % source[0].path,
 					cmdstr="$SIZECOMSTR")
 	else:
 		action = Action(size_action, cmdstr="$SIZECOMSTR")
@@ -119,7 +119,7 @@ def show_size(env, source, alias='__size'):
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 def list_symbols(env, source, alias='__symbols'):
-	action = Action("$NM %s -S -C --size-sort -td" % source[0].path, 
+	action = Action("$NM %s -S -C --size-sort -td" % source[0].path,
 					cmdstr="$SYMBOLSCOMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
@@ -135,10 +135,10 @@ def generate(env, **kw):
 	if ARGUMENTS.get('verbose') != '1':
 		env['SIZECOMSTR'] = "Size after:"
 		env['SYMBOLSCOMSTR'] = "Show symbols for '$SOURCE':"
-	
+
 	env.AddMethod(show_size, 'Size')
 	env.AddMethod(list_symbols, 'Symbols')
-	
+
 	env.AddMethod(run_program, 'Run')
 	env.AddMethod(phony_target, 'Phony')
 

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_r_v_z-b_c_d_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_r_v_z-b_c_d_e.xml
@@ -9,9 +9,9 @@
     <flash device-size-id="c">262144</flash>
     <flash device-size-id="d">393216</flash>
     <flash device-size-id="e">524288</flash>
-    <ram device-size-id="b">32768</ram>
-    <ram device-size-id="c">40960</ram>
-    <ram device-size-id="d|e" device-pin-id="r|v|z">65536</ram>
+    <ram device-size-id="b">40960</ram>
+    <ram device-size-id="c">49152</ram>
+    <ram device-size-id="d|e">81920</ram>
     <linkerscript device-size-id="b">stm32f3xx_b.ld</linkerscript>
     <linkerscript device-size-id="c">stm32f3xx_c.ld</linkerscript>
     <core>cortex-m4f</core>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
@@ -7,7 +7,7 @@
   <device platform="stm32" family="f4" name="405|407|415|417" pin_id="i|o|r|v|z" size_id="e|g">
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
-    <ram>131072</ram>
+    <ram>196608</ram>
     <core>cortex-m4f</core>
     <linkerscript device-size-id="e">stm32f4xx_e.ld</linkerscript>
     <linkerscript device-size-id="g">stm32f4xx_g.ld</linkerscript>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
@@ -8,7 +8,7 @@
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
     <flash device-size-id="i">2097152</flash>
-    <ram>196608</ram>
+    <ram>262144</ram>
     <core>cortex-m4f</core>
     <linkerscript device-size-id="i">stm32f4xx_i.ld</linkerscript>
     <pin-count device-pin-id="v">100</pin-count>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
@@ -8,7 +8,7 @@
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
     <flash device-size-id="i">2097152</flash>
-    <ram>327680</ram>
+    <ram>393216</ram>
     <core>cortex-m4f</core>
 	<linkerscript device-size-id="i">stm32f46x_i.ld</linkerscript>
     <pin-count device-pin-id="a">169</pin-count>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
@@ -7,7 +7,7 @@
   <device platform="stm32" family="f7" name="745|746|756" pin_id="b|i|n|v|z" size_id="e|g">
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
-    <ram>327680</ram>
+    <ram>409600</ram>
     <core>cortex-m7f</core>
     <linkerscript device-size-id="g">stm32f7xx_g.ld</linkerscript>
     <pin-count device-pin-id="v">100</pin-count>
@@ -21,12 +21,12 @@
     <define device-name="746">STM32F746xx</define>
     <define device-name="756" device-size-id="g">STM32F756xx</define>
     <driver type="core" name="cortex">
-      <section access="rwx" start="0x200000" name="itcm" size="16"/>
-      <section device-size-id="g" access="rx" start="0x8000000" name="flash" size="1024"/>
-      <section device-size-id="e" access="rx" start="0x8000000" name="flash" size="512"/>
-      <section access="rwx" start="0x20000000" name="dtcm" size="64"/>
-      <section access="rwx" start="0x20010000" name="sram1" size="240"/>
-      <section access="rwx" start="0x2004C000" name="sram2" size="16"/>
+      <memory access="rwx" start="0x00" name="itcm" size="16"/>
+      <memory device-size-id="e" access="rx" start="0x8000000" name="flash" size="512"/>
+      <memory device-size-id="g" access="rx" start="0x8000000" name="flash" size="1024"/>
+      <memory access="rwx" start="0x20000000" name="dtcm" size="64"/>
+      <memory access="rwx" start="0x20010000" name="sram1" size="240"/>
+      <memory access="rwx" start="0x2004C000" name="sram2" size="16"/>
       <vector position="0" name="WWDG"/>
       <vector position="1" name="PVD"/>
       <vector position="2" name="TAMP_STAMP"/>

--- a/src/xpcc/architecture/platform/linker/stm32/stm32_dccm.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32_dccm.ld
@@ -8,38 +8,37 @@
  * Any symbols defined in the Linker Script are automatically global and
  * available to the rest of the program.
  *
- * Example for STM32F427: (SRAM3 not available on F40* / F41* devices!
+ * Example for STM32F427:
  *
  *                          MEMORY MAP (RAM)
  *
  * Auxiliary internal SRAM3 (64 kB):
  *   only accessible by CPU via S-Bus (less efficient than I-Bus), otherwise fully DMA capable
- *                |                                 | 0x2003 0000 <---- __ram_end, __heap_end
- *                |---------------------------------| 0x2002 FFFF
- *                |                                 |
- *                |                                 |
- *                |                                 |
- *                |---------------------------------| 0x2002 0000
+ *                |                                 | 0x2003 0000 <---- __ram_end, __heap3_end, __heap_end
+ *      +-------> |---------------------------------| 0x2002 FFFF
+ *      |         |                                 |
+ *   .heap3       |         not available on        |
+ *      |         |        F40./F41. devices!       |
+ *      +-------> |---------------------------------| 0x2002 0000 <--- __heap3_start
  *
  * Auxiliary internal SRAM2 (16 kB):
  *   only accessible by CPU via S-Bus (less efficient than I-Bus), otherwise fully DMA capable
- *                |                                 | 0x2002 0000 <---- __ram_end, __heap_end
- *                |---------------------------------| 0x2001 FFFF       (F40* / F41* devices)
- *                |                                 |
- *                |                                 |
- *                |                                 |
- *                |---------------------------------| 0x2001 C000
+ *                |                                 | 0x2002 0000 <---- (__ram_end, __heap_end), __heap2_end
+ *      +-------> |---------------------------------| 0x2001 FFFF
+ *      |         |                                 |
+ *   .heap2       |                                 |
+ *      |         |                                 |
+ *      +-------> |---------------------------------| 0x2001 C000 <--- __heap2_start
  *
  *
  * Main internal SRAM1 (112 kB):
- *                |                                 | 0x2001 C000
- *                |---------------------------------| 0x2001 BFFF
- *                |                                 |
- *                |               ^                 |
- *                |               |                 |
- *                |            Heap Area            |
- *                |         (grows upwards)         |
- *                |                                 | <------- __heap_start
+ *                |                                 | 0x2001 C000 <---- __heap1_end
+ *      +-------> |---------------------------------| 0x2001 BFFF
+ *      |         |                                 |
+ *      |         |               ^                 |
+ *   .heap1       |               |                 |
+ *      |         |            Heap Area            |
+ *      |         |         (grows upwards)         | <------- __heap1_start, __heap_start
  *      +-------> |---------------------------------| <------- __noinit_end
  *      |         |                                 |
  *   .noinit      |     Global data not cleared     |
@@ -63,32 +62,33 @@
  *
  * CCM (Core Coupled memory) (64 kB):
  *   only accessible by the CPU (no DMA) via D-Bus, not I-Bus!
- *                |                                 | 0x1001 0000
- *                |---------------------------------| 0x1000 FFFF
- *                |           Unused RAM            |
- *                |    (perhaps usable for heap?)   |
+ *                |                                 | 0x1001 0000 <---- __heap0_end
+ *      +-------> |---------------------------------| 0x1000 FFFF
+ *      |         |                                 |
+ *   .heap0       |           Unused RAM            |
+ *      |         |                                 | <------- __heap0_start
  *      +-------> |---------------------------------| <------- __fastdata_end
  *      |         |                                 |
  *  .fastdata     |     initialized variables       |
  *      |         |                                 | <------- __fastdata_start
  *      +-------> |---------------------------------| <------- __process_stack_top, __stack_end
- *                |       Process Stack (psp)       |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 |
- *                |---------------------------------| <------- __main_stack_top
- *                |        Main Stack (msp)         |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 | <------- __stack_start
- *                |---------------------------------| 0x1000 0000
+ *      |         |       Process Stack (psp)       |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 |
+ *   .stack       |---------------------------------| <------- __main_stack_top
+ *      |         |        Main Stack (msp)         |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 | <------- __stack_start
+ *      +-------> |---------------------------------| 0x1000 0000
  *
  *
  *                          MEMORY MAP (Flash)
  *
+ *                |                                 | 0x0802 0000 <--- __rom_end
+ *                |---------------------------------| 0x0801 FFFF
  *                |                                 |
- *                |---------------------------------| 0x0802 0000
- *                |                                 | 0x0801 FFFF
  *                |                                 |
  *                |                                 |
  *                |          Unused flash           |
@@ -117,9 +117,9 @@
  *      |         |         into CCM RAM            | <------- __fastdata_load
  *      +-------> |---------------------------------|
  *      |         |                                 |
- *   .reset       |    Interrupt Vectors (in ROM)   | <------- __vector_table_ram_load
- *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start
- *      +-------> |---------------------------------| 0x0800 0000
+ *   .reset       |    Interrupt Vectors (in ROM)   |
+ *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start, __vector_table_ram_load
+ *      +-------> |---------------------------------| 0x0800 0000 <--- __rom_start
  *
  * The first two words (32-bit) in the Flash defines the initial stack pointer
  * location and the reset handler location.
@@ -137,7 +137,8 @@ EXTERN(_init)
 
 PROVIDE(__ram_start = ORIGIN(RAM));
 PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
-PROVIDE(__heap_end  = ORIGIN(RAM) + LENGTH(RAM));
+PROVIDE(__rom_start = ORIGIN(ROM));
+PROVIDE(__rom_end   = ORIGIN(ROM) + LENGTH(ROM));
 
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
 PROCESS_STACK_SIZE  = DEFINED(__process_stack_size) ? (__process_stack_size & ~0x7) : 256;
@@ -193,6 +194,17 @@ SECTIONS
 		. = ALIGN(4);
 		__fastdata_end = .;
 	} >CCM AT>ROM
+
+	/* This is currently not used by the heap allocator!
+	.heap0 (NOLOAD) :
+	{
+		. = ALIGN(4);
+		__heap0_start = .;
+
+		. = ORIGIN(CCM) + LENGTH(CCM);
+		__heap0_end = .;
+	} >CCM
+	*/
 
 	.text :
 	{
@@ -376,8 +388,37 @@ SECTIONS
 
 		. = ALIGN (4);
 		PROVIDE (__noinit_end = .);
-		. = ALIGN (4);
+	} >RAM
+
+	.heap1 (NOLOAD) :
+	{
+		. = ALIGN(4);
 		PROVIDE (__heap_start = .);
+		__heap1_start = .;
+
+		. = ORIGIN(SRAM1) + LENGTH(SRAM1);
+		__heap1_end = .;
+	} >RAM
+
+	.heap2 (NOLOAD) :
+	{
+		. = ORIGIN(SRAM2);
+		__heap2_start = .;
+
+		. = ORIGIN(SRAM2) + LENGTH(SRAM2);
+		__heap2_end = .;
+	} >RAM
+
+	/* The section length is zero if SRAM3 is not available
+	 * on this device. Ideally, the section would not exist.
+	 */
+	.heap3 (NOLOAD) :
+	{
+		__heap3_start = .;
+
+		. = ORIGIN(RAM) + LENGTH(RAM);
+		__heap3_end = .;
+		PROVIDE (__heap_end = .);
 	} >RAM
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/linker/stm32/stm32_iccm.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32_iccm.ld
@@ -14,15 +14,13 @@
  *
  *
  * Main internal SRAM1 (up to 40 kB):
- *                |                                 | 0x2001 C000 <--- __handler_stack_top, __stack_end
- *                |---------------------------------| 0x2001 BFFF
- *                |           Unused RAM            |
- *                |     (overwritten by heap!)      |
- *                |---------------------------------|
- *                |               ^                 |
- *                |               |                 |
- *                |            Heap Area            |
- *                |         (grows upwards)         | <------- __heap_start
+ *                |                                 | 0x2001 C000 <---- __ram_end, __heap1_end, __heap_end
+ *      +-------> |---------------------------------| 0x2001 BFFF
+ *      |         |                                 |
+ *      |         |               ^                 |
+ *   .heap1       |               |                 |
+ *      |         |            Heap Area            |
+ *      |         |         (grows upwards)         | <------- __heap1_start, __heap_start
  *      +-------> |---------------------------------| <------- __noinit_end
  *      |         |                                 |
  *   .noinit      |     Global data not cleared     |
@@ -38,23 +36,25 @@
  *      |         |                                 |
  *      |         |                                 |
  *      +-------> |---------------------------------| <------- __process_stack_top, __stack_end, __data_start
- *                |       Process Stack (psp)       |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 |
- *                |---------------------------------| <------- __main_stack_top
- *                |        Main Stack (msp)         |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 | <------- __stack_start
- *                |---------------------------------| 0x2000 0000 <--- __ram_start
+ *      |         |       Process Stack (psp)       |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 |
+ *   .stack       |---------------------------------| <------- __main_stack_top
+ *      |         |        Main Stack (msp)         |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 | <------- __stack_start
+ *      +-------> |---------------------------------| 0x2000 0000 <--- __ram_start
  *
  *
  * CCM (Core Coupled memory) (up to 16 kB):
  *   only accessible by the CPU (no DMA etc.) via D-Bus _and_ I-Bus!
- *                |                                 | 0x1000 4000
- *                |---------------------------------| 0x1000 3FFF
- *                |           Unused RAM            |
+ *                |                                 | 0x1000 4000 <---- __heap4_end
+ *      +-------> |---------------------------------| 0x1000 3FFF
+ *      |         |                                 |
+ *   .heap4       |           Unused RAM            |
+ *      |         |                                 | <------- __heap4_start
  *      +-------> |---------------------------------| <------- __fastdata_end
  *      |         |                                 |
  *  .fastdata     |     initialized variables       |
@@ -72,9 +72,9 @@
  *
  *                         MEMORY MAP (Flash)
  *
+ *                |                                 | 0x0802 0000 <--- __rom_end
+ *                |---------------------------------| 0x0801 FFFF
  *                |                                 |
- *                |---------------------------------| 0x0802 0000
- *                |                                 | 0x0801 FFFF
  *                |                                 |
  *                |                                 |
  *                |          Unused flash           |
@@ -107,9 +107,9 @@
  *      |         |         into CCM RAM            | <------- __fastcode_load
  *      +-------> |---------------------------------|
  *      |         |                                 |
- *   .reset       |    Interrupt Vectors (in ROM)   | <------- __vector_table_ram_load
- *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start
- *      +-------> |---------------------------------| 0x0800 0000
+ *   .reset       |    Interrupt Vectors (in ROM)   |
+ *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start, __vector_table_ram_load
+ *      +-------> |---------------------------------| 0x0800 0000 <--- __rom_start
  *
  * The first two words (32-bit) in the Flash defines the initial stack pointer
  * location and the reset handler location.
@@ -127,7 +127,8 @@ EXTERN(_init)
 
 PROVIDE(__ram_start = ORIGIN(RAM));
 PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
-PROVIDE(__heap_end  = ORIGIN(RAM) + LENGTH(RAM));
+PROVIDE(__rom_start = ORIGIN(ROM));
+PROVIDE(__rom_end   = ORIGIN(ROM) + LENGTH(ROM));
 
 /* Used for interrupt handlers */
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
@@ -180,6 +181,17 @@ SECTIONS
 		. = ALIGN(4);
 		__fastdata_end = .;
 	} >CCM AT>ROM
+
+	/* This is currently not used by the heap allocator!
+	.heap4 (NOLOAD) :
+	{
+		. = ALIGN(4);
+		__heap4_start = .;
+
+		. = ORIGIN(CCM) + LENGTH(CCM);
+		__heap4_end = .;
+	} >CCM
+	*/
 
 	.text :
 	{
@@ -352,8 +364,17 @@ SECTIONS
 
 		. = ALIGN (4);
 		PROVIDE (__noinit_end = .);
-		. = ALIGN (4);
+	} >RAM
+
+	.heap1 (NOLOAD) :
+	{
+		. = ALIGN(4);
 		PROVIDE (__heap_start = .);
+		__heap1_start = .;
+
+		. = ORIGIN(RAM) + LENGTH(RAM);
+		__heap1_end = .;
+		PROVIDE (__heap_end = .);
 	} >RAM
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/linker/stm32/stm32_idtcm.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32_idtcm.ld
@@ -14,23 +14,22 @@
  *
  * Auxiliary internal SRAM2 (16 kB):
  *   only accessible by CPU via S-Bus (less efficient than I-Bus), otherwise fully DMA capable
- *                |                                 | 0x2005 0000 <---- __ram_end, __heap_ends
- *                |---------------------------------| 0x2004 FFFF
- *                |                                 |
- *                |                                 |
- *                |                                 |
- *                |---------------------------------| 0x2004 C000
+ *                |                                 | 0x2005 0000 <---- __ram_end, __heap2_end, __heap_end
+ *      +-------> |---------------------------------| 0x2004 FFFF
+ *      |         |                                 |
+ *    heap2       |                                 |
+ *      |         |                                 |
+ *      +-------> |---------------------------------| 0x2004 C000 <--- __heap2_start
  *
  *
  * Main internal SRAM1 (240 kB):
  *                |                                 | 0x2004 C000
- *                |---------------------------------| 0x2004 BFFF
- *                |                                 |
- *                |               ^                 |
- *                |               |                 |
- *                |            Heap Area            |
- *                |         (grows upwards)         |
- *                |                                 | <------- __heap_start
+ *      +-------> |---------------------------------| 0x2004 BFFF
+ *      |         |                                 |
+ *      |         |               ^                 |
+ *   .heap1       |               |                 |
+ *      |         |            Heap Area            |
+ *      |         |         (grows upwards)         | <------- __heap1_start, __heap_start
  *      +-------> |---------------------------------| <------- __noinit_end
  *      |         |                                 |
  *   .noinit      |     Global data not cleared     |
@@ -50,32 +49,33 @@
  *
  * DTCM (Data Tightly Coupled memory) (64 kB):
  *   accessible by DMA and the CPU via D-Bus, not I-Bus!
- *                |                                 | 0x2001 0000
- *                |---------------------------------| 0x2000 FFFF
- *                |           Unused RAM            |
- *                |    (perhaps usable for heap?)   |
+ *                |                                 | 0x2001 0000 <---- __heap0_end
+ *      +-------> |---------------------------------| 0x2000 FFFF
+ *      |         |                                 |
+ *   .heap0       |           Unused RAM            |
+ *      |         |                                 | <------- __heap0_start
  *      +-------> |---------------------------------| <------- __fastdata_end
  *      |         |                                 |
  *  .fastdata     |     initialized variables       |
  *      |         |                                 | <------- __fastdata_start
  *      +-------> |---------------------------------| <------- __process_stack_top, __stack_end
- *                |       Process Stack (psp)       |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 |
- *                |---------------------------------| <------- __main_stack_top
- *                |        Main Stack (msp)         |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 | <------- __stack_start
- *                |---------------------------------| 0x2000 0000
+ *      |         |       Process Stack (psp)       |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 |
+ *   .stack       |---------------------------------| <------- __main_stack_top
+ *      |         |        Main Stack (msp)         |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 | <------- __stack_start
+ *      +-------> |---------------------------------| 0x2000 0000
  *
  *
  *                          MEMORY MAP (Flash)
  *
+ *                |                                 | 0x0802 0000 <--- __rom_end
+ *                |---------------------------------| 0x0801 FFFF
  *                |                                 |
- *                |---------------------------------| 0x0802 0000
- *                |                                 | 0x0801 FFFF
  *                |                                 |
  *                |                                 |
  *                |          Unused flash           |
@@ -108,15 +108,17 @@
  *      |         |         into ITCM RAM           | <------- __fastcode_load
  *      +-------> |---------------------------------|
  *      |         |                                 |
- *   .reset       |    Interrupt Vectors (in ROM)   | <------- __vector_table_ram_load
- *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start
- *      +-------> |---------------------------------| 0x0800 0000
+ *   .reset       |    Interrupt Vectors (in ROM)   |
+ *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start, __vector_table_ram_load
+ *      +-------> |---------------------------------| 0x0800 0000 <--- __rom_start
  *
  * ITCM (Instruction Tightly Coupled Memory) (16 kB):
  *   only accessible by the CPU (no DMA etc.) via I-Bus!
- *                |                                 | 0x0000 4000
- *                |---------------------------------| 0x0000 3FFF
- *                |           Unused RAM            |
+ *                |                                 | 0x0000 4000 <---- __heap4_end
+ *      +-------> |---------------------------------| 0x0000 3FFF
+ *      |         |                                 |
+ *   .heap4       |           Unused RAM            |
+ *      |         |                                 | <------- __heap4_start
  *      +-------> |---------------------------------| <------- __fastcode_end
  *      |         |                                 |
  *  .fastcode     |     C/C++-Functions in RAM      |
@@ -143,7 +145,8 @@ EXTERN(_init)
 
 PROVIDE(__ram_start = ORIGIN(RAM));
 PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
-PROVIDE(__heap_end  = ORIGIN(RAM) + LENGTH(RAM));
+PROVIDE(__rom_start = ORIGIN(ROM));
+PROVIDE(__rom_end   = ORIGIN(ROM) + LENGTH(ROM));
 
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
 PROCESS_STACK_SIZE  = DEFINED(__process_stack_size) ? (__process_stack_size & ~0x7) : 256;
@@ -185,6 +188,17 @@ SECTIONS
 		__fastcode_end = .;
 	} >ITCM AT>ROM
 
+	/* This is currently not used by the heap allocator!
+	.heap4 (NOLOAD) :
+	{
+		. = ALIGN(4);
+		__heap4_start = .;
+
+		. = ORIGIN(ITCM) + LENGTH(ITCM);
+		__heap4_end = .;
+	} >ITCM
+	*/
+
 	.stack (NOLOAD) :
 	{
 		__stack_start = . ;
@@ -210,6 +224,17 @@ SECTIONS
 		. = ALIGN(4);
 		__fastdata_end = .;
 	} >DTCM AT>ROM
+
+	/* This is currently not used by the heap allocator!
+	.heap0 (NOLOAD) :
+	{
+		. = ALIGN(4);
+		__heap0_start = .;
+
+		. = ORIGIN(DTCM) + LENGTH(DTCM);
+		__heap0_end = .;
+	} >DTCM
+	*/
 
 	.text :
 	{
@@ -367,8 +392,26 @@ SECTIONS
 
 		. = ALIGN (4);
 		PROVIDE (__noinit_end = .);
-		. = ALIGN (4);
+	} >RAM
+
+	.heap1 (NOLOAD) :
+	{
+		. = ALIGN(4);
 		PROVIDE (__heap_start = .);
+		__heap1_start = .;
+
+		. = ORIGIN(SRAM1) + LENGTH(SRAM1);
+		__heap1_end = .;
+	} >RAM
+
+	.heap2 (NOLOAD) :
+	{
+		. = ORIGIN(SRAM2);
+		__heap2_start = .;
+
+		. = ORIGIN(SRAM2) + LENGTH(SRAM2);
+		__heap2_end = .;
+		PROVIDE (__heap_end = .);
 	} >RAM
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/linker/stm32/stm32_ram.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32_ram.ld
@@ -12,15 +12,13 @@
  *
  *                          MEMORY MAP (RAM)
  *
- *                |                                 | 0x2001 0000
- *                |---------------------------------| 0x2000 FFFF
- *                |           Unused RAM            |
- *                |     (overwritten by heap!)      |
- *                |---------------------------------|
- *                |               ^                 |
- *                |               |                 |
- *                |            Heap Area            |
- *                |         (grows upwards)         | <------- __heap_start
+ *                |                                 | 0x2001 0000 <---- __ram_end, __heap1_end, __heap_end
+ *      +-------> |---------------------------------| 0x2000 FFFF
+ *      |         |                                 |
+ *      |         |               ^                 |
+ *   .heap1       |               |                 |
+ *      |         |            Heap Area            |
+ *      |         |         (grows upwards)         | <------- __heap1_start, __heap_start
  *      +-------> |---------------------------------| <------- __noinit_end
  *      |         |                                 |
  *   .noinit      |     Global data not cleared     |
@@ -40,24 +38,24 @@
  *  .vectors      |    Interrupt Vectors (in RAM)   |
  *      |         |        (if re-mapped)           | <------- __vector_table_ram_start
  *      +-------> |---------------------------------| <------- __process_stack_top, __stack_end
- *                |       Process Stack (psp)       |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 |
- *                |---------------------------------| <------- __main_stack_top
- *                |        Main Stack (msp)         |
- *                |       (grows downwards)         |
- *                |               |                 |
- *                |               v                 | <------- __stack_start
- *                |---------------------------------|
- *                |  Alignment buffer for .vectors  |
- *                |     (overwritten by stack!)     |
- *                |---------------------------------| 0x2000 0000 <--- __ram_start
+ *      |         |       Process Stack (psp)       |
+ *      |         |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 |
+ *      |         |---------------------------------| <------- __main_stack_top
+ *      |         |        Main Stack (msp)         |
+ *   .stack       |       (grows downwards)         |
+ *      |         |               |                 |
+ *      |         |               v                 |
+ *      |         |---------------------------------|
+ *      |         |  Alignment buffer for .vectors  |
+ *      |         |   (overwritten by main stack!)  | <------- __stack_start
+ *      +-------> |---------------------------------| 0x2000 0000 <--- __ram_start
  *
  *
  *                          MEMORY MAP (Flash)
  *
- *                |                                 | 0x0802 0000
+ *                |                                 | 0x0802 0000 <--- __rom_end
  *                |---------------------------------| 0x0801 FFFF
  *                |                                 |
  *                |                                 |
@@ -84,9 +82,9 @@
  *      |         |                                 | <------- __fastcode_load, __fastcode_start, __fastcode_end
  *      +-------> |---------------------------------|
  *      |         |                                 |
- *   .reset       |    Interrupt Vectors (in ROM)   | <------- __vector_table_ram_load
- *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start
- *      +-------> |---------------------------------| 0x0800 0000
+ *   .reset       |    Interrupt Vectors (in ROM)   |
+ *      |         |       (copy of .vectors)        | <------- __vector_table_rom_start, __vector_table_ram_load
+ *      +-------> |---------------------------------| 0x0800 0000 <--- __rom_start
  *
  * The first two words (32-bit) in the Flash defines the initial stack pointer
  * location and the reset handler location.
@@ -104,7 +102,8 @@ EXTERN(_init)
 
 PROVIDE(__ram_start = ORIGIN(RAM));
 PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
-PROVIDE(__heap_end  = ORIGIN(RAM) + LENGTH(RAM));
+PROVIDE(__rom_start = ORIGIN(ROM));
+PROVIDE(__rom_end   = ORIGIN(ROM) + LENGTH(ROM));
 
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
 PROCESS_STACK_SIZE  = DEFINED(__process_stack_size) ? (__process_stack_size & ~0x7) : 192;
@@ -355,8 +354,17 @@ SECTIONS
 
 		. = ALIGN (4);
 		PROVIDE (__noinit_end = .);
-		. = ALIGN (4);
+	} >RAM
+
+	.heap1 (NOLOAD) :
+	{
+		. = ALIGN(4);
 		PROVIDE (__heap_start = .);
+		__heap1_start = .;
+
+		. = ORIGIN(RAM) + LENGTH(RAM);
+		__heap1_end = .;
+		PROVIDE (__heap_end = .);
 	} >RAM
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f46x_i.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f46x_i.ld
@@ -5,8 +5,8 @@ MEMORY
 	RAM (rwx)   : ORIGIN = 0x20000000, LENGTH = 160k + 32k + 128k	/* Entire continuous RAM section */
 
 	SRAM1 (rwx) : ORIGIN = 0x20000000, LENGTH = 160k		/* Main internal SRAM1 */
-	SRAM2 (rwx) : ORIGIN = 0x2001C000, LENGTH = 32k			/* Auxiliary internal SRAM2 */
-	SRAM3 (rwx) : ORIGIN = 0x20200000, LENGTH = 128k		/* Auxiliary internal SRAM3 */
+	SRAM2 (rwx) : ORIGIN = 0x20028000, LENGTH = 32k			/* Auxiliary internal SRAM2 */
+	SRAM3 (rwx) : ORIGIN = 0x20030000, LENGTH = 128k		/* Auxiliary internal SRAM3 */
 	CCM (rw)    : ORIGIN = 0x10000000, LENGTH = 64k			/* Core Coupled Memory */
 }
 

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f4xx_g.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f4xx_g.ld
@@ -1,7 +1,7 @@
 
 MEMORY
 {
-	ROM (rx)      : ORIGIN = 0x08000000, LENGTH = 1m
+	ROM (rx)    : ORIGIN = 0x08000000, LENGTH = 1m
 	RAM (rwx)   : ORIGIN = 0x20000000, LENGTH = 112k + 16k	/* Entire continuous RAM section */
 
 	SRAM1 (rwx) : ORIGIN = 0x20000000, LENGTH = 112k		/* Main internal SRAM1 */

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f4xx_i.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f4xx_i.ld
@@ -6,7 +6,7 @@ MEMORY
 
 	SRAM1 (rwx) : ORIGIN = 0x20000000, LENGTH = 112k		/* Main internal SRAM1 */
 	SRAM2 (rwx) : ORIGIN = 0x2001C000, LENGTH = 16k			/* Auxiliary internal SRAM2 */
-	SRAM3 (rwx) : ORIGIN = 0x20200000, LENGTH = 64k			/* Auxiliary internal SRAM3 */
+	SRAM3 (rwx) : ORIGIN = 0x20020000, LENGTH = 64k			/* Auxiliary internal SRAM3 */
 	CCM (rw)    : ORIGIN = 0x10000000, LENGTH = 64k			/* Core Coupled Memory */
 }
 

--- a/tools/device_file_generator/stm.py
+++ b/tools/device_file_generator/stm.py
@@ -210,7 +210,7 @@ stm32_memory = \
 		'start': {
 			'flash': 0x08000000,
 			'dtcm': 0x20000000,
-			'itcm': 0x00200000,
+			'itcm': 0x00000000,
 			'sram': 0x20010000
 		},
 		'model': [

--- a/tools/device_file_generator/stm_reader.py
+++ b/tools/device_file_generator/stm_reader.py
@@ -106,9 +106,14 @@ class STMDeviceReader(XMLDeviceReader):
 		if mem_model == None:
 			self.log.error("STMDeviceReader: Memory model not found for device '{}'".format(self.id.string))
 
-		ram = int(rams[sizeIndexRam].text) + mem_model['memories']['sram1']
+		total_ram = ram = int(rams[sizeIndexRam].text) + mem_model['memories']['sram1']
 		flash = int(flashs[sizeIndexFlash].text) + mem_model['memories']['flash']
-		self.addProperty('ram', ram * 1024)
+		if 'ccm' in mem_model['memories']:
+			total_ram += mem_model['memories']['ccm']
+		if 'itcm' in mem_model['memories']:
+			total_ram += mem_model['memories']['itcm']
+			total_ram += mem_model['memories']['dtcm']
+		self.addProperty('ram', total_ram * 1024)
 		self.addProperty('flash', flash * 1024)
 
 		memories = []


### PR DESCRIPTION
Since the stack memory usage is now bound we can:
1. clarify the `.stack` section memory usage to make it clearer how much static memory is used.
2. accurately calculate the available heap size, since the stack now has a fixed size.
3. remove  `.vectors` from the flash sections, since it is now completely overlaid on the `.reset` section.

This PR adds heap section information and improves the memory usage printout.
It also corrects a mistake in the Device Files, where the CCM size was not part of the top-level `ram` tag and therefore the usage of RAM in percent was higher than actual.
### Memory usage printout

```
Device: stm32f407vg

Program:    2400 bytes (0.2% Full)
(.data + .fastdata + .reset + .rodata + .text + .vectors)

Data:       3740 bytes (2.9% Full)
(.bss + .data + .fastdata + .noinit + .stack + .vectors)
```

The new printout is much more verbose and accurate:

```
Device: stm32f407vg

Program:    2012 bytes (0.2% used)
(.data + .fastdata + .reset + .rodata + .text)

Data:       3740 bytes (1.9% used) = 412 bytes static (0.2%) + 3328 bytes stack (1.7%)
(.bss + .data + .fastdata + .noinit + .stack + .vectors)

Heap:     130668 bytes (66.5% available)
(.heap1 + .heap2 + .heap3)
```

(Note: the 412 bytes static usage are actually only 8 bytes + vector table in RAM).
### Heap sections

Five new memory sections are added to the linker scripts:
- `.heap0` is free memory in non-executable CCM (F4) or DTCM (F7)
- `.heap1` is free memory in SRAM1 (all STM32)
- `.heap2` is free memory in SRAM2 (F3, F4, F7)
- `.heap3` is free memory in SRAM3 (F4)
- `.heap4` is free memory in executable CCM (F3) or ITCM (F7)

Note that Heap and Data usage do not always add up to 100% RAM, because heap allocation currently can only allocate within one continous memory section (`.heap1` to `.heap2` or `.heap3`), and therefore cannot make use of the free memory in .heap0 (CCM) and .heap4 (ITCM).
This would require an allocator with support for multiple traits (DMA-able, fast access, etc.) and multiple non-continous sections.
