### PR TITLE
Debugger-friendly hard fault handler

### DIFF
--- a/examples/stm32f4_discovery/hard_fault/SConstruct
+++ b/examples/stm32f4_discovery/hard_fault/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f4_discovery/hard_fault/main.cpp
+++ b/examples/stm32f4_discovery/hard_fault/main.cpp
@@ -1,0 +1,72 @@
+#include "../stm32f4_discovery.hpp"
+#include <xpcc/debug/logger.hpp>
+
+/* This example showcases the hard fault handler LED blinking and UART logging.
+ * You can trigger the hard fault by pressing the blue button, which will execute an undefined instruction.
+ * The hard fault handler will report failure reason over PA2 @ 115.2kBaud and flash the blue LED.
+ *
+ * Connecting a debugger changes this behavior: the hardfault will now trigger a breakpoint.
+ * This allows normal debugging of the failure reason.
+ * You can try this yourself, open two shell in this folder, then:
+ *  - in one terminal execute `scons openocd-debug`. This starts the openocd server.
+ *  - then execute `scons debug`, which starts the GDB debugger in TUI mode.
+ *  - type `monitor reset halt`, then `c` into GDB to restart the controller.
+ * The red LED should now be on, signaling that the debugger has been recognized.
+ * Pressing the blue button now, will make GDB jump to the breakpoint.
+ *
+ * You need to power cycle the board to reset the debugger recognition.
+ */
+
+
+// ----------------------------------------------------------------------------
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Usart2, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+MAIN_FUNCTION
+{
+	Board::initialize();
+	LedOrange::set();
+
+	// initialize Uart2 for XPCC_LOG_
+	GpioOutputA2::connect(Usart2::Tx);
+	Usart2::initialize<Board::systemClock, 115200>(12);
+
+	XPCC_LOG_INFO << "Press Button to cause a Hardfault!" << xpcc::endl;
+
+	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) {
+		// if this LED is on, the debugger is connected
+		LedRed::set();
+		XPCC_LOG_INFO << "Debugger connected!" << xpcc::endl;
+	}
+
+	while (1)
+	{
+		LedGreen::toggle();
+		LedOrange::toggle();
+
+		if (Button::read()) {
+			// execute undefined instructed
+			// the hard fault handler will blink the blue LED
+			// or, if the debugger is connected, will trigger a breakpoint
+			asm volatile (".short 0xde00");
+		}
+
+		xpcc::delayMilliseconds(500);
+
+	}
+
+	return 0;
+}

--- a/examples/stm32f4_discovery/hard_fault/project.cfg
+++ b/examples/stm32f4_discovery/hard_fault/project.cfg
@@ -1,0 +1,18 @@
+[general]
+name = hard_fault
+
+[build]
+device = stm32f407vg
+clock = 168000000
+buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
+
+[parameters]
+core.cortex.0.enable_hardfault_handler_log = true
+core.cortex.0.hardfault_handler_uart = 2
+
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = D
+core.cortex.0.hardfault_handler_led_pin = 15
+
+[openocd]
+configfile = board/stm32f4discovery.cfg

--- a/scons/site_tools/openocd.py
+++ b/scons/site_tools/openocd.py
@@ -35,9 +35,10 @@ def openocd_run(env, source, alias='openocd_run'):
 	if env['OPENOCD_COMMANDS'] == 'default':
 		env['OPENOCD_COMMANDS'] = """
 			init
-			reset init
+			reset halt
 			flash write_image erase $SOURCE
-			reset run
+			reset halt
+			mww 0xE000EDF0 0xA05F0000
 			shutdown"""
 
 	if platform.system() == "Windows":

--- a/scons/site_tools/openocd_remote.py
+++ b/scons/site_tools/openocd_remote.py
@@ -23,7 +23,7 @@ def openocd_remote_run(env, source, alias='openocd_remote_run'):
 		action = fail
 		return env.AlwaysBuild(env.Alias(alias, source, action))
 	else:
-		commands = ["init", "reset halt", "flash write_image erase /tmp/openocd.hex", "reset run"]
+		commands = ["init", "reset halt", "flash write_image erase /tmp/openocd.hex", "reset halt", "mww 0xE000EDF0 0xA05F0000"]
 		action = Action("scp $SOURCE $OPENOCD_REMOTE_USER@$OPENOCD_REMOTE_HOST:/tmp/openocd.hex; echo %s | nc $OPENOCD_REMOTE_HOST 4444" % ' '.join(['"%s;"' % c for c in commands]),
 			cmdstr="$OPENOCD_COMSTR")
 		return env.AlwaysBuild(env.Alias(alias, source, action))

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -45,6 +45,54 @@
 	.func	HardFault_Handler
 HardFault_Handler:
 
+%% if target is stm32
+	/* When a hard fault occurs, this handler will move the stack pointer around.
+ 	 * This makes it harder to debug a hard fault with a real debugger, so if one is connected we would
+	 * like to trigger a software breakpoint before moving the stack pointer.
+	 * The decision to trigger the breakpoint needs to happen at runtime and not at compile time,
+	 * since when a hard fault has been triggered, you want to debug the binary on the device and not
+	 * compile a new binary with the breakpoint in it, which might then prevent the fault from occurring.
+	 *
+	 * The Cortex-M3 Core Debug module contains the "Debug Halting Control and Status Register" (DHCSR),
+	 * which contains the `C_DEBUGEN` bit, which is set by the debugger to enable halting debug.
+	 * "If halting debug is enabled [...], captured events will halt the processor in Debug state."
+	 * You can test if halting debug is enabled using `(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)`.
+	 *
+	 * !!!WARNING:
+	 *    "If DHCSR.C_DEBUGEN is clear and a breakpoint occurs in an NMI or HardFault exception handler,
+	 *     the system locks up with an unrecoverable error."
+	 *
+	 * Since we are using a breakpoint inside the HardFault exception handler, we must therefore always
+	 * check this flag, before executing the breakpoint.
+	 *
+	 * !!!WARNING:
+	 *     On ARMv6-M "access to the DHCSR from software running on the processor is IMPLEMENTATION DEFINED."
+	 *     This means, that on Cortex-M0, it might not be possible to read the DHCSR from software!
+	 *
+	 * STM32F0 implements this access, but LPC11 does not!
+	 *
+	 * !!!WARNING:
+	 *     OpenOcd does not reset the `C_DEBUGEN` bit on the `shutdown` command. This might be a bug.
+	 *     A workaround is to issue `reset halt`, then manually reset the bits using `mww 0xE000EDF0 0xA05F0000`.
+	 *     This will also clear the `C_HALT` bit and therefore this is equivalent to `reset run`.
+	 *
+	 * !!!WARNING:
+	 *    `C_DEBUGEN` is sticky! It survives all resets but a power-on reset. This means that after debugging
+	 *    either power cycle the target or manually clear `C_DEBUGEN` using `mww 0xE000EDF0 0xA05F0000`.
+	 */
+	msr psp, r0							// save register 0 into the process stack pointer (PSP)
+	ldr r0, =0xE000EDF0					// Load the address of the Debug Halting Control and Status Register (DHCSR)
+	ldr r0, [r0, #0]					// load the content of DHCSR, we need to check if bit 0 is set
+	lsls r0, #31						// test bit 0 by shifting it left 31 times, becoming sign bit
+	mrs r0, psp							// restore r0 before triggering the breakpoint
+	bpl no_debugger						// branch over breakpoint if lsls resulted in positive integer (MSB not set)
+	bkpt #42							// trigger a break point, only if a debugger is connected
+no_debugger:
+%% endif
+
+%% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
+	b HardFault_Handler					// busy wait in a loop forever
+%% else
 	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
 	 * is not able to push an exception frame onto the main stack!
 	 * So we need to push all registers onto the process stack, since it definitely has space.
@@ -116,6 +164,7 @@ HardFault_Handler:
 	// call the C code handler
 	b _hardFaultHandler
 
+%% endif
 	.size	HardFault_Handler, . - HardFault_Handler
 	.endfunc
 

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -211,7 +211,7 @@ _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 
 	// Infinite loop
 %% if parameters.enable_hardfault_handler_led
-	uint32_t ledCounter = 1;
+	volatile uint32_t ledCounter = 1;
 	xpcc::stm32::Gpio{{ parameters.hardfault_handler_led_port }}{{ parameters.hardfault_handler_led_pin }}::setOutput();
 %% endif
 


### PR DESCRIPTION
The hard fault handler moves the stack pointer which disallows a connected debugger to do a backtrace and gather valid stack frames.

Therefore, if a debugger is connected (as signalled by the `C_DEBUGEN` bit in the `CoreDebug->DHCSR` register) a breakpoint it triggered _before_ continuing executing the hard fault handler.
This allows debugging of the controller without recompiling or reflashing which potentially preserves the hard fault reason (recompiling can move things around). A reset is however still required!

OpenOCD does not automatically reset the `C_DEBUGEN` bit on the `shutdown` command, so all `project.cfg` using OpenOCD had to be adapted to force this.
I'm not sure if this is a bug, or if this is expected behaviour. It could also be that no-one has ever used it this way before.

This PR adds the following:
- breakpoint triggering in hard fault handler if `C_DEBUGEN` is set.
- traditional busy waiting in hard fault handler if neither LED nor Log is enabled.
- forcing the `C_DEBUGEN` bit low after flashing using openocd.
- Example for running this on the STM32F4.

cc @ekiwi @daniel-k:
Please test the hard fault handler on STM32F0, since for the Cortex-M0, software access to `CoreDebug->DHCSR` is implementation defined, and for LPC11 it is not implemented (but I believe for F0 it is).
