### PR TITLE
Improve hardfault handler code

### DIFF
--- a/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
+++ b/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
@@ -7,7 +7,7 @@
 		</parameter>
 		<parameter name="enable_gpio" type="bool">true</parameter>
 		<parameter name="vector_table_in_ram" type="bool">false</parameter>
-		<parameter name="main_stack_size" type="int" min="512" max="8192">1856</parameter>
+		<parameter name="main_stack_size" type="int" min="512" max="8192">3040</parameter>
 
 
 		<parameter name="enable_hardfault_handler_log" type="enum" values="false;basic;true">false</parameter>

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -99,6 +99,18 @@ no_debugger:
 	ldr r0, =__process_stack_top		// load the PSP value into register 0
 	mov sp, r0							// write the current stack pointer to the new PSP value
 	mov r0, lr							// restore register 0 from the LR
+
+%% if parameters.enable_hardfault_handler_log == "false"
+	ldr r0, =_initHardFaultHandlerLed
+	blx r0 								// call Led::setOutput();
+loop:
+	ldr r0, =_ZN4xpcc5clock4fcpuE		// load xpcc::clock::fcpu
+1:	subs r0, r0, #5						// subtract 5 from value
+	bpl	1b								// loop while positive
+	ldr r0, =_toggleHardFaultHandlerLed
+	blx r0								// call Led::toggle();
+	b loop								// loop forever
+%% else
 	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
 	 * is not able to push an exception frame onto the main stack!
 	 * So we need to push all registers onto the process stack, since it definitely has space.
@@ -165,6 +177,7 @@ no_debugger:
 	// call the C code handler
 	b _hardFaultHandler
 
+%% endif
 %% endif
 	.size	HardFault_Handler, . - HardFault_Handler
 	.endfunc

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -86,22 +86,50 @@ HardFault_Handler:
 	lsls r0, #31						// test bit 0 by shifting it left 31 times, becoming sign bit
 	mov r0, lr							// restore register 0 before triggering the breakpoint
 	bpl no_debugger						// branch over breakpoint if lsls resulted in positive integer (MSB not set)
+
 	ldr lr, =0xfffffff9					// restore link register for GDB
 	bkpt #42							// trigger a break point, only if a debugger is connected
+
 no_debugger:
 %% endif
 
 %% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
 	b HardFault_Handler					// busy wait in a loop forever
 %% else
+	// Save the current main stack pointer into the PSP register.
 	mov lr, r0							// save register 0 into the link register
 	mov r0, sp							// move SP into r0
 	msr psp, r0							// save SP into the process stack pointer (PSP)
+
+%% if parameters.enable_hardfault_handler_log == "false"
+	/* The LED blinking code consumes at most 32B of stack.
+	 * If there is >32B of space on the main stack, we do not switch the
+	 * stack pointer to the reserved hard fault handler stack.
+	 * This way you can connect the GDB debugger and it recognizes the stack
+	 * frames correctly, even while blinking the LED.
+	 */
+	ldr r0, =__stack_start
+	sub sp, #32							// subtract 32B from the stack pointer
+	cmp sp, r0							// compare: SP - R0 => pos. if space left
+	add sp, #32							// undo the subtraction
+	bpl use_main_stack					// do not switch stack, if there is enough space left
+										// otherwise change SP to hard fault handler stack
+%% endif
 	ldr r0, =__process_stack_top		// load the PSP value into register 0
 	mov sp, r0							// write the current stack pointer to the new PSP value
+
+use_main_stack:
 	mov r0, lr							// restore register 0 from the LR
 
 %% if parameters.enable_hardfault_handler_log == "false"
+	/* This sets up and toggles an LED.
+	 * The actual setup and toggle code is delegated to C++ world,
+	 * so that the xpcc GPIO API can be used.
+	 * This consumes very, very little stack, definitely less than 32B.
+	 *
+	 * This code clobbers R0,R1,R2 & R3, hopefully they were saved on exception entry.
+	 * Note: We are restoring LR to enable GDB stack unwinding.
+	 */
 	ldr r0, =_initHardFaultHandlerLed
 	blx r0 								// call Led::setOutput();
 	ldr r0, =0xfffffff9					// ARMv6 cannot load directly into LR
@@ -115,6 +143,7 @@ loop:
 	ldr r0, =0xfffffff9					// ARMv6 cannot load directly into LR
 	mov lr, r0							// restore link register for GDB
 	b loop								// loop forever
+
 %% else
 	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
 	 * is not able to push an exception frame onto the main stack!

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -80,11 +80,11 @@ HardFault_Handler:
 	 *    `C_DEBUGEN` is sticky! It survives all resets but a power-on reset. This means that after debugging
 	 *    either power cycle the target or manually clear `C_DEBUGEN` using `mww 0xE000EDF0 0xA05F0000`.
 	 */
-	msr psp, r0							// save register 0 into the process stack pointer (PSP)
+	mov lr, r0							// save register 0 into the link register
 	ldr r0, =0xE000EDF0					// Load the address of the Debug Halting Control and Status Register (DHCSR)
 	ldr r0, [r0, #0]					// load the content of DHCSR, we need to check if bit 0 is set
 	lsls r0, #31						// test bit 0 by shifting it left 31 times, becoming sign bit
-	mrs r0, psp							// restore r0 before triggering the breakpoint
+	mov r0, lr							// restore register 0 before triggering the breakpoint
 	bpl no_debugger						// branch over breakpoint if lsls resulted in positive integer (MSB not set)
 	bkpt #42							// trigger a break point, only if a debugger is connected
 no_debugger:
@@ -93,6 +93,12 @@ no_debugger:
 %% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
 	b HardFault_Handler					// busy wait in a loop forever
 %% else
+	mov lr, r0							// save register 0 into the link register
+	mov r0, sp							// move SP into r0
+	msr psp, r0							// save SP into the process stack pointer (PSP)
+	ldr r0, =__process_stack_top		// load the PSP value into register 0
+	mov sp, r0							// write the current stack pointer to the new PSP value
+	mov r0, lr							// restore register 0 from the LR
 	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
 	 * is not able to push an exception frame onto the main stack!
 	 * So we need to push all registers onto the process stack, since it definitely has space.
@@ -109,11 +115,6 @@ no_debugger:
 	 * preserved during hard fault exception entry, however, a more thorough interpretation of the hard fault
 	 * reason and validation of plausibility of these recovered values is done in C code.
 	 */
-	msr psp, r0							// save register 0 into the process stack pointer (PSP)
-	mov lr, sp							// save the main stack pointer into the link register
-	ldr r0, =__process_stack_top		// load the PSP value into register 0
-	mov sp, r0							// write the current stack pointer to the new PSP value
-	mrs r0, psp							// restore register 0 from the PSP
 %% if target is cortex_m0
 	push {r4-r7}				// +4	// push registers r4 through r7 onto the stack, CM0 cannot push r8-r12
 	push {r4-r7}				// +4	// reserve space for r12, lr, pc and psr on the stack
@@ -131,7 +132,7 @@ no_debugger:
 %% endif
 	// prepare the four arguments for the C hard fault handler function
 	mov r0, sp							// load the PSP (the exception stack frame)
-	mov r1, lr							// load the MSP from the link register
+	mrs r1, psp							// load the MSP from the PSP register
 
 	// opportunistically copy LR, PC and PSR from main stack over to the process stack
 	// this doesn't cause a bus fault (which would result in core lockup) since we disabled that behavior.

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -127,14 +127,17 @@ loop:
 	 * preserved during hard fault exception entry, however, a more thorough interpretation of the hard fault
 	 * reason and validation of plausibility of these recovered values is done in C code.
 	 */
-%% if target is cortex_m0
-	push {r4-r7}				// +4	// push registers r4 through r7 onto the stack, CM0 cannot push r8-r12
-	push {r4-r7}				// +4	// reserve space for r12, lr, pc and psr on the stack
-	push {r0-r3}				// +4	// push remaining registers (without the R12 or LR or PC or xPSR) onto the stack
-%% else
-	push {r4-r11}				// +8	// push registers r4 through r11 onto the stack
-	push {r0-r2}				// +3	// reserve space for lr, pc and psr on the stack
-	push {r0-r3,r12}			// +5	// push remaining registers (without the LR or PC or xPSR) onto the stack
+	push {r0-r7}				// +8	// push registers r0 through r7 onto the stack
+	mov r0, r8							// copy the higher registers into the lower ones
+	mov r1, r9							// this is required since the Cortex-M0 cannot
+	mov r2, r10							// push the higher registers onto the stack
+	mov r3, r11
+	mov r4, r12
+	mov r5, lr							// INVALID!
+	mov r6, pc							// INVALID!
+	mrs r7, psr
+	push {r0-r7}				// +8	// push registers r8 through r12, lr, pc, xpsr onto the stack
+%% if target is not cortex_m0
 	mov r9, sp							// buffer the current PSP for later
 	// we now push all valuable information about the bus fault onto the stack
 	// this means loading a range or registers from SCB and preserving them
@@ -149,10 +152,6 @@ loop:
 	// opportunistically copy LR, PC and PSR from main stack over to the process stack
 	// this doesn't cause a bus fault (which would result in core lockup) since we disabled that behavior.
 %% if target is cortex_m0
-	ldr r2, [r1, #16]					// load  R12
-	str r2, [r0, #16]					// store R12
-	ldr r2, [r1, #16]					// load  R12
-	str r2, [r0, #16]					// store R12
 	ldr r2, [r1, #20]					// load  LR
 	str r2, [r0, #20]					// store LR
 	ldr r2, [r1, #24]					// load  PC
@@ -169,13 +168,14 @@ loop:
 %% endif
 
 %% if target is cortex_m0
-	// 12 registers have been pushed onto the stack, => 48 bytes of the process stack have already been used!
+	// 16 registers have been pushed onto the stack, => 64 bytes of the process stack have already been used!
 %% else
 	// 23 registers have been pushed onto the stack, => 92 bytes of the process stack have already been used!
 %% endif
 	dsb
 	// call the C code handler
-	b _hardFaultHandler
+	ldr r2, =_hardFaultHandler
+	bx r2
 
 %% endif
 %% endif

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -145,15 +145,14 @@ loop:
 	b loop								// loop forever
 
 %% else
-	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
-	 * is not able to push an exception frame onto the main stack!
-	 * So we need to push all registers onto the process stack, since it definitely has space.
+	/* We are switching to the reserved hard fault handler stack, and stack
+	 * all 16 CPU registers and 7 fault registers (only on CM3 and up).
 	 *
-	 * To do this, we need to:
-	 *	- buffer the main stack pointer value
-	 *	- write the main stack pointer value to __process_stack_top (a constant)
-	 *	- push the registers r4 through r11 onto the process stack (only r4 -> r7 on CM0)
-	 *  - push the remaining registers as a formatted stack frame onto the process stack (r0-r3,r12,lr,pc,psr)
+	 *  1. push the registers r0 through r7 onto the stack
+	 *  2. load the valid high registers r8-r12 into r0-r4
+	 *  3. push the registers r0 through r7 onto the stack (ie. r8-r15 with 3x placeholder)
+	 * (4. load fault registers into r1-r7)
+	 * (5. push the registers r1 through r7 onto the stack (ie. fault registers))
 	 *
 	 * Unfortunately the original LR, PC and PSR are (obviously) invalidated upon exception entry,
 	 * therefore we do not push these registers onto the stack, but only reserve space for them.
@@ -169,39 +168,32 @@ loop:
 	mov r2, r10							// push the higher registers onto the stack
 	mov r3, r11
 	mov r4, r12
-	mov r5, lr							// INVALID!
-	mov r6, pc							// INVALID!
-	mrs r7, psr
-	push {r0-r7}				// +8	// push registers r8 through r12, lr, pc, xpsr onto the stack
+//	mov r5, lr							// INVALID!
+//	mov r6, pc							// INVALID!
+//	mrs r7, psr							// INVALID!
+	push {r0-r7}				// +8	// push registers r8 through r12, lr, pc, psr onto the stack
+	mov r2, sp							// buffer the current PSP for later
 %% if target is not cortex_m0
-	mov r9, sp							// buffer the current PSP for later
+
 	// we now push all valuable information about the bus fault onto the stack
 	// this means loading a range or registers from SCB and preserving them
 	ldr r0, =0xE000ED24					// load address of SCB->SHCRS register
 	ldm r0, {r1,r2,r3,r4,r5,r6,r7}		// load SHCRS, CFSR, HFSR, DFSR, MMAR, BFAR, AFSR registers
 	push {r1-r7}				// +7	// push them onto the stack
 %% endif
-	// prepare the four arguments for the C hard fault handler function
+
+	// prepare the two arguments for the C hard fault handler function
 	mov r0, sp							// load the PSP (the exception stack frame)
 	mrs r1, psp							// load the MSP from the PSP register
 
 	// opportunistically copy LR, PC and PSR from main stack over to the process stack
 	// this doesn't cause a bus fault (which would result in core lockup) since we disabled that behavior.
-%% if target is cortex_m0
-	ldr r2, [r1, #20]					// load  LR
-	str r2, [r0, #20]					// store LR
-	ldr r2, [r1, #24]					// load  PC
-	str r2, [r0, #24]					// store PC
-	ldr r2, [r1, #28]					// load  PSR
-	str r2, [r0, #28]					// store PSR
-%% else
-	ldr r2, [r1, #20]					// load  LR
-	str r2, [r9, #20]					// store LR
-	ldr r2, [r1, #24]					// load  PC
-	str r2, [r9, #24]					// store PC
-	ldr r2, [r1, #28]					// load  PSR
-	str r2, [r9, #28]					// store PSR
-%% endif
+	ldr r3, [r1, #20]					// load  LR
+	str r3, [r2, #20]					// store LR
+	ldr r3, [r1, #24]					// load  PC
+	str r3, [r2, #24]					// store PC
+	ldr r3, [r1, #28]					// load  PSR
+	str r3, [r2, #28]					// store PSR
 
 %% if target is cortex_m0
 	// 16 registers have been pushed onto the stack, => 64 bytes of the process stack have already been used!
@@ -209,6 +201,7 @@ loop:
 	// 23 registers have been pushed onto the stack, => 92 bytes of the process stack have already been used!
 %% endif
 	dsb
+
 	// call the C code handler
 	ldr r2, =_hardFaultHandler
 	bx r2

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -86,6 +86,7 @@ HardFault_Handler:
 	lsls r0, #31						// test bit 0 by shifting it left 31 times, becoming sign bit
 	mov r0, lr							// restore register 0 before triggering the breakpoint
 	bpl no_debugger						// branch over breakpoint if lsls resulted in positive integer (MSB not set)
+	ldr lr, =0xfffffff9					// restore link register for GDB
 	bkpt #42							// trigger a break point, only if a debugger is connected
 no_debugger:
 %% endif
@@ -103,12 +104,16 @@ no_debugger:
 %% if parameters.enable_hardfault_handler_log == "false"
 	ldr r0, =_initHardFaultHandlerLed
 	blx r0 								// call Led::setOutput();
+	ldr r0, =0xfffffff9					// ARMv6 cannot load directly into LR
+	mov lr, r0							// restore link register for GDB
 loop:
 	ldr r0, =_ZN4xpcc5clock4fcpuE		// load xpcc::clock::fcpu
 1:	subs r0, r0, #5						// subtract 5 from value
 	bpl	1b								// loop while positive
 	ldr r0, =_toggleHardFaultHandlerLed
 	blx r0								// call Led::toggle();
+	ldr r0, =0xfffffff9					// ARMv6 cannot load directly into LR
+	mov lr, r0							// restore link register for GDB
 	b loop								// loop forever
 %% else
 	/* We want to preserve the entire stack frame, since in case of a stack overflow, the exception entry
@@ -126,6 +131,8 @@ loop:
 	 * We opportunistically attempt to recover these register from the main stack frame that might have been
 	 * preserved during hard fault exception entry, however, a more thorough interpretation of the hard fault
 	 * reason and validation of plausibility of these recovered values is done in C code.
+	 *
+	 * Note: By pushing all these registers to the stack, GDB cannot correctly unwind it anymore!
 	 */
 	push {r0-r7}				// +8	// push registers r0 through r7 onto the stack
 	mov r0, r8							// copy the higher registers into the lower ones

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault.sx.in
@@ -45,7 +45,7 @@
 	.func	HardFault_Handler
 HardFault_Handler:
 
-%% if target is stm32
+%% if (target is stm32) and (target is not stm32f0)
 	/* When a hard fault occurs, this handler will move the stack pointer around.
  	 * This makes it harder to debug a hard fault with a real debugger, so if one is connected we would
 	 * like to trigger a software breakpoint before moving the stack pointer.
@@ -69,7 +69,7 @@ HardFault_Handler:
 	 *     On ARMv6-M "access to the DHCSR from software running on the processor is IMPLEMENTATION DEFINED."
 	 *     This means, that on Cortex-M0, it might not be possible to read the DHCSR from software!
 	 *
-	 * STM32F0 implements this access, but LPC11 does not!
+	 * Neither STM32F0 nor LPC11 implement this access!
 	 *
 	 * !!!WARNING:
 	 *     OpenOcd does not reset the `C_DEBUGEN` bit on the `shutdown` command. This might be a bug.

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -71,6 +71,18 @@ void flushUart()
 		}
 	}
 }
+
+const char *valid   = "";
+const char *invalid = " [INVALID]";
+
+extern const uint32_t __stack_start;
+extern const uint32_t __stack_end;
+extern const uint32_t __main_stack_top;
+extern const uint32_t __process_stack_top;
+
+constexpr uint16_t usage_fault_mask = 0x30f;
+constexpr uint8_t    bus_fault_mask = 0xbf;
+constexpr uint8_t    mem_fault_mask = 0xbb;
 %% endif
 
 %% if parameters.enable_hardfault_handler_log == "true" and target is not cortex_m0
@@ -133,17 +145,6 @@ const char *stack_frame_names[] = {
 };
 const char *exception_stack_frame = " ^-- exception stack frame\n";
 %% endif
-const char *valid   = "";
-const char *invalid = " [INVALID]";
-
-extern const uint32_t __stack_start;
-extern const uint32_t __stack_end;
-extern const uint32_t __main_stack_top;
-extern const uint32_t __process_stack_top;
-
-constexpr uint16_t usage_fault_mask = 0x30f;
-constexpr uint8_t    bus_fault_mask = 0xbf;
-constexpr uint8_t    mem_fault_mask = 0xbb;
 
 // ----------------------------------------------------------------------------
 extern "C"

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -166,23 +166,26 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 {
 #undef XPCC_LOG_LEVEL
 #define XPCC_LOG_LEVEL	xpcc::log::ERROR
-%% if target is cortex_m0
-	// original exception stack frame
-	const uint32_t& stacked_r0  = ctx[ 0];
-	const uint32_t& stacked_r1  = ctx[ 1];
-	const uint32_t& stacked_r2  = ctx[ 2];
-	const uint32_t& stacked_r3  = ctx[ 3];
+	// all CPU registers
+	%% if target is cortex_m0
+	const uint32_t& stacked_r8  = ctx[ 0];
+	const uint32_t& stacked_r9  = ctx[ 1];
+	const uint32_t& stacked_r10 = ctx[ 2];
+	const uint32_t& stacked_r11 = ctx[ 3];
 	const uint32_t& stacked_r12 = ctx[ 4];
 	const uint32_t& stacked_lr  = ctx[ 5]; // possibly invalid!
 	const uint32_t& stacked_pc  = ctx[ 6]; // possibly invalid!
 	const uint32_t& stacked_psr = ctx[ 7]; // possibly invalid!
 
-	// all other registers
-	const uint32_t& stacked_r4  = ctx[ 8];
-	const uint32_t& stacked_r5  = ctx[ 9];
-	const uint32_t& stacked_r6  = ctx[10];
-	const uint32_t& stacked_r7  = ctx[11];
-%% else
+	const uint32_t& stacked_r0  = ctx[ 8];
+	const uint32_t& stacked_r1  = ctx[ 9];
+	const uint32_t& stacked_r2  = ctx[10];
+	const uint32_t& stacked_r3  = ctx[11];
+	const uint32_t& stacked_r4  = ctx[12];
+	const uint32_t& stacked_r5  = ctx[13];
+	const uint32_t& stacked_r6  = ctx[14];
+	const uint32_t& stacked_r7  = ctx[15];
+	%% else
 	// all fault registers
 	const uint32_t& shcrs = ctx[ 0];
 	const uint32_t& cfsr  = ctx[ 1];
@@ -192,26 +195,24 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 	const uint32_t& bfar  = ctx[ 5];
 	const uint32_t& afsr  = ctx[ 6];
 
-	// original exception stack frame
-	const uint32_t& stacked_r0  = ctx[ 7];
-	const uint32_t& stacked_r1  = ctx[ 8];
-	const uint32_t& stacked_r2  = ctx[ 9];
-	const uint32_t& stacked_r3  = ctx[10];
+	const uint32_t& stacked_r8  = ctx[ 7];
+	const uint32_t& stacked_r9  = ctx[ 8];
+	const uint32_t& stacked_r10 = ctx[ 9];
+	const uint32_t& stacked_r11 = ctx[10];
 	const uint32_t& stacked_r12 = ctx[11];
 	const uint32_t& stacked_lr  = ctx[12]; // possibly invalid!
 	const uint32_t& stacked_pc  = ctx[13]; // possibly invalid!
 	const uint32_t& stacked_psr = ctx[14]; // possibly invalid!
 
-	// all other registers
-	const uint32_t& stacked_r4  = ctx[15];
-	const uint32_t& stacked_r5  = ctx[16];
-	const uint32_t& stacked_r6  = ctx[17];
-	const uint32_t& stacked_r7  = ctx[18];
-	const uint32_t& stacked_r8  = ctx[19];
-	const uint32_t& stacked_r9  = ctx[20];
-	const uint32_t& stacked_r10 = ctx[21];
-	const uint32_t& stacked_r11 = ctx[22];
-%% endif
+	const uint32_t& stacked_r0  = ctx[15];
+	const uint32_t& stacked_r1  = ctx[16];
+	const uint32_t& stacked_r2  = ctx[17];
+	const uint32_t& stacked_r3  = ctx[18];
+	const uint32_t& stacked_r4  = ctx[19];
+	const uint32_t& stacked_r5  = ctx[20];
+	const uint32_t& stacked_r6  = ctx[21];
+	const uint32_t& stacked_r7  = ctx[22];
+	%% endif
 
 	xpcc::stm32::{{ uart ~ id }}::discardTransmitBuffer();
 
@@ -262,6 +263,8 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 	%% else
 			bool is_stack_execution = (stacked_pc == (uint32_t)&__stack_start);
 			//constexpr bool is_floating_point_active = false;
+			const bool is_stack_overflow = (msp < &__stack_start);
+			constexpr bool is_stack_underflow = false;
 	%% endif
 			XPCC_LOG_ERROR.printf("\n\n\n####  Hard Fault Exception  ####\n\n"); flushUart();
 
@@ -295,21 +298,6 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			XPCC_LOG_ERROR.printf("Main Stack Pointer: 0x%08lx\n", msp + 8); flushUart();
 			XPCC_LOG_ERROR.printf("Maximum Stack Usage: %u Bytes\n", (&__main_stack_top - main_stack_end)*4); flushUart();
 
-	%% if target is cortex_m0
-			XPCC_LOG_ERROR << '\n';
-			XPCC_LOG_ERROR.printf("r0 : 0x%08lx\n", stacked_r0 ); flushUart();
-			XPCC_LOG_ERROR.printf("r1 : 0x%08lx\n", stacked_r1 ); flushUart();
-			XPCC_LOG_ERROR.printf("r2 : 0x%08lx\n", stacked_r2 ); flushUart();
-			XPCC_LOG_ERROR.printf("r3 : 0x%08lx\n", stacked_r3 ); flushUart();
-			XPCC_LOG_ERROR.printf("r4 : 0x%08lx\n", stacked_r4 ); flushUart();
-			XPCC_LOG_ERROR.printf("r5 : 0x%08lx\n", stacked_r5 ); flushUart();
-			XPCC_LOG_ERROR.printf("r6 : 0x%08lx\n", stacked_r6 ); flushUart();
-			XPCC_LOG_ERROR.printf("r7 : 0x%08lx\n", stacked_r7 ); flushUart();
-			XPCC_LOG_ERROR.printf("r12: 0x%08lx\n", stacked_r12); flushUart();
-			XPCC_LOG_ERROR.printf("lr : 0x%08lx\n", stacked_lr ); flushUart();
-			XPCC_LOG_ERROR.printf("pc : 0x%08lx\n", stacked_pc ); flushUart();
-			XPCC_LOG_ERROR.printf("psr: 0x%08lx\n", stacked_psr); flushUart();
-	%% else
 			XPCC_LOG_ERROR << '\n';
 			XPCC_LOG_ERROR.printf("r0 : 0x%08lx   r8  : 0x%08lx\n",   stacked_r0, stacked_r8);  flushUart();
 			XPCC_LOG_ERROR.printf("r1 : 0x%08lx   r9  : 0x%08lx\n",   stacked_r1, stacked_r9);  flushUart();
@@ -320,6 +308,7 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			XPCC_LOG_ERROR.printf("r6 : 0x%08lx   pc  : 0x%08lx%s\n", stacked_r6, stacked_pc,  (is_stack_overflow or is_stack_underflow) ? invalid : valid); flushUart();
 			XPCC_LOG_ERROR.printf("r7 : 0x%08lx   psr : 0x%08lx%s\n", stacked_r7, stacked_psr, (is_stack_overflow or is_stack_underflow) ? invalid : valid); flushUart();
 
+	%% if target is not cortex_m0
 			XPCC_LOG_ERROR << '\n';
 			XPCC_LOG_ERROR.printf("SHCSR : 0x%08lx\n",   shcrs); flushUart();
 			XPCC_LOG_ERROR.printf("CFSR  : 0x%08lx\n",   cfsr);  flushUart();
@@ -328,8 +317,7 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			XPCC_LOG_ERROR.printf("MMAR  : 0x%08lx%s\n", mmar, is_mmar_valid ? valid : invalid); flushUart();
 			XPCC_LOG_ERROR.printf("BFAR  : 0x%08lx%s\n", bfar, is_bfar_valid ? valid : invalid); flushUart();
 			XPCC_LOG_ERROR.printf("AFSR  : 0x%08lx\n",   afsr);  flushUart();
-	%% endif
-	%% if parameters.enable_hardfault_handler_log != "basic" and target is not cortex_m0
+		%% if parameters.enable_hardfault_handler_log != "basic"
 			XPCC_LOG_ERROR << '\n';
 			if (mem_fault)
 			{
@@ -376,10 +364,11 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 				};
 				XPCC_LOG_ERROR << '\n';
 			}
+		%% endif
 	%% endif
 			if (is_stack_execution) { XPCC_LOG_ERROR << "  ### STACK EXECUTION ###\n"; flushUart(); }
-	%% if target is not cortex_m0
 			if (is_stack_overflow)  { XPCC_LOG_ERROR << "  ### STACK OVERFLOW  ###\n"; flushUart(); }
+	%% if target is not cortex_m0
 			if (is_stack_underflow) { XPCC_LOG_ERROR << "  ### STACK UNDERFLOW ###\n"; flushUart(); }
 	%% endif
 		}

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -258,10 +258,10 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			bool is_stack_execution = (cfsr == 0x00010000) and
 									  (stacked_pc == (uint32_t)&__stack_start);
 
-			bool is_floating_point_active = FPU->FPCCR & 1;
+			//bool is_floating_point_active = FPU->FPCCR & 1;
 	%% else
 			bool is_stack_execution = (stacked_pc == (uint32_t)&__stack_start);
-			constexpr bool is_floating_point_active = false;
+			//constexpr bool is_floating_point_active = false;
 	%% endif
 			XPCC_LOG_ERROR.printf("\n\n\n####  Hard Fault Exception  ####\n\n"); flushUart();
 
@@ -277,6 +277,7 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			const uint32_t *main_stack_end = ii;
 
 			// print the entire main stack content and annotate it
+			/*
 			uint32_t *sp = (uint32_t*)&__main_stack_top;
 			for (; sp >= main_stack_end; sp--)
 			{
@@ -290,7 +291,9 @@ extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 				else { XPCC_LOG_ERROR << '\n'; }
 			}
 			if (sp == msp - 1) { XPCC_LOG_ERROR << "                           "; XPCC_LOG_ERROR << exception_stack_frame; }
-			XPCC_LOG_ERROR.printf("\nMaximum Stack Usage: %u Bytes\n", (&__main_stack_top - main_stack_end)*4); flushUart();
+			*/
+			XPCC_LOG_ERROR.printf("Main Stack Pointer: 0x%08lx\n", msp + 8); flushUart();
+			XPCC_LOG_ERROR.printf("Maximum Stack Usage: %u Bytes\n", (&__main_stack_top - main_stack_end)*4); flushUart();
 
 	%% if target is cortex_m0
 			XPCC_LOG_ERROR << '\n';

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -42,6 +42,19 @@
 	%% else
 #include "../../gpio/stm32/gpio.hpp"
 	%% endif
+
+extern "C" void _initHardFaultHandlerLed() __attribute__((optimize("Os")));
+extern "C" void _initHardFaultHandlerLed()
+{
+	xpcc::stm32::Gpio{{ parameters.hardfault_handler_led_port }}{{ parameters.hardfault_handler_led_pin }}::setOutput();
+}
+
+extern "C" void _toggleHardFaultHandlerLed() __attribute__((optimize("Os")));
+extern "C" void _toggleHardFaultHandlerLed()
+{
+	xpcc::stm32::Gpio{{ parameters.hardfault_handler_led_port }}{{ parameters.hardfault_handler_led_pin }}::toggle();
+}
+
 %% endif
 
 %% if parameters.enable_hardfault_handler_log != "false"
@@ -146,16 +159,11 @@ const char *stack_frame_names[] = {
 const char *exception_stack_frame = " ^-- exception stack frame\n";
 %% endif
 
-// ----------------------------------------------------------------------------
-extern "C"
-void
-_hardFaultHandler(const uint32_t *ctx, const uint32_t *msp) __attribute__((noreturn));
-
-extern "C"
-void
-_hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
-{
 %% if parameters.enable_hardfault_handler_log != "false"
+// ----------------------------------------------------------------------------
+extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp) __attribute__((noreturn, optimize("Os")));
+extern "C" void _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
+{
 #undef XPCC_LOG_LEVEL
 #define XPCC_LOG_LEVEL	xpcc::log::ERROR
 %% if target is cortex_m0
@@ -206,32 +214,26 @@ _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 %% endif
 
 	xpcc::stm32::{{ uart ~ id }}::discardTransmitBuffer();
-%% else
-	(void) ctx; (void) msp;	// avoid warnings
-%% endif
 
 	// Infinite loop
-%% if parameters.enable_hardfault_handler_led
+	%% if parameters.enable_hardfault_handler_led
 	volatile uint32_t ledCounter = 1;
-	xpcc::stm32::Gpio{{ parameters.hardfault_handler_led_port }}{{ parameters.hardfault_handler_led_pin }}::setOutput();
-%% endif
+	_initHardFaultHandlerLed();
+	%% endif
 
-%% if parameters.enable_hardfault_handler_log != "false"
 	uint32_t logCounter = 1;
-%% endif
 
 	while(1)
 	{
-%% if parameters.enable_hardfault_handler_led
+	%% if parameters.enable_hardfault_handler_led
 		if (--ledCounter == 0)
 		{
 			ledCounter = xpcc::clock::fcpu / 20;
 
-			xpcc::stm32::Gpio{{ parameters.hardfault_handler_led_port }}{{ parameters.hardfault_handler_led_pin }}::toggle();
+			_toggleHardFaultHandlerLed();
 		}
-%% endif
+	%% endif
 
-%% if parameters.enable_hardfault_handler_log != "false"
 		if (--logCounter == 0)
 		{
 			logCounter = xpcc::clock::fcpu;
@@ -378,6 +380,6 @@ _hardFaultHandler(const uint32_t *ctx, const uint32_t *msp)
 			if (is_stack_underflow) { XPCC_LOG_ERROR << "  ### STACK UNDERFLOW ###\n"; flushUart(); }
 	%% endif
 		}
-%% endif
 	}
 }
+%% endif

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -159,12 +159,15 @@ PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
 PROVIDE(__rom_start = ORIGIN(FLASH));
 PROVIDE(__rom_end   = ORIGIN(FLASH) + LENGTH(FLASH));
 
-/* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
-%% if parameters.enable_hardfault_handler_led or (parameters.enable_hardfault_handler_log != "false")
-PROCESS_STACK_SIZE  = 192;
+%% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
+	%% set pss = 0
+%% elif parameters.enable_hardfault_handler_log == "false"
+	%% set pss = 32
 %% else
-PROCESS_STACK_SIZE  = 0;
+	%% set pss = 512
 %% endif
+/* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
+PROCESS_STACK_SIZE  = {{ pss }};
 /* the handler stack is used for main program as well as interrupts */
 MAIN_STACK_SIZE     = {{ parameters.main_stack_size }};
 /* combined stack size */

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -149,13 +149,16 @@ PROVIDE(__ram_end   = ORIGIN(RAM) + LENGTH(RAM));
 PROVIDE(__rom_start = ORIGIN(FLASH));
 PROVIDE(__rom_end   = ORIGIN(FLASH) + LENGTH(FLASH));
 
-/* Used for interrupt handlers */
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
-%% if parameters.enable_hardfault_handler_led or (parameters.enable_hardfault_handler_log != "false")
-PROCESS_STACK_SIZE  = 192;
+%% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
+	%% set pss = 0
+%% elif parameters.enable_hardfault_handler_log == "false"
+	%% set pss = 32
 %% else
-PROCESS_STACK_SIZE  = 0;
+	%% set pss = 512
 %% endif
+/* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
+PROCESS_STACK_SIZE  = {{ pss }};
 /* the handler stack is used for main program as well as interrupts */
 MAIN_STACK_SIZE     = {{ parameters.main_stack_size }};
 /* combined stack size */

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -168,11 +168,15 @@ PROVIDE(__rom_start = ORIGIN(FLASH));
 PROVIDE(__rom_end   = ORIGIN(FLASH) + LENGTH(FLASH));
 
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
-%% if parameters.enable_hardfault_handler_led or (parameters.enable_hardfault_handler_log != "false")
-PROCESS_STACK_SIZE  = 192;
+%% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
+	%% set pss = 0
+%% elif parameters.enable_hardfault_handler_log == "false"
+	%% set pss = 32
 %% else
-PROCESS_STACK_SIZE  = 0;
+	%% set pss = 512
 %% endif
+/* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
+PROCESS_STACK_SIZE  = {{ pss }};
 /* the handler stack is used for main program as well as interrupts */
 MAIN_STACK_SIZE     = {{ parameters.main_stack_size }};
 /* combined stack size */

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -125,11 +125,15 @@ PROVIDE(__rom_start = ORIGIN(FLASH));
 PROVIDE(__rom_end   = ORIGIN(FLASH) + LENGTH(FLASH));
 
 /* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
-%% if parameters.enable_hardfault_handler_led or (parameters.enable_hardfault_handler_log != "false")
-PROCESS_STACK_SIZE  = 192;
+%% if (not parameters.enable_hardfault_handler_led) and (parameters.enable_hardfault_handler_log == "false")
+	%% set pss = 0
+%% elif parameters.enable_hardfault_handler_log == "false"
+	%% set pss = 32
 %% else
-PROCESS_STACK_SIZE  = 0;
+	%% set pss = 512
 %% endif
+/* the thread stack is used only for reporting hard fault conditions! It may therefore be small. */
+PROCESS_STACK_SIZE  = {{ pss }};
 /* the handler stack is used for main program as well as interrupts, **main stack size must be a multiple of 32!** */
 MAIN_STACK_SIZE     = {{ parameters.main_stack_size }};
 /* combined stack size */


### PR DESCRIPTION
This change modifies the hardfault handler code to remove some bugs and add some features:
- Fix accidental masking of saving R0 in PSP, due to 8B stack alignment mask. This change uses LR to save R0 and saves SP into PSP.
- Remove breakpoint check for STM32F0, since it cannot access the `C_DEBUGEN` bit anyways.
- Use much simpler LED blinking code, which consumes less than 32B of stack.
- When using blinking LED only, switch stack only on stack overflow.
- Allow saving of high registers on ARM Cortex-M0 by moving them to the lower regs before pushing.
- Unifying the register printout for all ARM Cortex-M cores.
- Remove printing of stack, because it is useless information.
- Use better hardfault handler sizes in generated linkerscripts.
- Increase main stack size by ~1kB.

These changes are a great temporary solution until we have integrated [CrashCatcher](https://github.com/adamgreen/CrashCatcher).
This PR is related to #112.

Note: When using the blinking LED option only and no stack overflow occurred, the stack frames are preserved for GDB to unwind them. This means you get a blinking LED _and_ debuggable hardfault all in one!

cc @ekiwi @daniel-k @dergraaf 
