### PR TITLE
[io] IOStream: printf: Fix the position of the minus sign.

### DIFF
--- a/examples/linux/printf/SConstruct
+++ b/examples/linux/printf/SConstruct
@@ -1,0 +1,33 @@
+# path to the xpcc root directory
+rootpath = '../../..'
+
+env = Environment(tools = ['xpcc'], toolpath = [rootpath + '/scons/site_tools'])
+
+# find all source files
+files = env.FindFiles('.')
+
+# build the program
+program = env.Program(target = env['XPCC_CONFIG']['general']['name'], source = files.sources)
+
+# build the xpcc library
+env.XpccLibrary()
+
+# build xpcc_git_info.hpp and xpcc_build_info.hpp file
+env.GitInfoHeader()
+env.BuildInfoHeader()
+
+# build xpcc_build_info.hpp file
+env.BuildInfoHeader()
+
+# create a file called 'defines.hpp' with all preprocessor defines if necessary
+env.Defines()
+
+env.Alias('size', env.Size(program))
+env.Alias('symbols', env.Symbols(program))
+env.Alias('defines', env.ShowDefines())
+
+env.Alias('build', program)
+env.Alias('run', env.Run(program))
+env.Alias('all', ['build', 'run'])
+
+env.Default('all')

--- a/examples/linux/printf/main.cpp
+++ b/examples/linux/printf/main.cpp
@@ -1,0 +1,35 @@
+#include <xpcc/architecture.hpp>
+#include <xpcc/debug/logger.hpp>
+
+#include <xpcc_build_info.hpp>
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+int
+main()
+{
+	// Let's print some information that is provided in the xpcc_build_info.hpp
+	XPCC_LOG_INFO << "Machine:  " << XPCC_BUILD_MACHINE  << xpcc::endl;
+	XPCC_LOG_INFO << "User:     " << XPCC_BUILD_USER     << xpcc::endl;
+	XPCC_LOG_INFO << "Os:       " << XPCC_BUILD_OS       << xpcc::endl;
+	XPCC_LOG_INFO << "Compiler: " << XPCC_BUILD_COMPILER << xpcc::endl;
+
+	XPCC_LOG_INFO << "Compare xpcc's printf and xpcc with glibc's printf" << xpcc::endl;
+
+	int32_t ii = -42;
+
+	char format_string[] = ">>%5d<<";
+
+	XPCC_LOG_INFO << "xpcc  ";
+	XPCC_LOG_INFO.printf(format_string, ii);
+	XPCC_LOG_INFO << xpcc::endl;
+
+	char buf[32] = {' '};
+	sprintf(buf, format_string, ii);
+	XPCC_LOG_INFO.printf("glibc %s", buf);
+	XPCC_LOG_INFO << xpcc::endl;
+
+	return 0;
+}

--- a/examples/linux/printf/project.cfg
+++ b/examples/linux/printf/project.cfg
@@ -1,0 +1,6 @@
+[general]
+name = printf_hosted
+
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/${name}

--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -487,7 +487,7 @@ protected:
 #endif
 
 	void
-	writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill);
+	writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill, bool isNegative);
 
 private:
 	enum class

--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -487,6 +487,10 @@ protected :
 #endif
 
 private :
+	void
+	writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill);
+
+private:
 	enum class
 	Mode
 	{

--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -33,7 +33,7 @@ namespace xpcc
  */
 class IOStream
 {
-public :
+public:
 	/**
 	 * @param	device	device to write the stream to
 	 *
@@ -444,7 +444,7 @@ public :
 	IOStream&
 	vprintf(const char *fmt, va_list vlist);
 
-protected :
+protected:
 	void
 	writeInteger(int16_t value);
 
@@ -486,7 +486,6 @@ protected :
 	writeDouble(const double& value);
 #endif
 
-private :
 	void
 	writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill);
 

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -137,40 +137,46 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 				unsignedValue = (unsigned long) signedValue;
 			}
 
-			{
-				char scratch[26];
-
-				ptr = scratch + sizeof(scratch);
-				*--ptr = 0;
-				do
-				{
-					char ch = (unsignedValue % base) + '0';
-
-					if (ch > '9') {
-						ch += 'A' - '9' - 1;
-					}
-
-					*--ptr = ch;
-					unsignedValue /= base;
-
-					if (width) {
-						--width;
-					}
-				} while (unsignedValue);
-
-				// insert padding chars
-				while (width--) {
-					*--ptr = fill;
-				}
-
-				// output result
-				while ((c = *ptr++)) {
-					this->device->write(c);
-				}
-			}
+			writeUnsignedInteger(unsignedValue, base, width, fill);
 		}
 	}
 
 	return *this;
 }
 
+void
+xpcc::IOStream::writeUnsignedInteger(
+	unsigned long unsignedValue, uint_fast8_t base,
+	size_t width, char fill)
+{
+	char scratch[26];
+
+	char *ptr = scratch + sizeof(scratch);
+	*--ptr = 0;
+	do
+	{
+		char ch = (unsignedValue % base) + '0';
+
+		if (ch > '9') {
+			ch += 'A' - '9' - 1;
+		}
+
+		*--ptr = ch;
+		unsignedValue /= base;
+
+		if (width) {
+			--width;
+		}
+	} while (unsignedValue);
+
+	// insert padding chars
+	while (width--) {
+		*--ptr = fill;
+	}
+
+	// output result
+	char ch;
+	while ((ch = *ptr++)) {
+		this->device->write(ch);
+	}
+}

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -36,6 +36,7 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 		bool isSigned = false;
 		bool isLong = false;
 		bool isLongLong = false;
+		bool isNegative = false;
 
 		if (c != '%')
 		{
@@ -127,17 +128,14 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 				{
 					if (signedValue < 0)
 					{
+						isNegative = true;
 						signedValue = -signedValue; // make it positive
-						this->device->write('-');
-						if (width) {
-							--width;
-						}
 					}
 				}
 				unsignedValue = (unsigned long) signedValue;
 			}
 
-			writeUnsignedInteger(unsignedValue, base, width, fill);
+			writeUnsignedInteger(unsignedValue, base, width, fill, isNegative);
 		}
 	}
 
@@ -147,7 +145,7 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 void
 xpcc::IOStream::writeUnsignedInteger(
 	unsigned long unsignedValue, uint_fast8_t base,
-	size_t width, char fill)
+	size_t width, char fill, bool isNegative)
 {
 	char scratch[26];
 
@@ -168,6 +166,15 @@ xpcc::IOStream::writeUnsignedInteger(
 			--width;
 		}
 	} while (unsignedValue);
+
+	// Insert minus sign if needed
+	if (isNegative)
+	{
+		*--ptr = '-';
+		if (width) {
+			--width;
+		}
+	}
 
 	// insert padding chars
 	while (width--) {

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -33,9 +33,9 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 	// for all chars in format (fmt)
 	while ((c = *fmt++) != 0)
 	{
-		bool isSigned = 0;
-		bool isLong = 0;
-		bool isLongLong = 0;
+		bool isSigned = false;
+		bool isLong = false;
+		bool isLongLong = false;
 
 		if (c != '%')
 		{


### PR DESCRIPTION
In xpcc printf the minus does not touch the number.
glibc's printf does and is (to my experience) the most common behaviour.

Info:    xpcc  >>-  42<<
Info:    glibc >>  -42<<

With this PR xpcc's printf matches the output of glibc's printf:

Info:    xpcc  >>  -42<<
Info:    glibc >>  -42<<

I know that the printf is not the best available printf for STM32 but no-one else implemented a better printf for xpcc yet. 
