### PR TITLE
Remove build.clock for all ARM Cortex-M targets

### DIFF
--- a/examples/lpcxpresso/lpc11c24/blink/project.cfg
+++ b/examples/lpcxpresso/lpc11c24/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = lpc11c24_301
-clock = 48000000
 buildpath = ${xpccpath}/build/lpcxpresso/lpc11c24/${name}
 
 [lpclink]

--- a/examples/lpcxpresso/lpc11c24/gpio/project.cfg
+++ b/examples/lpcxpresso/lpc11c24/gpio/project.cfg
@@ -3,7 +3,6 @@ name = gpio
 
 [build]
 device = lpc11c24_301
-clock = 48000000
 buildpath = ${xpccpath}/build/lpcxpresso/lpc11c24/${name}
 
 [lpclink]

--- a/examples/lpcxpresso/lpc11c24/uart/project.cfg
+++ b/examples/lpcxpresso/lpc11c24/uart/project.cfg
@@ -3,7 +3,6 @@ name = uart
 
 [build]
 device = lpc11c24_301
-clock = 48000000
 buildpath = ${xpccpath}/build/lpcxpresso/lpc11c24/${name}
 
 [lpclink]

--- a/examples/nucleo_f103rb/blink/project.cfg
+++ b/examples/nucleo_f103rb/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f103rb
-clock = 64000000
 buildpath = ${xpccpath}/build/nucleo_f103rb/${name}
 extrasources = ['../nucleo_f103rb.cpp']
 

--- a/examples/stm32/fsmc/project.cfg
+++ b/examples/stm32/fsmc/project.cfg
@@ -3,7 +3,6 @@ name = fsmc
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32/${name}
 
 [openocd]

--- a/examples/stm32f072_discovery/blink/project.cfg
+++ b/examples/stm32f072_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f072rb
-clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [openocd]

--- a/examples/stm32f072_discovery/can/project.cfg
+++ b/examples/stm32f072_discovery/can/project.cfg
@@ -3,7 +3,6 @@ name = can
 
 [build]
 device = stm32f072rb
-clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [openocd]

--- a/examples/stm32f072_discovery/hard_fault/project.cfg
+++ b/examples/stm32f072_discovery/hard_fault/project.cfg
@@ -3,7 +3,6 @@ name = hard_fault
 
 [build]
 device = stm32f072rb
-clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [parameters]

--- a/examples/stm32f072_discovery/rotation/project.cfg
+++ b/examples/stm32f072_discovery/rotation/project.cfg
@@ -3,7 +3,6 @@ name = rotation
 
 [build]
 device = stm32f072rb
-clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [openocd]

--- a/examples/stm32f072_discovery/uart/project.cfg
+++ b/examples/stm32f072_discovery/uart/project.cfg
@@ -3,7 +3,6 @@ name = uart
 
 [build]
 device = stm32f072rb
-clock = 48000000
 buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
 
 [openocd]

--- a/examples/stm32f1_discovery/blink/project.cfg
+++ b/examples/stm32f1_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f100rbt6b
-clock = 24000000
 buildpath = ${xpccpath}/build/stm32f1_discovery/${name}
 
 [openocd]

--- a/examples/stm32f1_discovery/logger/project.cfg
+++ b/examples/stm32f1_discovery/logger/project.cfg
@@ -3,7 +3,6 @@ name = logger
 
 [build]
 device = stm32f100rbt6b
-clock = 24000000
 buildpath = ${xpccpath}/build/stm32f1_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/accelerometer/project.cfg
+++ b/examples/stm32f3_discovery/accelerometer/project.cfg
@@ -3,7 +3,6 @@ name = acceleration
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/adc/continous/project.cfg
+++ b/examples/stm32f3_discovery/adc/continous/project.cfg
@@ -3,7 +3,6 @@ name = adc_continous
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/adc/interrupt/project.cfg
+++ b/examples/stm32f3_discovery/adc/interrupt/project.cfg
@@ -3,7 +3,6 @@ name = adc_interrupt
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/adc/simple/project.cfg
+++ b/examples/stm32f3_discovery/adc/simple/project.cfg
@@ -3,7 +3,6 @@ name = adc_simple
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/blink/project.cfg
+++ b/examples/stm32f3_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/can/project.cfg
+++ b/examples/stm32f3_discovery/can/project.cfg
@@ -3,7 +3,6 @@ name = can
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/ft245/project.cfg
+++ b/examples/stm32f3_discovery/ft245/project.cfg
@@ -3,7 +3,6 @@ name = ft245
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/gdb/project.cfg
+++ b/examples/stm32f3_discovery/gdb/project.cfg
@@ -3,7 +3,6 @@ name = gdb
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/hard_fault/project.cfg
+++ b/examples/stm32f3_discovery/hard_fault/project.cfg
@@ -3,7 +3,6 @@ name = hard_fault
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [parameters]

--- a/examples/stm32f3_discovery/rotation/project.cfg
+++ b/examples/stm32f3_discovery/rotation/project.cfg
@@ -3,7 +3,6 @@ name = rotation
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/timer/basic/project.cfg
+++ b/examples/stm32f3_discovery/timer/basic/project.cfg
@@ -3,7 +3,6 @@ name = timer_basic
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/uart/hal/project.cfg
+++ b/examples/stm32f3_discovery/uart/hal/project.cfg
@@ -3,7 +3,6 @@ name = hal
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/uart/${name}
 
 [openocd]

--- a/examples/stm32f3_discovery/uart/logger/project.cfg
+++ b/examples/stm32f3_discovery/uart/logger/project.cfg
@@ -3,7 +3,6 @@ name = logger
 
 [build]
 device = stm32f303vc
-clock = 72000000
 buildpath = ${xpccpath}/build/stm32f3_discovery/uart/${name}
 
 [openocd]

--- a/examples/stm32f429_discovery/blink/project.cfg
+++ b/examples/stm32f429_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f429zit6
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f429_discovery/${name}
 
 [openocd]

--- a/examples/stm32f429_discovery/logger/project.cfg
+++ b/examples/stm32f429_discovery/logger/project.cfg
@@ -3,7 +3,6 @@ name = logger
 
 [build]
 device = stm32f429zit6
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f429_discovery/${name}
 
 [openocd]

--- a/examples/stm32f469_discovery/blink/project.cfg
+++ b/examples/stm32f469_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f469nih6
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f469_discovery/${name}
 extrasources = ['../stm32f469_discovery.cpp']
 

--- a/examples/stm32f4_discovery/accelerometer/project.cfg
+++ b/examples/stm32f4_discovery/accelerometer/project.cfg
@@ -3,7 +3,6 @@ name = lis302dl
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/adc/interrupt/project.cfg
+++ b/examples/stm32f4_discovery/adc/interrupt/project.cfg
@@ -3,7 +3,6 @@ name = adc_interrupt
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/adc/oversample/project.cfg
+++ b/examples/stm32f4_discovery/adc/oversample/project.cfg
@@ -3,7 +3,6 @@ name = adc_oversample
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/adc/simple/project.cfg
+++ b/examples/stm32f4_discovery/adc/simple/project.cfg
@@ -3,7 +3,6 @@ name = adc_simple
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/app_uart_sniffer/project.cfg
+++ b/examples/stm32f4_discovery/app_uart_sniffer/project.cfg
@@ -3,7 +3,6 @@ name = app_uart_sniffer
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.cfg
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.cfg
@@ -3,7 +3,6 @@ name = barometer_bmp085_bmp180
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/blink/project.cfg
+++ b/examples/stm32f4_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/can/project.cfg
+++ b/examples/stm32f4_discovery/can/project.cfg
@@ -3,7 +3,6 @@ name = can
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/colour_tcs3414/project.cfg
+++ b/examples/stm32f4_discovery/colour_tcs3414/project.cfg
@@ -3,7 +3,6 @@ name = colour_tcs3414
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/display/hd44780/project.cfg
+++ b/examples/stm32f4_discovery/display/hd44780/project.cfg
@@ -3,7 +3,6 @@ name = hd44780
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/display/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/display/nokia_5110/project.cfg
+++ b/examples/stm32f4_discovery/display/nokia_5110/project.cfg
@@ -3,7 +3,6 @@ name = n5110
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/display/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/distance_vl6180/project.cfg
+++ b/examples/stm32f4_discovery/distance_vl6180/project.cfg
@@ -3,7 +3,6 @@ name = distance_vl6180
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/exti/project.cfg
+++ b/examples/stm32f4_discovery/exti/project.cfg
@@ -3,7 +3,6 @@ name = exti
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/fpu/project.cfg
+++ b/examples/stm32f4_discovery/fpu/project.cfg
@@ -3,7 +3,6 @@ name = fpu
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/fsmc/project.cfg
+++ b/examples/stm32f4_discovery/fsmc/project.cfg
@@ -3,7 +3,6 @@ name = fsmc
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/hard_fault/project.cfg
+++ b/examples/stm32f4_discovery/hard_fault/project.cfg
@@ -3,7 +3,6 @@ name = hard_fault
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/led_matrix_display/project.cfg
+++ b/examples/stm32f4_discovery/led_matrix_display/project.cfg
@@ -3,7 +3,6 @@ name = led_matrix
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/oled_display/project.cfg
+++ b/examples/stm32f4_discovery/oled_display/project.cfg
@@ -3,7 +3,6 @@ name = led_matrix
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/open407v-d/gui/project.cfg
+++ b/examples/stm32f4_discovery/open407v-d/gui/project.cfg
@@ -3,7 +3,6 @@ name = gui
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/openv407v_d/${name}
 
 [images]

--- a/examples/stm32f4_discovery/open407v-d/touchscreen/project.cfg
+++ b/examples/stm32f4_discovery/open407v-d/touchscreen/project.cfg
@@ -3,7 +3,6 @@ name = touchscreen
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/openv407v_d/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/protothreads/project.cfg
+++ b/examples/stm32f4_discovery/protothreads/project.cfg
@@ -3,7 +3,6 @@ name = protothreads
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.cfg
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.cfg
@@ -3,7 +3,6 @@ name = nrf24-basic-comm
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/radio/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/radio/nrf24-data/rx/project.cfg
+++ b/examples/stm32f4_discovery/radio/nrf24-data/rx/project.cfg
@@ -3,7 +3,6 @@ name = nrf24-data-rx
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/radio/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/radio/nrf24-data/tx/project.cfg
+++ b/examples/stm32f4_discovery/radio/nrf24-data/tx/project.cfg
@@ -3,7 +3,6 @@ name = nrf24-data-tx
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/radio/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/project.cfg
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/project.cfg
@@ -3,7 +3,6 @@ name = nrf24-phy
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/radio/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/project.cfg
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/project.cfg
@@ -3,7 +3,6 @@ name = nrf24-scanner
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/radio/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/spi/project.cfg
+++ b/examples/stm32f4_discovery/spi/project.cfg
@@ -3,7 +3,6 @@ name = spi
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/timer/project.cfg
+++ b/examples/stm32f4_discovery/timer/project.cfg
@@ -3,7 +3,6 @@ name = timer
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/timer_test/project.cfg
+++ b/examples/stm32f4_discovery/timer_test/project.cfg
@@ -3,7 +3,6 @@ name = timer_test
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_discovery/uart/project.cfg
+++ b/examples/stm32f4_discovery/uart/project.cfg
@@ -3,7 +3,6 @@ name = uart
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [parameters]

--- a/examples/stm32f4_discovery/uart_spi/project.cfg
+++ b/examples/stm32f4_discovery/uart_spi/project.cfg
@@ -3,7 +3,6 @@ name = uart_spi
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_discovery/${name}
 
 [openocd]

--- a/examples/stm32f4_loa_v2b/blink/project.cfg
+++ b/examples/stm32f4_loa_v2b/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f407vg
-clock = 168000000
 buildpath = ${xpccpath}/build/stm32f4_loa_v2b/${name}
 
 [openocd]

--- a/examples/stm32f7_discovery/blink/project.cfg
+++ b/examples/stm32f7_discovery/blink/project.cfg
@@ -3,7 +3,6 @@ name = blink
 
 [build]
 device = stm32f746ngh6u
-clock = 216000000
 buildpath = ${xpccpath}/build/stm32f7_discovery/${name}
 extrasources = ['../stm32f7_discovery.cpp']
 

--- a/scons/site_tools/xpcc.py
+++ b/scons/site_tools/xpcc.py
@@ -457,6 +457,8 @@ def generate(env, **kw):
 			env['ARM_ARCH'] = env['ARCHITECTURE']
 		env['ARM_DEVICE'] = device
 		env['ARM_CLOCK'] = clock
+		if clock != "NaN" and not 'freertos' in env['XPCC_ACTIVE_MODULES']:
+			env.Warn("Specifying clock for ARM devices is deprecated.")
 
 		env.Tool('arm')
 		env.Tool('dfu_stm32_programmer')

--- a/src/unittest_stm32.cfg
+++ b/src/unittest_stm32.cfg
@@ -6,7 +6,6 @@ unittest = true
 # stm32f4 discovery board
 architecture = cortex-m4
 device = stm32f407vg
-clock = 168000000
 template = ../templates/unittest/runner_stm32.cpp.in
 buildpath = ../build/unittest_stm32
 

--- a/src/xpcc/architecture/platform/driver/clock/generic/static.macros
+++ b/src/xpcc/architecture/platform/driver/clock/generic/static.macros
@@ -179,9 +179,6 @@ class
 private:
 {{ assertFrequency(s.name, "OutputFrequency", "min", s.minFrequency) }}
 {{ assertFrequency(s.name, "OutputFrequency", "max", s.maxFrequency) }}
-%#		FIXME: make optional in order for sink to be more generic
-	// static_assert(OutputFrequency == F_CPU,
-	// "OutputFrequency needs to match F_CPU value from project.cfg");
 public:
 	/// TypeId to connect an Output to {{ s.name }}
 	static const ::{{type_id_namespace}}::TypeId::{{ s.name }} Id;

--- a/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
@@ -11,6 +11,7 @@
 #include <xpcc_config.hpp>
 
 #include "../../../device.hpp"
+#include "../../clock/lpc/clock.hpp"
 
 #include "uart_1.hpp"
 #include "lpc11_uart_registers.hpp"
@@ -56,7 +57,7 @@ xpcc::lpc::Uart1::initialize(uint32_t baudrate)
 
 	LPC_UART->LCR = LCR_DLAB;
 	uint32_t regVal = LPC_SYSCON->UARTCLKDIV;
-	uint32_t   Fdiv = (((F_CPU * LPC_SYSCON->SYSAHBCLKDIV)/regVal)/16)/baudrate ; //390;
+	uint32_t   Fdiv = (((xpcc::lpc::ClockControl::getCpuFrequency() * LPC_SYSCON->SYSAHBCLKDIV)/regVal)/16)/baudrate ; //390;
 	LPC_UART->DLM = Fdiv >>    8;
 	LPC_UART->DLL = Fdiv  & 0xff;
 	//LPC_UART->DLM = 0;

--- a/tests/stm32_adc/project.cfg
+++ b/tests/stm32_adc/project.cfg
@@ -7,7 +7,6 @@ name = adc
 # ============
 architecture = cortex-m3
 device = stm32f103rb
-clock = 72000000
 
 # ===============
 # DISCOVERY BOARD


### PR DESCRIPTION
This cleans up the `project.cfg` files further by removing the redundant `build.clock` and `F_CPU` macro on ARM Cortex-M targets.

This removal was planned for a long time, there were some significant changes to the delay functions remove the dependence on `F_CPU` and replace it with something dynamic.
The correct way of accessing current CPU frequency is through the `ClockControl` class using the `getCpuFrequency()`, `getCpuFrequencykHz()` and `getCpuFrequencyMHz()` functions.

Note: Our FreeRTOS port still requires `F_CPU`, therefore I have not disabled the generation of the define. You can still declare `build.clock` and `F_CPU` still gets defined.
Considering [how much other magic one needs to do to enable FreeRTOS](https://github.com/roboterclubaachen/xpcc/blob/develop/examples/stm32f4_discovery/rtos/float_check/project.cfg#L9-L14), I did not want to fix this problem only. This requires a more comprehensive fix.

cc @dergraaf @ekiwi 
