### PR TITLE
Add support for STM32F373 und F427 FSMC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -107,5 +107,5 @@ for key, value in ARGUMENTS.items():
 	unittest_str += (" %s=%s" % (key, value))
 env.Phony(unittest=unittest_str)
 
-env.Alias('all', ['doc', 'update', 'templates', 'unittest'])
+env.Alias('all', ['doc', 'unittest'])
 env.Default('all')

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
@@ -66,7 +66,7 @@
     <driver type="i2c" name="stm32" instances="1,2"/>
     <driver type="spi" name="stm32" instances="1,2"/>
     <driver type="spi" name="stm32_uart" instances="1,2,3"/>
-    <driver type="timer" name="stm32" instances="1,2,3,4,6,7,15,16,17"/>
+    <driver type="timer" name="stm32" instances="1,2,3,4,6,7"/>
     <driver type="uart" name="stm32" instances="1,2,3"/>
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
@@ -66,7 +66,7 @@
     <driver type="i2c" name="stm32" instances="1,2"/>
     <driver type="spi" name="stm32" instances="1,2"/>
     <driver type="spi" name="stm32_uart" instances="1,2,3"/>
-    <driver type="timer" name="stm32" instances="1,2,3,4,6,7"/>
+    <driver type="timer" name="stm32" instances="1,2,3,4,6,7,15,16,17"/>
     <driver type="uart" name="stm32" instances="1,2,3"/>
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f373-c_r_v-8_b_c.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f373-c_r_v-8_b_c.xml
@@ -1,0 +1,525 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<rca version="1.0">
+  <!-- WARNING: This file is generated automatically, do not edit!
+ 		Please modify the xpcc/tools/device_file_generator code instead and rebuild this file.
+ 		Be aware, that regenerated files might have a different composition due to technical reasons. -->
+  <device platform="stm32" family="f3" name="373" pin_id="c|r|v" size_id="8|b|c">
+    <flash device-size-id="8">65536</flash>
+    <flash device-size-id="b">131072</flash>
+    <flash device-size-id="c">262144</flash>
+    <ram device-size-id="8">16384</ram>
+    <ram device-size-id="b">24576</ram>
+    <ram device-size-id="c">32768</ram>
+    <linkerscript device-size-id="8">stm32f373_8.ld</linkerscript>
+    <linkerscript device-size-id="b">stm32f373_b.ld</linkerscript>
+    <linkerscript device-size-id="c">stm32f373_c.ld</linkerscript>
+    <core>cortex-m4f</core>
+    <pin-count device-pin-id="v">100</pin-count>
+    <pin-count device-pin-id="c">48</pin-count>
+    <pin-count device-pin-id="r">64</pin-count>
+    <header>stm32f3xx.h</header>
+    <define>STM32F373xC</define>
+    <driver type="core" name="cortex">
+      <memory device-size-id="8" access="rx" start="0x8000000" name="flash" size="64"/>
+      <memory device-size-id="b" access="rx" start="0x8000000" name="flash" size="128"/>
+      <memory device-size-id="c" access="rx" start="0x8000000" name="flash" size="256"/>
+      <memory device-size-id="8" access="rwx" start="0x20000000" name="sram1" size="16"/>
+      <memory device-size-id="b" access="rwx" start="0x20000000" name="sram1" size="24"/>
+      <memory device-size-id="c" access="rwx" start="0x20000000" name="sram1" size="32"/>
+      <vector position="0" name="WWDG"/>
+      <vector position="1" name="PVD"/>
+      <vector position="2" name="TAMP_STAMP"/>
+      <vector position="3" name="RTC_WKUP"/>
+      <vector position="4" name="FLASH"/>
+      <vector position="5" name="RCC"/>
+      <vector position="6" name="EXTI0"/>
+      <vector position="7" name="EXTI1"/>
+      <vector position="8" name="EXTI2_TSC"/>
+      <vector position="9" name="EXTI3"/>
+      <vector position="10" name="EXTI4"/>
+      <vector position="11" name="DMA1_Channel1"/>
+      <vector position="12" name="DMA1_Channel2"/>
+      <vector position="13" name="DMA1_Channel3"/>
+      <vector position="14" name="DMA1_Channel4"/>
+      <vector position="15" name="DMA1_Channel5"/>
+      <vector position="16" name="DMA1_Channel6"/>
+      <vector position="17" name="DMA1_Channel7"/>
+      <vector position="18" name="ADC1"/>
+      <vector position="19" name="CAN_TX"/>
+      <vector position="20" name="CAN_RX0"/>
+      <vector position="21" name="CAN_RX1"/>
+      <vector position="22" name="CAN_SCE"/>
+      <vector position="23" name="EXTI9_5"/>
+      <vector position="24" name="TIM15"/>
+      <vector position="25" name="TIM16"/>
+      <vector position="26" name="TIM17"/>
+      <vector position="27" name="TIM18_DAC2"/>
+      <vector position="28" name="TIM2"/>
+      <vector position="29" name="TIM3"/>
+      <vector position="30" name="TIM4"/>
+      <vector position="31" name="I2C1_EV"/>
+      <vector position="32" name="I2C1_ER"/>
+      <vector position="33" name="I2C2_EV"/>
+      <vector position="34" name="I2C2_ER"/>
+      <vector position="35" name="SPI1"/>
+      <vector position="36" name="SPI2"/>
+      <vector position="37" name="USART1"/>
+      <vector position="38" name="USART2"/>
+      <vector position="39" name="USART3"/>
+      <vector position="40" name="EXTI15_10"/>
+      <vector position="41" name="RTC_Alarm"/>
+      <vector position="42" name="CEC"/>
+      <vector position="43" name="TIM12"/>
+      <vector position="44" name="TIM13"/>
+      <vector position="45" name="TIM14"/>
+      <vector position="50" name="TIM5"/>
+      <vector position="51" name="SPI3"/>
+      <vector position="54" name="TIM6_DAC1"/>
+      <vector position="55" name="TIM7"/>
+      <vector position="56" name="DMA2_Channel1"/>
+      <vector position="57" name="DMA2_Channel2"/>
+      <vector position="58" name="DMA2_Channel3"/>
+      <vector position="59" name="DMA2_Channel4"/>
+      <vector position="60" name="DMA2_Channel5"/>
+      <vector position="61" name="SDADC1"/>
+      <vector position="62" name="SDADC2"/>
+      <vector position="63" name="SDADC3"/>
+      <vector position="64" name="COMP"/>
+      <vector position="74" name="USB_HP"/>
+      <vector position="75" name="USB_LP"/>
+      <vector position="76" name="USBWakeUp"/>
+      <vector position="78" name="TIM19"/>
+      <vector position="81" name="FPU"/>
+    </driver>
+    <driver type="adc" name="stm32" instances="1"/>
+    <driver type="can" name="stm32" instances="1"/>
+    <driver type="clock" name="stm32"/>
+    <driver type="dma" name="stm32" instances="1,2"/>
+    <driver type="i2c" name="stm32" instances="1,2"/>
+    <driver type="id" name="stm32"/>
+    <driver type="spi" name="stm32" instances="1,2,3"/>
+    <driver type="spi" name="stm32_uart" instances="1,2,3"/>
+    <driver type="timer" name="stm32" instances="2,3,4,5,6,7,12,13,14,15,16,17,18,19"/>
+    <driver type="uart" name="stm32" instances="1,2,3"/>
+    <driver type="usb" name="stm32_fs"/>
+    <driver type="gpio" name="stm32">
+      <gpio port="A" id="0">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
+        <af id="7" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="11" peripheral="Timer19" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel0" type="analog"/>
+      </gpio>
+      <gpio port="A" id="1">
+        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart2" name="De"/>
+        <af id="7" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af id="11" peripheral="Timer19" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel1" type="analog"/>
+      </gpio>
+      <gpio port="A" id="2">
+        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer15" name="Channel1"/>
+        <af id="11" peripheral="Timer19" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel2" type="analog"/>
+      </gpio>
+      <gpio port="A" id="3">
+        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer15" name="Channel2"/>
+        <af id="11" peripheral="Timer19" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel3" type="analog"/>
+      </gpio>
+      <gpio port="A" id="4">
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Nss"/>
+        <af id="6" peripheral="SpiMaster3" name="Nss"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="10" peripheral="Timer12" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel4" type="analog"/>
+      </gpio>
+      <gpio port="A" id="5">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="10" peripheral="Timer12" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel5" type="analog"/>
+      </gpio>
+      <gpio port="A" id="6">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel6" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="A" id="7">
+        <af id="1" peripheral="Timer17" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel7" type="analog"/>
+      </gpio>
+      <gpio port="A" id="8">
+        <!--<af id="0" peripheral="MCO" type="out"/>-->
+        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart1" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
+        <af id="10" peripheral="Timer4" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="A" id="9">
+        <af id="2" peripheral="Timer13" name="Channel1"/>
+        <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
+        <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer15" name="BreakIn" type="in"/>
+        <af id="10" peripheral="Timer2" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="10">
+        <af id="1" peripheral="Timer17" name="BreakIn" type="in"/>
+        <af id="4" peripheral="I2cMaster2" name="Sda"/>
+        <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="10" peripheral="Timer2" name="Channel4"/>
+      </gpio>
+      <gpio port="A" id="11">
+        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster2" name="Nss"/>
+        <af id="6" peripheral="SpiMaster1" name="Nss"/>
+        <af id="7" peripheral="Uart1" name="Cts" type="in"/>
+        <af id="9" peripheral="Can1" name="Rx" type="in"/>
+        <af id="10" peripheral="Timer4" name="Channel1"/>
+        <af id="14" peripheral="Usb" name="Dm"/>
+      </gpio>
+      <gpio port="A" id="12">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="6" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart1" name="De"/>
+        <af id="7" peripheral="Uart1" name="Rts" type="out"/>
+        <af id="9" peripheral="Can1" name="Tx" type="out"/>
+        <af id="10" peripheral="Timer4" name="Channel2"/>
+        <af id="14" peripheral="Usb" name="Dp"/>
+      </gpio>
+      <gpio port="A" id="13">
+        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="6" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="10" peripheral="Timer4" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="14">
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="10" peripheral="Timer12" name="Channel1"/>
+      </gpio>
+      <gpio port="A" id="15">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="5" peripheral="SpiMaster1" name="Nss"/>
+        <af id="6" peripheral="SpiMaster3" name="Nss"/>
+        <af id="10" peripheral="Timer12" name="Channel2"/>
+      </gpio>
+      <gpio port="B" id="0">
+        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="10" peripheral="Timer3" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel8" type="analog"/>
+      </gpio>
+      <gpio port="B" id="1">
+        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af peripheral="Adc1" name="Channel9" type="analog"/>
+      </gpio>
+      <gpio port="B" id="2"/>
+      <gpio port="B" id="3">
+        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
+        <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="10" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="B" id="4">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af id="10" peripheral="Timer17" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="5">
+        <af id="1" peripheral="Timer16" name="BreakIn" type="in"/>
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="10" peripheral="Timer17" name="Channel1"/>
+        <af id="11" peripheral="Timer19" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="B" id="6">
+        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer15" name="Channel1"/>
+        <af id="10" peripheral="Timer3" name="Channel3"/>
+        <af id="11" peripheral="Timer19" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="7">
+        <af id="1" peripheral="Timer17" name="Channel1N"/>
+        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer15" name="Channel2"/>
+        <af id="10" peripheral="Timer3" name="Channel4"/>
+        <af id="11" peripheral="Timer19" name="Channel2"/>
+      </gpio>
+      <gpio port="B" id="8">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="9" peripheral="Can1" name="Rx" type="in"/>
+        <af id="11" peripheral="Timer19" name="Channel3"/>
+      </gpio>
+      <gpio port="B" id="9">
+        <af id="1" peripheral="Timer17" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="5" peripheral="SpiMaster2" name="Nss"/>
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="9" peripheral="Can1" name="Tx" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="v" port="B" id="10">
+        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="B" id="14">
+        <af id="1" peripheral="Timer15" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart3" name="De"/>
+        <af id="7" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="9" peripheral="Timer12" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="15">
+        <af id="1" peripheral="Timer15" name="Channel2"/>
+        <af id="2" peripheral="Timer15" name="Channel1N"/>
+        <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer12" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="0">
+        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
+        <af peripheral="Adc1" name="Channel10" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="1">
+        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel11" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="2">
+        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <af peripheral="Adc1" name="Channel12" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="3">
+        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <af peripheral="Adc1" name="Channel13" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="4">
+        <af id="2" peripheral="Timer13" name="Channel1"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af peripheral="Adc1" name="Channel14" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="5">
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af peripheral="Adc1" name="Channel15" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="6">
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster1" name="Nss"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="7">
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="8">
+        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="9">
+        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="10">
+        <af id="2" peripheral="Timer19" name="Channel1"/>
+        <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="11">
+        <af id="2" peripheral="Timer19" name="Channel2"/>
+        <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="C" id="12">
+        <af id="2" peripheral="Timer19" name="Channel3"/>
+        <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="C" id="13"/>
+      <gpio port="C" id="14"/>
+      <gpio port="C" id="15"/>
+      <gpio device-pin-id="v" port="D" id="0">
+        <af id="2" peripheral="Timer19" name="Channel4"/>
+        <af id="7" peripheral="Can1" name="Rx" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="1">
+        <af id="2" peripheral="Timer19" name="ExternalTrigger" type="in"/>
+        <af id="7" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r|v" port="D" id="2">
+        <af id="2" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="3">
+        <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart2" name="Cts" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="4">
+        <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart2" name="De"/>
+        <af id="7" peripheral="Uart2" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="5">
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="6">
+        <af id="5" peripheral="SpiMaster2" name="Nss"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="7">
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="D" id="8">
+        <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="9">
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="10">
+        <af id="7" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="11">
+        <af id="7" peripheral="Uart3" name="Cts" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="12">
+        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="7" peripheral="Uart3" name="De"/>
+        <af id="7" peripheral="Uart3" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="13">
+        <af id="2" peripheral="Timer4" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="14">
+        <af id="2" peripheral="Timer4" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="v" port="D" id="15">
+        <af id="2" peripheral="Timer4" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="0">
+        <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="1">
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="v" port="E" id="2"/>
+      <gpio device-pin-id="v" port="E" id="3"/>
+      <gpio device-pin-id="v" port="E" id="4"/>
+      <gpio device-pin-id="v" port="E" id="5"/>
+      <gpio device-pin-id="v" port="E" id="6"/>
+      <gpio device-pin-id="v" port="E" id="7"/>
+      <gpio port="E" id="8"/>
+      <gpio port="E" id="9"/>
+      <gpio device-pin-id="v" port="E" id="10"/>
+      <gpio device-pin-id="v" port="E" id="11"/>
+      <gpio device-pin-id="v" port="E" id="12"/>
+      <gpio device-pin-id="v" port="E" id="13"/>
+      <gpio device-pin-id="v" port="E" id="14"/>
+      <gpio device-pin-id="v" port="E" id="15">
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio port="F" id="0">
+        <af id="4" peripheral="I2cMaster2" name="Sda"/>
+      </gpio>
+      <gpio port="F" id="1">
+        <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="F" id="2"/>
+      <gpio device-pin-id="v" port="F" id="4"/>
+      <gpio port="F" id="6">
+        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart3" name="De"/>
+        <af id="7" peripheral="Uart3" name="Rts" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="F" id="7">
+        <af id="4" peripheral="I2cMaster2" name="Sda"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="v" port="F" id="9">
+        <af id="2" peripheral="Timer14" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="v" port="F" id="10"/>
+    </driver>
+  </device>
+</rca>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
@@ -127,6 +127,7 @@
     <driver type="can" name="stm32" instances="1,2"/>
     <driver type="clock" name="stm32"/>
     <driver type="dma" name="stm32" instances="1,2"/>
+    <driver device-pin-id="v|z|a|i|b|n" type="fsmc" name="stm32"/>
     <driver type="i2c" name="stm32" instances="1,2,3"/>
     <driver type="id" name="stm32"/>
     <driver type="random" name="stm32"/>
@@ -292,6 +293,7 @@
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af device-pin-id="i|o|v|z" id="12" peripheral="Fsmc" name="Nl"/>
       </gpio>
       <gpio port="B" id="8">
         <af id="2" peripheral="Timer4" name="Channel3"/>
@@ -422,9 +424,11 @@
       <gpio port="C" id="15"/>
       <gpio port="D" id="0">
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
+        <af id="12" peripheral="Fsmc" name="D2"/>
       </gpio>
       <gpio port="D" id="1">
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D3"/>
       </gpio>
       <gpio port="D" id="2">
         <af id="2" peripheral="Timer3" name="ExternalTrigger" type="in"/>
@@ -433,164 +437,232 @@
       <gpio port="D" id="3">
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
+        <af id="12" peripheral="Fsmc" name="Clk"/>
       </gpio>
       <gpio port="D" id="4">
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Noe"/>
       </gpio>
       <gpio port="D" id="5">
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Nwe"/>
       </gpio>
       <gpio port="D" id="6">
         <af id="5" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="12" peripheral="Fsmc" name="Nwait"/>
       </gpio>
       <gpio port="D" id="7">
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Nce2"/>
+        <af id="12" peripheral="Fsmc" name="Ne1"/>
       </gpio>
       <gpio port="D" id="8">
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D13"/>
       </gpio>
       <gpio port="D" id="9">
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="12" peripheral="Fsmc" name="D14"/>
       </gpio>
       <gpio port="D" id="10">
         <af id="7" peripheral="Uart3" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D15"/>
       </gpio>
       <gpio port="D" id="11">
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
+        <af id="12" peripheral="Fsmc" name="A16"/>
+        <af id="12" peripheral="Fsmc" name="Cle"/>
       </gpio>
       <gpio port="D" id="12">
         <af id="2" peripheral="Timer4" name="Channel1"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
+        <af id="12" peripheral="Fsmc" name="A17"/>
+        <af id="12" peripheral="Fsmc" name="Ale"/>
       </gpio>
       <gpio port="D" id="13">
         <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="12" peripheral="Fsmc" name="A18"/>
       </gpio>
       <gpio port="D" id="14">
         <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="12" peripheral="Fsmc" name="D0"/>
       </gpio>
       <gpio port="D" id="15">
         <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="12" peripheral="Fsmc" name="D1"/>
       </gpio>
       <gpio port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
         <af id="8" peripheral="Uart8" name="Rx" type="in"/>
+        <af id="12" peripheral="Fsmc" name="Nbl0"/>
       </gpio>
       <gpio port="E" id="1">
         <af id="8" peripheral="Uart8" name="Tx" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Nbl1"/>
       </gpio>
       <gpio port="E" id="2">
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
+        <af id="12" peripheral="Fsmc" name="A23"/>
       </gpio>
-      <gpio port="E" id="3"/>
+      <gpio port="E" id="3">
+		<af id="12" peripheral="Fsmc" name="A19"/>
+	  </gpio>
       <gpio port="E" id="4">
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
+        <af id="12" peripheral="Fsmc" name="A20"/>
       </gpio>
       <gpio port="E" id="5">
         <af id="3" peripheral="Timer9" name="Channel1"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
+        <af id="12" peripheral="Fsmc" name="A21"/>
       </gpio>
       <gpio port="E" id="6">
         <af id="3" peripheral="Timer9" name="Channel2"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
+        <af id="12" peripheral="Fsmc" name="A22"/>
       </gpio>
       <gpio port="E" id="7">
         <af id="1" peripheral="Timer1" name="ExternalTrigger" type="in"/>
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
+        <af id="12" peripheral="Fsmc" name="D4"/>
       </gpio>
       <gpio port="E" id="8">
         <af id="1" peripheral="Timer1" name="Channel1N"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D5"/>
       </gpio>
       <gpio port="E" id="9">
         <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="12" peripheral="Fsmc" name="D6"/>
       </gpio>
       <gpio port="E" id="10">
         <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="12" peripheral="Fsmc" name="D7"/>
       </gpio>
       <gpio port="E" id="11">
         <af id="1" peripheral="Timer1" name="Channel2"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
+        <af id="12" peripheral="Fsmc" name="D8"/>
       </gpio>
       <gpio port="E" id="12">
         <af id="1" peripheral="Timer1" name="Channel3N"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D9"/>
       </gpio>
       <gpio port="E" id="13">
         <af id="1" peripheral="Timer1" name="Channel3"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
+        <af id="12" peripheral="Fsmc" name="D10"/>
       </gpio>
       <gpio port="E" id="14">
         <af id="1" peripheral="Timer1" name="Channel4"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
+        <af id="12" peripheral="Fsmc" name="D11"/>
       </gpio>
       <gpio port="E" id="15">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="12" peripheral="Fsmc" name="D12"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="0">
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
+        <af id="12" peripheral="Fsmc" name="A0"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="1">
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
+        <af id="12" peripheral="Fsmc" name="A1"/>
       </gpio>
-      <gpio device-pin-id="a|b|i|n|z" port="F" id="2"/>
+      <gpio device-pin-id="a|b|i|n|z" port="F" id="2">
+		<af id="12" peripheral="Fsmc" name="A2"/>
+	  </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="3">
         <af peripheral="Adc3" name="Channel9" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="A3"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="4">
         <af peripheral="Adc3" name="Channel14" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="A4"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="5">
         <af peripheral="Adc3" name="Channel15" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="A5"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="6">
         <af id="3" peripheral="Timer10" name="Channel1"/>
         <af id="5" peripheral="SpiMaster5" name="Nss"/>
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="Niord"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="7">
         <af id="3" peripheral="Timer11" name="Channel1"/>
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="Nreg"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="8">
         <af id="5" peripheral="SpiMaster5" name="Miso" type="in"/>
         <af id="9" peripheral="Timer13" name="Channel1"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="Niowr"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="9">
         <af id="5" peripheral="SpiMaster5" name="Mosi" type="out"/>
         <af id="9" peripheral="Timer14" name="Channel1"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="Cd"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="10">
         <af peripheral="Adc3" name="Channel8" type="analog"/>
+        <af id="12" peripheral="Fsmc" name="Intr"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="F" id="11">
         <af id="5" peripheral="SpiMaster5" name="Mosi" type="out"/>
       </gpio>
-      <gpio device-pin-id="a|b|i|n|z" port="F" id="12"/>
-      <gpio device-pin-id="a|b|i|n|z" port="F" id="13"/>
-      <gpio device-pin-id="a|b|i|n|z" port="F" id="14"/>
-      <gpio device-pin-id="a|b|i|n|z" port="F" id="15"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="0"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="1"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="2"/>
-      <gpio device-pin-id="b|i|n|z" port="G" id="3"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="4"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="5"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="6"/>
+      <gpio device-pin-id="a|b|i|n|z" port="F" id="12">
+		<af id="12" peripheral="Fsmc" name="A6"/>
+	  </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="F" id="13">
+        <af id="12" peripheral="Fsmc" name="A7"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="F" id="14">
+        <af id="12" peripheral="Fsmc" name="A8"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="F" id="15">
+        <af id="12" peripheral="Fsmc" name="A9"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="0">
+        <af id="12" peripheral="Fsmc" name="A10"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="1">
+        <af id="12" peripheral="Fsmc" name="A11"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="2">
+        <af id="12" peripheral="Fsmc" name="A12"/>
+      </gpio>
+      <gpio device-pin-id="b|i|n|z" port="G" id="3">
+        <af id="12" peripheral="Fsmc" name="A13"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="4">
+        <af id="12" peripheral="Fsmc" name="A14"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="5">
+        <af id="12" peripheral="Fsmc" name="A15"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="6">
+        <af id="12" peripheral="Fsmc" name="Int2"/>
+      </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="G" id="7">
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Int3"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="G" id="8">
         <af device-pin-id="b|i|n|z" id="5" peripheral="SpiMaster6" name="Nss"/>
@@ -599,21 +671,31 @@
       <gpio device-pin-id="b|i|n|z" port="G" id="9">
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
+        <af id="12" peripheral="Fsmc" name="Nce3"/>
+        <af id="12" peripheral="Fsmc" name="Ne2"/>
       </gpio>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="10"/>
-      <gpio device-pin-id="a|b|i|n|z" port="G" id="11"/>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="10">
+        <af id="12" peripheral="Fsmc" name="Nce4"/>
+        <af id="12" peripheral="Fsmc" name="Ne3"/>
+      </gpio>
+      <gpio device-pin-id="a|b|i|n|z" port="G" id="11">
+        <af id="12" peripheral="Fsmc" name="Nce4"/>
+      </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="G" id="12">
         <af device-pin-id="b|i|n|z" id="5" peripheral="SpiMaster6" name="Miso" type="in"/>
         <af id="8" peripheral="Uart6" name="Rts" type="out"/>
+        <af id="12" peripheral="Fsmc" name="Ne4"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="G" id="13">
         <af id="5" peripheral="SpiMaster6" name="Sck" type="out"/>
         <af id="8" peripheral="Uart6" name="Cts" type="in"/>
+        <af id="12" peripheral="Fsmc" name="A24"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="G" id="14">
         <af id="5" peripheral="SpiMaster6" name="Mosi" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
+        <af id="12" peripheral="Fsmc" name="A25"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n|z" port="G" id="15">
         <af id="8" peripheral="Uart6" name="Cts" type="in"/>

--- a/src/xpcc/architecture/platform/driver/adc/stm32/adc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32/adc.hpp.in
@@ -11,7 +11,7 @@
 %% set channels = [0,1,2,3,4,5,6,7,8,10,11,12,13]
 %% if target is stm32f2 or target is stm32f4 or target is stm32f7
 	%% do channels.extend([9,14,15,16,17,18])
-%% elif target is stm32f1
+%% elif target is stm32f1 or target is stm32f3
 	%% if id == 1
 		%% do channels.extend([16,17])
 	%% endif

--- a/src/xpcc/architecture/platform/driver/adc/stm32/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32/adc_impl.hpp.in
@@ -78,7 +78,7 @@ xpcc::stm32::Adc{{ id }}::setPrescaler(const Prescaler prescaler)
 {
 %% if target is stm32f2 or target is stm32f4 or target is stm32f7
 	ADC->CCR = (ADC->CCR & ~(0b11 << 17)) | (uint32_t(prescaler) << 17);
-%% elif target is stm32f1
+%% elif target is stm32f1 or target is stm32f3
 	RCC->CFGR = (RCC->CFGR & ~(0b11 << 14)) | (uint32_t(prescaler) << 14);
 %% endif
 }
@@ -265,7 +265,7 @@ xpcc::stm32::Adc{{ id }}::enableInterruptVector(const uint32_t priority,
 {
 %% if target is stm32f2 or target is stm32f4 or target is stm32f7
 	const IRQn_Type InterruptVector = ADC_IRQn;
-%% elif target is stm32f1
+%% elif target is stm32f1 or target is stm32f3
 	%% if id < 3
 	const IRQn_Type InterruptVector = ADC1_2_IRQn;
 	%% elif id == 3

--- a/src/xpcc/architecture/platform/driver/clock/stm32/static.hpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/static.hpp.in
@@ -213,6 +213,42 @@ namespace xpcc
 							 'divisions': [1],
 							 'sources': [internalClock, externalClock,
 										 externalCrystal, pll, systemClock] }
+%% elif target is stm32f3 and target.name == "373"
+	%% set internalClock =	{'name': "InternalClock",
+							 'fixedFrequency': "MHz8" }
+	%% set sys_timer = 	{'name': "SystemTimer",
+					     'prescaler': "1/8" }
+	%% set apb1_timers = 	{'name': "APB1Timers",
+							 'prescaler': "1" ,
+							 'sinks': [ "Timer2",  "Timer3",  "Timer4", "Timer5",
+										"Timer6",  "Timer7", "Timer12", "Timer13", "Timer14" ] }
+	%% set apb1 = 	{'name': "APB1",
+					 'prescaler': "1/2",
+					 'sinks': [ apb1_timers, "Can1", "I2c1", "I2c2",
+								"Usart2", "Usart3", "Uart4", "Uart5",
+								"Spi2", "Spi3" ] }
+	%% set apb2 = 	{'name': "APB2",
+					 'prescaler': "1",
+					 'sinks': [ "Usart1", "Spi1", "Adc",
+								"Timer1", "Timer8", "Timer15", "Timer16", "Timer17" ] }
+	%% set ahb = 	{'name': "AHB",
+					 'prescaler': "1",
+					 'sinks': [ sys_timer, apb1, apb2, "Gpio", "Dma" ] }
+					%#	 Note: Adc has its own prescaler
+	%% set pll =			{'name': "Pll",
+							 'setup': "PllSetup",
+							 'sources': [internalClock,
+										externalClock, externalCrystal] }
+	%% set systemClock =	{'name': "SystemClock",
+							 'minFrequency': "MHz4",
+							 'maxFrequency': "MHz72",
+							 'sources': [ internalClock, externalClock,
+										  externalCrystal, pll ],
+							 'sinks': [ ahb ] }
+	%% set mco1 =			{'name': "ClockOutput",
+							 'divisions': [1],
+							 'sources': [internalClock, externalClock,
+										 externalCrystal, pll, systemClock] }
 %% elif target is stm32f1 or target is stm32f3
 	%% set internalClock =	{'name': "InternalClock",
 							 'fixedFrequency': "MHz16" }

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
@@ -46,8 +46,10 @@
 %% if target is stm32f3
 	// enable clock
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+%%   if target.name != "373"
 	// Remap USB Interrupts
 	SYSCFG->CFGR1 |= SYSCFG_CFGR1_USB_IT_RMP;
+%%   endif
 %% endif
 
 %% if target is stm32f4

--- a/src/xpcc/architecture/platform/driver/fsmc/stm32/fsmc.cpp.in
+++ b/src/xpcc/architecture/platform/driver/fsmc/stm32/fsmc.cpp.in
@@ -1,10 +1,10 @@
 // coding: utf-8
 /* Copyright (c) 2012-2013, Roboterclub Aachen e.V.
-* All Rights Reserved.
-*
-* The file is part of the xpcc library and is released under the 3-clause BSD
-* license. See the file `LICENSE` for the full license governing this code.
-*/
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
 // ----------------------------------------------------------------------------
 
 #include "fsmc.hpp"
@@ -15,6 +15,12 @@
 %% elif target is stm32f1
 %%  set BCRx = "BCRx"
 %%  set BTRx = "BTRx"
+%% endif
+
+%% if target is stm32f4 and (target.name not in ["405", "407", "415", "417"])
+%%   set FMC = "FMC"
+%% else
+%%   set FMC = "FSMC"
 %% endif
 
 // ----------------------------------------------------------------------------
@@ -39,16 +45,16 @@ xpcc::stm32::fsmc::NorSram::resetRegion(Region region)
 	if (region == CHIP_SELECT_1)
 	{
 		// FSMC_Bank1_NORSRAM1
-		FSMC_Bank1->BTCR[region*2] = 0x000030DB;
+		{{ FMC }}_Bank1->BTCR[region*2] = 0x000030DB;
 	}
 	else
 	{
 		// FSMC_Bank1_NORSRAM2,  FSMC_Bank1_NORSRAM3 or FSMC_Bank1_NORSRAM4
-		FSMC_Bank1->BTCR[region*2] = 0x000030D2;
+		{{ FMC }}_Bank1->BTCR[region*2] = 0x000030D2;
 	}
 
-	FSMC_Bank1->BTCR[region*2 + 1] = 0x0FFFFFFF;
-	FSMC_Bank1E->BWTR[region] = 0x0FFFFFFF;
+	{{ FMC }}_Bank1->BTCR[region*2 + 1] = 0x0FFFFFFF;
+	{{ FMC }}_Bank1E->BWTR[region] = 0x0FFFFFFF;
 }
 
 void
@@ -56,18 +62,18 @@ xpcc::stm32::fsmc::NorSram::configureSynchronousRegion(Region region,
 		BusType multiplex, MemoryType memoryType, SynchronousTiming timing)
 {
 	// NOR/PSRAM chip-select control register (BCR)
-	FSMC_Bank1->BTCR[region*2] =
-			FSMC_{{ BCRx }}_CBURSTRW |
-			FSMC_{{ BCRx }}_EXTMOD |	// Enable extended mode, this allows different timings for read and write
-			FSMC_{{ BCRx }}_WREN |	// enable write
-			FSMC_{{ BCRx }}_BURSTEN | // synchronous access
+	{{ FMC }}_Bank1->BTCR[region*2] =
+			{{ FMC }}_{{ BCRx }}_CBURSTRW |
+			{{ FMC }}_{{ BCRx }}_EXTMOD |	// Enable extended mode, this allows different timings for read and write
+			{{ FMC }}_{{ BCRx }}_WREN |	// enable write
+			{{ FMC }}_{{ BCRx }}_BURSTEN | // synchronous access
 			(1 << 7) |			// FWPRLVL (unknown, should be kept at reset level (=1))
 			memoryType |
 			multiplex;
 
 	if (memoryType == NOR) {
 		// Flash access enable
-		FSMC_Bank1->BTCR[region*2] |= FSMC_{{ BCRx }}_FACCEN;
+		{{ FMC }}_Bank1->BTCR[region*2] |= {{ FMC }}_{{ BCRx }}_FACCEN;
 	}
 
 	if (memoryType == PSRAM) {
@@ -89,14 +95,14 @@ xpcc::stm32::fsmc::NorSram::configureSynchronousRegion(Region region,
 	}
 
 	// SRAM/NOR-Flash timing register (BTR) (for read access)
-	FSMC_Bank1->BTCR[region*2 + 1] =
+	{{ FMC }}_Bank1->BTCR[region*2 + 1] =
 			timing.dataLatency << 24 |
 			timing.clockDivideRatio << 20 |
 			timing.busTurnAround << 16;
 
 	// SRAM/NOR-Flash write timing registers (BWTR)
 	// TODO read write timing different?
-	FSMC_Bank1E->BWTR[region] =
+	{{ FMC }}_Bank1E->BWTR[region] =
 			timing.dataLatency << 24 |
 			timing.clockDivideRatio << 20 |
 			timing.busTurnAround << 16;
@@ -112,16 +118,16 @@ xpcc::stm32::fsmc::NorSram::configureAsynchronousRegion(Region region,
 						memoryType == NOR && accessMode == MODE_A)?
 						(1 << 6) : 0;
 	// NOR/PSRAM chip-select control register (BCR)
-	FSMC_Bank1->BTCR[region*2] =
+	{{ FMC }}_Bank1->BTCR[region*2] =
 			static_cast<uint32_t>(extended) |	// Enable extended mode, this allows different timings for read and write
-			FSMC_{{ BCRx }}_WREN |	// enable write
+			{{ FMC }}_{{ BCRx }}_WREN |	// enable write
 			FACCEN |
 			(1 << 7) |			// FWPRLVL (unknown, should be kept at reset level (=1))
 			memoryType |
 			busType;
 
 	// SRAM/NOR-Flash timing register (BTR) (for read access)
-	FSMC_Bank1->BTCR[region*2 + 1] =
+	{{ FMC }}_Bank1->BTCR[region*2 + 1] =
 			accessMode |
 			timing.busTurnAround << 16 |
 			timing.readDataPhase << 8 |
@@ -129,7 +135,7 @@ xpcc::stm32::fsmc::NorSram::configureAsynchronousRegion(Region region,
 			timing.readAddressSetup;
 
 	// SRAM/NOR-Flash write timing registers (BWTR)
-	FSMC_Bank1E->BWTR[region] =
+	{{ FMC }}_Bank1E->BWTR[region] =
 			accessMode |
 			timing.busTurnAround << 16 |
 			timing.writeDataPhase << 8 |

--- a/src/xpcc/architecture/platform/driver/fsmc/stm32/fsmc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/fsmc/stm32/fsmc.hpp.in
@@ -27,6 +27,11 @@
 %%  set BTRx = "BTRx"
 %% endif
 
+%% if target is stm32f4 and (target.name not in ["405", "407", "415", "417"])
+%%   set FMC = "FMC"
+%% else
+%%   set FMC = "FSMC"
+%% endif
 
 namespace xpcc
 {
@@ -124,30 +129,30 @@ namespace xpcc
 				enum BusType
 				{
 					NO_MULTIPLEX_8BIT = 0,
-					NO_MULTIPLEX_16BIT = FSMC_{{ BCRx }}_MWID_0,
-					ADDRESS_DATA_MULIPLEX_8BIT = FSMC_{{ BCRx }}_MUXEN,
-					ADDRESS_DATA_MULIPLEX_16BIT = FSMC_{{ BCRx }}_MUXEN | FSMC_{{ BCRx }}_MWID_0,
+					NO_MULTIPLEX_16BIT = {{ FMC }}_{{ BCRx }}_MWID_0,
+					ADDRESS_DATA_MULIPLEX_8BIT = {{ FMC }}_{{ BCRx }}_MUXEN,
+					ADDRESS_DATA_MULIPLEX_16BIT = {{ FMC }}_{{ BCRx }}_MUXEN | {{ FMC }}_{{ BCRx }}_MWID_0,
 				};
 
 				enum MemoryType
 				{
 					SRAM_ROM = 0,
-					PSRAM = FSMC_{{ BCRx }}_MTYP_0, ///< PSRAM (CRAM)
-					NOR = FSMC_{{ BCRx }}_MTYP_1, ///< NOR Flash/OneNAND Flash
+					PSRAM = {{ FMC }}_{{ BCRx }}_MTYP_0, ///< PSRAM (CRAM)
+					NOR = {{ FMC }}_{{ BCRx }}_MTYP_1, ///< NOR Flash/OneNAND Flash
 				};
 
 				enum AccessMode
 				{
 					MODE_A = 0,	///< access mode A
-					MODE_B = FSMC_{{ BTRx }}_ACCMOD_0, ///< access mode B
-					MODE_C = FSMC_{{ BTRx }}_ACCMOD_1, ///< access mode C
-					MODE_D = FSMC_{{ BTRx }}_ACCMOD_0 | FSMC_{{ BTRx }}_ACCMOD_1 ///< access mode D
+					MODE_B = {{ FMC }}_{{ BTRx }}_ACCMOD_0, ///< access mode B
+					MODE_C = {{ FMC }}_{{ BTRx }}_ACCMOD_1, ///< access mode C
+					MODE_D = {{ FMC }}_{{ BTRx }}_ACCMOD_0 | {{ FMC }}_{{ BTRx }}_ACCMOD_1 ///< access mode D
 				};
 
 				enum class ExtendedMode : uint32_t
 				{
 					Disable = 0,
-					Enable  = FSMC_{{ BCRx }}_EXTMOD,
+					Enable  = {{ FMC }}_{{ BCRx }}_EXTMOD,
 				};
 
 				/**
@@ -197,10 +202,10 @@ namespace xpcc
 				enableRegion(Region region, bool enable = true)
 				{
 					if (enable) {
-						FSMC_Bank1->BTCR[region] |= FSMC_{{ BCRx }}_MBKEN;
+						{{ FMC }}_Bank1->BTCR[region] |= {{ FMC }}_{{ BCRx }}_MBKEN;
 					}
 					else {
-						FSMC_Bank1->BTCR[region] &= ~FSMC_{{ BCRx }}_MBKEN;
+						{{ FMC }}_Bank1->BTCR[region] &= ~{{ FMC }}_{{ BCRx }}_MBKEN;
 					}
 
 				}
@@ -229,11 +234,12 @@ namespace xpcc
 				enableAsynchronousWait(Region region,
 						WaitPolarity polarity = WAIT_LOW_ACTIVE)
 				{
-					uint32_t btcr = FSMC_{{ BCRx }}_ASYNCWAIT;
-					if (polarity != WAIT_LOW_ACTIVE) {
-						btcr |= FSMC_{{ BCRx }}_WAITPOL;
+					uint32_t btcr = {{ FMC }}_{{ BCRx }}_ASYNCWAIT;
+					if (polarity != WAIT_LOW_ACTIVE)
+					{
+						btcr |= {{ FMC }}_{{ BCRx }}_WAITPOL;
 					}
-					FSMC_Bank1->BTCR[region] = btcr;
+					{{ FMC }}_Bank1->BTCR[region] = btcr;
 				}
 
 				/**
@@ -243,7 +249,8 @@ namespace xpcc
 				 */
 				template<typename T>
 				static constexpr inline T*
-				getRegionPointer(Region region) {
+				getRegionPointer(Region region)
+				{
 					return 	(region == CHIP_SELECT_1)? (T *)(0x60000000) :
 							(region == CHIP_SELECT_2)? (T *)(0x64000000) :
 							(region == CHIP_SELECT_3)? (T *)(0x68000000) :
@@ -321,7 +328,7 @@ namespace xpcc
 			enable()
 			{
 %% if target is stm32f2 or target is stm32f4
-				RCC->AHB3ENR |= RCC_AHB3ENR_FSMCEN;
+				RCC->AHB3ENR |= RCC_AHB3ENR_{{ FMC }}EN;
 %% else
 				RCC->AHBENR |= RCC_AHBENR_FSMCEN;
 %% endif
@@ -331,7 +338,7 @@ namespace xpcc
 			disable()
 			{
 %% if target is stm32f2 or target is stm32f4
-				RCC->AHB3ENR &= ~RCC_AHB3ENR_FSMCEN;
+				RCC->AHB3ENR &= ~RCC_AHB3ENR_{{ FMC }}EN;
 %% else
 				RCC->AHBENR &= ~RCC_AHBENR_FSMCEN;
 %% endif

--- a/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
@@ -16,7 +16,7 @@
 #include <xpcc/math/utils/bit_operation.hpp>
 
 %% for instance in gpios | getAdcs
-	%% if target is stm32f3
+	%% if (target is stm32f3 and target.name != "373")
 #include "../../adc/stm32f3/adc_{{instance}}.hpp"
 	%% else
 #include "../../adc/stm32/adc_{{instance}}.hpp"

--- a/src/xpcc/architecture/platform/driver/timer/stm32/advanced_base.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/advanced_base.hpp.in
@@ -62,7 +62,7 @@ public:
 		SetComgOrRisingTrigEdge = TIM_CR2_CCUS
 	};
 
-%% if target is stm32f3 or target is stm32f7
+%% if (target is stm32f3 and target.name != "373") or target is stm32f7
 	enum class MasterMode2 : uint32_t
 	{
 		Reset			= 0,							//0b0000
@@ -136,7 +136,7 @@ public:
 
 	enum class Event : uint32_t
 	{
-%% if target is stm32f3 or target is stm32f7
+%% if (target is stm32f3 and target.name != "373") or target is stm32f7
 		Break2 						= TIM_EGR_B2G,
 %% endif
 		Break 						= TIM_EGR_BG,

--- a/src/xpcc/architecture/platform/driver/timer/stm32/basic.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/basic.cpp.in
@@ -39,9 +39,11 @@ xpcc::stm32::Timer{{ id }}::setMode(Mode mode)
 }
 
 %% if (id == 6) and (target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7)
-	%% set interrupt_vector = "TIM6_DAC_IRQn"
+%%   set interrupt_vector = "TIM6_DAC_IRQn"
+%% elif (id == 18) and (target is stm32f3 and target.name == "373")
+%%   set interrupt_vector = "TIM18_DAC2_IRQn"
 %% else
-	%% set interrupt_vector = "TIM" ~ id ~ "_IRQn"
+%%   set interrupt_vector = "TIM" ~ id ~ "_IRQn"
 %% endif
 void
 xpcc::stm32::Timer{{ id }}::enableInterruptVector(bool enable, uint32_t priority)

--- a/src/xpcc/architecture/platform/driver/timer/stm32/connectors.macros
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/connectors.macros
@@ -11,7 +11,7 @@
 			["Channel1", "Channel1N", "Channel2", "Channel2N",
 			 "Channel3", "Channel3N", "Channel4", "Channel4N",
 			 "ExternalTrigger", "BreakIn"])
-	%% elif id in [2, 3, 4, 5]
+	%% elif id in [2, 3, 4, 5, 19]
 	%# General Purpose Timer
 		%% do connectors.extend(
 			["Channel1", "Channel2", "Channel3", "Channel4", "ExternalTrigger"])

--- a/src/xpcc/architecture/platform/driver/timer/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/driver.xml
@@ -5,10 +5,10 @@
 		<!-- Template: file that needs to be turned into a source file -->
 		<template instances="1,8" out="timer_{{id}}.cpp">advanced.cpp.in</template>
 		<template instances="1,8" out="timer_{{id}}.hpp">advanced.hpp.in</template>
-		<template instances="6,7" out="timer_{{id}}.cpp">basic.cpp.in</template>
-		<template instances="6,7" out="timer_{{id}}.hpp">basic.hpp.in</template>
-		<template instances="2,3,4,5,9,10,11,12,13,14" out="timer_{{id}}.cpp">general_purpose.cpp.in</template>
-		<template instances="2,3,4,5,9,10,11,12,13,14" out="timer_{{id}}.hpp">general_purpose.hpp.in</template>
+		<template instances="6,7,18" out="timer_{{id}}.cpp">basic.cpp.in</template>
+		<template instances="6,7,18" out="timer_{{id}}.hpp">basic.hpp.in</template>
+		<template instances="2,3,4,5,9,10,11,12,13,14,15,16,17,19" out="timer_{{id}}.cpp">general_purpose.cpp.in</template>
+		<template instances="2,3,4,5,9,10,11,12,13,14,15,16,17,19" out="timer_{{id}}.hpp">general_purpose.hpp.in</template>
 		<!-- Static: files that just need to be copied to the generated directory -->
 		<template>type_ids.hpp.in</template>
 		<template>advanced_base.hpp.in</template>

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
@@ -7,25 +7,15 @@
  */
 // ----------------------------------------------------------------------------
 
-%% if id in range(9,12)
-%% set apb = "APB2"
+%% if id in range(9,12) or id in range(15,20)
+%%   set apb = "APB2"
 %% else
-%% set apb = "APB1"
+%%   set apb = "APB1"
 %% endif
 
 %% if target is stm32f3 and target.name == "373"
-%%   if id in range(9,12) or id in range(15,20)
-%%     set apb = "APB2"
-%%   else
-%%     set apb = "APB1"
-%%   endif
 %%   set irq_name = id
 %% else
-%%   if id in range(9,12)
-%%     set apb = "APB2"
-%%   else
-%%     set apb = "APB1"
-%%   endif
 %%   if id == 9
 %%     set irq_name = "1_BRK_TIM9"
 %%   elif id == 10

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
@@ -13,7 +13,7 @@
 %%   set apb = "APB1"
 %% endif
 
-%% if target is stm32f3 and target.name == "373"
+%% if (target is stm32f3 and target.name == "373") or target is stm32f0
 %%   set irq_name = id
 %% else
 %%   if id == 9
@@ -28,6 +28,12 @@
 %%     set irq_name = "8_UP_TIM13"
 %%   elif id == 14 and not target is stm32f0
 %%     set irq_name = "8_TRG_COM_TIM14"
+%%   elif id == 15
+%%     set irq_name = "1_BRK_TIM15"
+%%   elif id == 16
+%%     set irq_name = "1_UP_TIM16"
+%%   elif id == 17
+%%     set irq_name = "1_TRG_COM_TIM17"
 %%   else
 %%     set irq_name = id
 %%   endif

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
@@ -13,20 +13,34 @@
 %% set apb = "APB1"
 %% endif
 
-%% if id == 9
-%% set irq_name = "1_BRK_TIM9"
-%% elif id == 10
-%% set irq_name = "1_UP_TIM10"
-%% elif id == 11
-%% set irq_name = "1_TRG_COM_TIM11"
-%% elif id == 12
-%% set irq_name = "8_BRK_TIM12"
-%% elif id == 13
-%% set irq_name = "8_UP_TIM13"
-%% elif id == 14 and not target is stm32f0
-%% set irq_name = "8_TRG_COM_TIM14"
+%% if target is stm32f3 and target.name == "373"
+%%   if id in range(9,12) or id in range(15,20)
+%%     set apb = "APB2"
+%%   else
+%%     set apb = "APB1"
+%%   endif
+%%   set irq_name = id
 %% else
-%% set irq_name = id
+%%   if id in range(9,12)
+%%     set apb = "APB2"
+%%   else
+%%     set apb = "APB1"
+%%   endif
+%%   if id == 9
+%%     set irq_name = "1_BRK_TIM9"
+%%   elif id == 10
+%%     set irq_name = "1_UP_TIM10"
+%%   elif id == 11
+%%     set irq_name = "1_TRG_COM_TIM11"
+%%   elif id == 12
+%%     set irq_name = "8_BRK_TIM12"
+%%   elif id == 13
+%%     set irq_name = "8_UP_TIM13"
+%%   elif id == 14 and not target is stm32f0
+%%     set irq_name = "8_TRG_COM_TIM14"
+%%   else
+%%     set irq_name = id
+%%   endif
 %% endif
 
 #include <xpcc_config.hpp>

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
@@ -103,7 +103,7 @@ public:
 		Trigger	= TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1,
 		/// Rising edges of the selected trigger (TRGI) clock the counter.
 		ExternalClock = TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0,
-	%% if target is stm32f3 or target is stm32f7 and (id >= 2 and id <= 4)
+	%% if (target is stm32f3 and target.name != "373") or target is stm32f7 and (id >= 2 and id <= 4)
 		/// reinitialize and start counter
 		SLAVE_RESET_TRIGGER	= TIM_SMCR_SMS_3,
 	%% endif

--- a/src/xpcc/architecture/platform/driver/timer/stm32/type_ids.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/type_ids.hpp.in
@@ -17,7 +17,7 @@ namespace stm32
 
 namespace TypeId
 {
-%% for id in [1,2,3,4,5,8,9,10,11,12,13,14,15,16,17]
+%% for id in [1,2,3,4,5,8,9,10,11,12,13,14,15,16,17,18,19]
 	%% set connectors = []
 	%% import 'connectors.macros' as cons with context
 	%% for connector in connectors

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f373_8.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f373_8.ld
@@ -1,0 +1,8 @@
+
+MEMORY
+{
+	ROM (rx)      : ORIGIN = 0x08000000, LENGTH = 64k
+	RAM (rwx)     : ORIGIN = 0x20000000, LENGTH = 16k
+}
+
+INCLUDE stm32_ram.ld

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f373_b.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f373_b.ld
@@ -1,0 +1,8 @@
+
+MEMORY
+{
+	ROM (rx)      : ORIGIN = 0x08000000, LENGTH = 128k
+	RAM (rwx)     : ORIGIN = 0x20000000, LENGTH = 24k
+}
+
+INCLUDE stm32_ram.ld

--- a/src/xpcc/architecture/platform/linker/stm32/stm32f373_c.ld
+++ b/src/xpcc/architecture/platform/linker/stm32/stm32f373_c.ld
@@ -1,0 +1,8 @@
+
+MEMORY
+{
+	ROM (rx)      : ORIGIN = 0x08000000, LENGTH = 256k
+	RAM (rwx)     : ORIGIN = 0x20000000, LENGTH = 32k
+}
+
+INCLUDE stm32_ram.ld


### PR DESCRIPTION
Adds support for the STM32F373 family and with that enables timers >15 for all affected STM32 devices.
Adds the FMC pin definitions for the STM32F427. Renames the FSMC to FMC for the STM32 devices with SDRAM support.
