### PR TITLE
[ci] Fix two different example projects build into the same path.

### DIFF
--- a/examples/avr/adc/basic/project.cfg
+++ b/examples/avr/adc/basic/project.cfg
@@ -1,7 +1,7 @@
 [build]
 device = atmega644
 clock = 14745600
-buildpath = ${xpccpath}/build/avr/${name}
+buildpath = ${xpccpath}/build/avr/adc/${name}
 
 [avrdude]
 port = usb

--- a/examples/avr/adc/oversample/project.cfg
+++ b/examples/avr/adc/oversample/project.cfg
@@ -1,7 +1,7 @@
 [build]
 device = atmega644
 clock = 14745600
-buildpath = ${xpccpath}/build/avr/${name}
+buildpath = ${xpccpath}/build/avr/adc/${name}
 
 [avrdude]
 port = usb

--- a/examples/avr/gpio/basic/project.cfg
+++ b/examples/avr/gpio/basic/project.cfg
@@ -1,7 +1,7 @@
 [build]
 device = attiny85
 clock = 8000000
-buildpath = ${xpccpath}/build/avr/${name}
+buildpath = ${xpccpath}/build/avr/gpio/${name}
 
 [avrdude]
 port = usb

--- a/examples/avr/gpio/blinking/project.cfg
+++ b/examples/avr/gpio/blinking/project.cfg
@@ -1,7 +1,7 @@
 [build]
 device = atmega328p
 clock = 1000000
-buildpath = ${xpccpath}/build/avr/${name}
+buildpath = ${xpccpath}/build/avr/gpio/${name}
 
 [avrdude]
 port = usb

--- a/examples/avr/gpio/button_group/project.cfg
+++ b/examples/avr/gpio/button_group/project.cfg
@@ -1,7 +1,7 @@
 [build]
 device = atmega644
 clock = 14745600
-buildpath = ${xpccpath}/build/avr/${name}
+buildpath = ${xpccpath}/build/avr/gpio/${name}
 
 [avrdude]
 port = usb


### PR DESCRIPTION
Fix side effect of f42add1b9a251fb2eeeef06d9494ff221dd1cc6a.
I am not sure why TravisCI did not complain.

Both examples avr/gpio/basic and avr/adc/basic build to the same path: build/avr/basic.

➜  xpcc git:(develop) cat examples/avr/adc/basic/project.cfg | grep buildpath
buildpath = ${xpccpath}/build/avr/${name}

➜  xpcc git:(develop) cat examples/avr/gpio/basic/project.cfg | grep buildpath
buildpath = ${xpccpath}/build/avr/${name}

So when compiling gpio/basic the remainings of adc/basic are still there which include 
generated_platform/driver/i2c/at90_tiny_mega/i2c.hpp
but gpio/basic is a attiny85 which does not have an I2C.

➜  basic git:(develop) scons
scons: Reading SConscript files ...
Warn: 'driver/timer/attiny' implementation for target 'attiny85' does not exist!
scons: done reading SConscript files.
scons: Building targets ...
Compiling C++: /Users/usr/Dev/xpcc/build/avr/basic/main.o
In file included from /Users/usr/Dev/xpcc/build/avr/basic/libxpcc/src/xpcc/architecture/../../../generated_platform/drivers.hpp:59:0,
                 from /Users/usr/Dev/xpcc/build/avr/basic/libxpcc/src/xpcc/architecture/platform.hpp:19,
                 from main.cpp:10:
/Users/usr/Dev/xpcc/build/avr/basic/libxpcc/src/xpcc/architecture/../../../generated_platform/driver/i2c/at90_tiny_mega/i2c.hpp:36:17: error: 'TWPS0' was not declared in this scope
   Div4  = (1 << TWPS0),
                 ^
