### PR TITLE
Add unaligned accessor helper

### DIFF
--- a/examples/stm32f072_discovery/unaligned_access/SConstruct
+++ b/examples/stm32f072_discovery/unaligned_access/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f072_discovery/unaligned_access/main.cpp
+++ b/examples/stm32f072_discovery/unaligned_access/main.cpp
@@ -1,0 +1,75 @@
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/architecture/driver/accessor.hpp>
+#include <xpcc/container/smart_pointer.hpp>
+
+using namespace Board;
+
+uint8_t buffer[300] = {0};
+
+uint32_t input = 0x06050403;
+uint32_t output;
+
+void error()
+{
+	while(1)
+	{
+		LedUp::toggle();
+		xpcc::delayMilliseconds(100);
+	}
+}
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	LedRight::setOutput(xpcc::Gpio::High);
+	LedLeft::setOutput();
+	LedUp::setOutput();
+	LedDown::setOutput();
+
+	uint8_t offset(0);
+
+	// if an unaligned access is trapped, the blue led will blink
+
+	while (1)
+	{
+		{
+			// "smart" pointer is created on the heap
+			xpcc::SmartPointer p(&input);
+
+			// manually interpreting the pointer
+			output = *reinterpret_cast<uint32_t*>(p.getPointer());
+			if (output != input) error();
+
+			// letting the class interpret it
+			output = p.get<uint32_t>();
+			if (output != input) error();
+		}
+
+		{
+			// `u32` is a pointer to a xpcc::unaligned_t<uint32_t> !
+			auto *u32 = xpcc::asUnaligned<uint32_t>(buffer + offset);
+			// this is short for:
+			// xpcc::unaligned_t<uint32_t> *u32 = reinterpret_cast<xpcc::unaligned_t<uint32_t>*>(buffer + offset);
+			// write to the unaligned location
+			*u32 = input;
+			// read from the unaligned location
+			output = *u32;
+			if (output != input) error();
+
+			// Anonymous form
+			*xpcc::asUnaligned<uint32_t>(buffer + offset) = input;
+			output = *xpcc::asUnaligned<uint32_t>(buffer + offset);
+			if (output != input) error();
+		}
+
+		input += 0x0125197;
+		offset += 1;
+
+		LedRight::toggle();
+		LedLeft::toggle();
+		xpcc::delayMilliseconds(Button::read() ? 250 : 500);
+	}
+
+	return 0;
+}

--- a/examples/stm32f072_discovery/unaligned_access/project.cfg
+++ b/examples/stm32f072_discovery/unaligned_access/project.cfg
@@ -1,0 +1,8 @@
+[build]
+board = stm32f072_discovery
+buildpath = ${xpccpath}/build/stm32f072_discovery/${name}
+
+[parameters]
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = C
+core.cortex.0.hardfault_handler_led_pin = 7

--- a/src/xpcc/architecture/driver/accessor.hpp
+++ b/src/xpcc/architecture/driver/accessor.hpp
@@ -33,6 +33,7 @@
 
 #include "accessor/ram.hpp"
 #include "accessor/flash.hpp"
+#include "accessor/unaligned.hpp"
 
 namespace xpcc
 {

--- a/src/xpcc/architecture/driver/accessor/unaligned.hpp
+++ b/src/xpcc/architecture/driver/accessor/unaligned.hpp
@@ -1,0 +1,113 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_ACCESSOR_UNALIGNED_HPP
+#define XPCC_ACCESSOR_UNALIGNED_HPP
+
+#include <xpcc/architecture/detect.hpp>
+#include <xpcc/architecture/utils.hpp>
+
+namespace xpcc
+{
+
+/**
+ * Accesses a type using byte-wise copy.
+ *
+ * This wrapper manages unaligned access to memory, by copying
+ * the memory to and from the stack, which is always correctly aligned.
+ * Use this with teh `asUnaligned` helper:
+ * @code
+ * uint8_t *buffer;
+ * // `u32` is a pointer to a unaligned_t<uint32_t> !
+ * auto *u32 = xpcc::asUnaligned<uint32_t>(buffer);
+ * // write to the unaligned location
+ * *u32 = input;
+ * // read from the unaligned location
+ * output = *u32;
+ * @endcode
+ *
+ * @ingroup	accessor
+ * @author	Niklas Hauser
+ */
+template< typename T >
+struct
+unaligned_t
+{
+	inline unaligned_t() : data{0} {}
+
+	inline unaligned_t(T value)
+#ifdef XPCC__CPU_CORTEX_M0
+	{ write(value); }
+#else
+	: data(value) {}
+#endif
+
+
+	inline operator T() const
+	{
+#ifdef XPCC__CPU_CORTEX_M0
+		T t;
+		read(t);
+		return t;
+#else
+		return data;
+#endif
+	}
+
+protected:
+	void inline
+	write(T &value)
+	{
+#ifdef XPCC__CPU_CORTEX_M0
+		// memcpy(data, (uint8_t*)&value, sizeof(T));
+		// manual copy is faster for small sizes
+		for(uint_fast8_t ii=0; ii<sizeof(T); ii++)
+			data[ii] = reinterpret_cast<uint8_t*>(&value)[ii];
+#else
+		data = value;
+#endif
+	}
+
+	void inline
+	read(T &value) const
+	{
+#ifdef XPCC__CPU_CORTEX_M0
+		// memcpy((uint8_t*)&value, data, sizeof(T));
+		// manual copy is faster for small sizes
+		for(uint_fast8_t ii=0; ii<sizeof(T); ii++)
+			reinterpret_cast<uint8_t*>(&value)[ii] = data[ii];
+#else
+		value = data;
+#endif
+	}
+
+
+protected:
+#ifdef XPCC__CPU_CORTEX_M0
+	uint8_t data[sizeof(T)];
+#else
+	T data;
+#endif
+} ATTRIBUTE_PACKED;
+
+/**
+ * Accesses a memory location using a unaligned-safe method.
+ *
+ * @ingroup	accessor
+ */
+template< typename T, typename U>
+ALWAYS_INLINE unaligned_t<T>*
+asUnaligned(U* value)
+{
+	return reinterpret_cast< unaligned_t<T>* >(value);
+}
+
+}
+
+#endif	// XPCC_ACCESSOR_UNALIGNED_HPP

--- a/src/xpcc/container/smart_pointer.cpp
+++ b/src/xpcc/container/smart_pointer.cpp
@@ -31,14 +31,14 @@
 #include "smart_pointer.hpp"
 
 // ----------------------------------------------------------------------------
-// must allocate at least four bytes, so getPointer() does return
+// must allocate at least five bytes, so getPointer() does return
 // a valid address
 xpcc::SmartPointer::SmartPointer() :
-	ptr(new uint8_t[4])
+	ptr(new uint8_t[5])
 {
 	ptr[0] = 1;
-	ptr[1] = 0;
 	ptr[2] = 0;
+	ptr[3] = 0;
 }
 
 xpcc::SmartPointer::SmartPointer(const SmartPointer& other) :
@@ -47,13 +47,13 @@ xpcc::SmartPointer::SmartPointer(const SmartPointer& other) :
 	ptr[0]++;
 }
 
-// must allocate at least four bytes, so getPointer() does return
+// must allocate at least five bytes, so getPointer() does return
 // a valid address
 xpcc::SmartPointer::SmartPointer(uint16_t size) :
-	ptr(new uint8_t[size ? size + 3 : 4])
+	ptr(new uint8_t[size ? size + 4 : 5])
 {
 	ptr[0] = 1;
-	*reinterpret_cast<uint16_t*>(ptr + 1) = size;
+	*reinterpret_cast<uint16_t*>(ptr + 2) = size;
 }
 
 xpcc::SmartPointer::~SmartPointer()
@@ -88,7 +88,7 @@ xpcc::IOStream&
 xpcc::operator << (xpcc::IOStream& s, const xpcc::SmartPointer& v)
 {
 	s << "0x" << xpcc::hex;
-	for (uint8_t i = 3; i < v.getSize() + 3; i++)
+	for (uint8_t i = 4; i < v.getSize() + 4; i++)
 	{
 		s << v.ptr[i];
 	}

--- a/src/xpcc/container/smart_pointer.hpp
+++ b/src/xpcc/container/smart_pointer.hpp
@@ -70,11 +70,11 @@ namespace xpcc
 		// between constructor and copy constructor!
 		template<typename T>
 		explicit SmartPointer(const T *data)
-		: ptr(new uint8_t[sizeof(T) + 3])
+		: ptr(new uint8_t[sizeof(T) + 4])
 		{
 			ptr[0] = 1;
-			*reinterpret_cast<uint16_t*>(ptr + 1) = sizeof(T);
-			std::memcpy(ptr + 3, data, sizeof(T));
+			*reinterpret_cast<uint16_t*>(ptr + 2) = sizeof(T);
+			std::memcpy(ptr + 4, data, sizeof(T));
 		}
 
 		SmartPointer(const SmartPointer& other);
@@ -84,19 +84,19 @@ namespace xpcc
 		inline const uint8_t *
 		getPointer() const
 		{
-			return ptr + 3;
+			return ptr + 4;
 		}
 
 		inline uint8_t *
 		getPointer()
 		{
-			return ptr + 3;
+			return ptr + 4;
 		}
 
 		inline uint16_t
 		getSize() const
 		{
-			return *reinterpret_cast<uint16_t*>(ptr + 1);
+			return *reinterpret_cast<uint16_t*>(ptr + 2);
 		}
 
 	public:
@@ -110,7 +110,7 @@ namespace xpcc
 		inline const T&
 		get() const
 		{
-			return *reinterpret_cast<T*>(ptr + 3);
+			return *reinterpret_cast<T*>(ptr + 4);
 		}
 
 		/**
@@ -125,7 +125,7 @@ namespace xpcc
 		{
 			if (sizeof(T) == getSize())
 			{
-				value = *reinterpret_cast<T*>(ptr + 3);
+				value = *reinterpret_cast<T*>(ptr + 4);
 				return true;
 			}
 			else {

--- a/src/xpcc/driver/position/vl6180.hpp
+++ b/src/xpcc/driver/position/vl6180.hpp
@@ -320,7 +320,7 @@ public:
 		inline float
 		getAmbientLight()
 		{
-			uint16_t* rawData = reinterpret_cast<uint16_t*>(data+1);
+			auto* rawData = xpcc::asUnaligned<uint16_t>(data+1);
 			uint16_t value = xpcc::fromBigEndian(*rawData);
 			float lux = (32.f * value);
 			lux /= (vl6180_private::gain[gain & 0x7] * time);


### PR DESCRIPTION
This adds a `xpcc::unaligned_t` wrapper class, that manages access to the underlying type using byte-wise access.
For access to bytes streams use the `xpcc::asUnaligned<T>` helper class.
See example for usage.

This also fixed alignment issues in `xpcc::SmartPointer`, which should make the XPCC protocol work on CM0 as well.

Fixes #95.

cc @ekiwi @dergraaf @rleh @strongly-typed 
