### PR TITLE
Use ::round instead of std::round.

### DIFF
--- a/examples/stm32f072_discovery/stm32f072_discovery.hpp
+++ b/examples/stm32f072_discovery/stm32f072_discovery.hpp
@@ -49,7 +49,7 @@ struct systemClock
 		xpcc::clock::fcpu     = Frequency;
 		xpcc::clock::fcpu_kHz = Frequency / 1000;
 		xpcc::clock::fcpu_MHz = Frequency / 1000000;
-		xpcc::clock::ns_per_loop = std::round(4000 / (Frequency / 1000000));
+		xpcc::clock::ns_per_loop = ::round(4000 / (Frequency / 1000000));
 
 		return true;
 	}

--- a/examples/stm32f7_discovery/stm32f7_discovery.hpp
+++ b/examples/stm32f7_discovery/stm32f7_discovery.hpp
@@ -94,7 +94,7 @@ struct systemClock
 		xpcc::clock::fcpu     = Frequency;
 		xpcc::clock::fcpu_kHz = Frequency / 1000;
 		xpcc::clock::fcpu_MHz = Frequency / 1000000;
-		xpcc::clock::ns_per_loop = std::round(1000 / (Frequency / 1000000));
+		xpcc::clock::ns_per_loop = ::round(1000 / (Frequency / 1000000));
 
 		return true;
 	}

--- a/src/xpcc/architecture/platform/driver/clock/lpc/static.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/lpc/static.hpp.in
@@ -62,7 +62,7 @@ namespace xpcc
 				xpcc::clock::fcpu     = OutputFrequency;
 				xpcc::clock::fcpu_kHz = OutputFrequency / 1000;
 				xpcc::clock::fcpu_MHz = OutputFrequency / 1000000;
-				xpcc::clock::ns_per_loop = std::round(1000000000.f / OutputFrequency * 4.f);
+				xpcc::clock::ns_per_loop = ::round(1000000000.f / OutputFrequency * 4.f);
 				return StartupError::None;
 			}
 		};

--- a/src/xpcc/architecture/platform/driver/clock/stm32/static.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/static.hpp.in
@@ -70,7 +70,7 @@ namespace xpcc
 				xpcc::clock::fcpu     = OutputFrequency;
 				xpcc::clock::fcpu_kHz = OutputFrequency / 1000;
 				xpcc::clock::fcpu_MHz = OutputFrequency / 1000000;
-				xpcc::clock::ns_per_loop = std::round(1000000000.f / OutputFrequency * 3.f);
+				xpcc::clock::ns_per_loop = ::round(1000000000.f / OutputFrequency * 3.f);
 				return StartupError::None;
 			}
 		};
@@ -114,7 +114,7 @@ namespace xpcc
 				xpcc::clock::fcpu     = OutputFrequency;
 				xpcc::clock::fcpu_kHz = OutputFrequency / 1000;
 				xpcc::clock::fcpu_MHz = OutputFrequency / 1000000;
-				xpcc::clock::ns_per_loop = std::round(1000000000.f / OutputFrequency * 3.f);
+				xpcc::clock::ns_per_loop = ::round(1000000000.f / OutputFrequency * 3.f);
 				return StartupError::None;
 			}
 		};


### PR DESCRIPTION
The round function is not available in the std namespace on all ARM libstdc++ implemenations. Fixes #69
