### PR TITLE
Add tables to linkerscript for copying and zeroing memory

### DIFF
--- a/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
@@ -89,8 +89,8 @@ void HardFault_Handler(void)			__attribute__ ((weak, alias("defaultHandler")));
 typedef void (* const FunctionPointer)(void);
 
 // defined in the linkerscript
-extern uint32_t __main_stack_top;
-extern uint32_t __process_stack_top;
+extern uint32_t __main_stack_top[];
+extern uint32_t __process_stack_top[];
 
 %% if parameters.vector_table_in_ram
 // reserve space for the remapped vector table in RAM
@@ -101,7 +101,7 @@ FunctionPointer ramVectors[{{number_of_interrupts + 16}}];
 __attribute__(( section(".reset") ))
 FunctionPointer flashVectors[] =
 {
-	(FunctionPointer) &__main_stack_top,	// -16: stack pointer
+	(FunctionPointer)__main_stack_top,		// -16: stack pointer
 	Reset_Handler,							// -15: code entry point
 	NMI_Handler,							// -14: Non Maskable Interrupt handler
 	HardFault_Handler,						// -13: hard fault handler
@@ -120,31 +120,18 @@ FunctionPointer flashVectors[] =
 
 // ----------------------------------------------------------------------------
 // The following are constructs created by the linker, indicating where the
-// the "data" and "bss" segments reside in memory.  The initializers for the
-// for the "data" segment resides immediately following the "text" segment.
-extern uint32_t __stack_start;
-extern uint32_t __stack_end;
+// the "data" and "bss" segments reside in memory.
+extern uint32_t __stack_start[];
+extern uint32_t __stack_end[];
 
-extern uint32_t __fastcode_load;
-extern uint32_t __fastcode_start;
-extern uint32_t __fastcode_end;
+extern uint32_t __table_copy_start[];
+extern uint32_t __table_copy_end[];
 
-extern uint32_t __vector_table_ram_load;
-extern uint32_t __vector_table_ram_start;
-extern uint32_t __vector_table_ram_end;
+extern uint32_t __table_zero_start[];
+extern uint32_t __table_zero_end[];
 
-extern uint32_t __vector_table_rom_start;
-
-extern uint32_t __fastdata_load;
-extern uint32_t __fastdata_start;
-extern uint32_t __fastdata_end;
-
-extern uint32_t __data_load;
-extern uint32_t __data_start;
-extern uint32_t __data_end;
-
-extern uint32_t __bss_start;
-extern uint32_t __bss_end;
+extern uint32_t __vector_table_rom_start[];
+extern uint32_t __vector_table_ram_start[];
 
 // Application's main function
 int
@@ -198,47 +185,32 @@ Reset_Handler(void)
 		"bne   1b"                      "\n\t" // continue loop if not equal
 	);
 
-	uint32_t* src;
-	uint32_t* dest;
-
-%% if parameters.vector_table_in_ram
-	// copy vector table to RAM (.vectors)
-	src = &__vector_table_ram_load;
-	dest = &__vector_table_ram_start;
-	while (dest < &__vector_table_ram_end)
+	// copy all memory declared in linkerscript table
 	{
-		*(dest++) = *(src++);
+		uint32_t **table = (uint32_t**)__table_copy_start;
+		while(table < (uint32_t**)__table_copy_end)
+		{
+			uint32_t *src  = table[0]; // load address
+			uint32_t *dest = table[1]; // destination start
+			while (dest < table[2])    // destination end
+			{
+				*(dest++) = *(src++);
+			}
+			table += 3;
+		}
 	}
-%% endif
-
-	// Copy functions to RAM (.fastcode)
-	src = &__fastcode_load;
-	dest = &__fastcode_start;
-	while (dest < &__fastcode_end)
+	// zero all memory declared in linkerscript table
 	{
-		*(dest++) = *(src++);
-	}
-
-	src = &__fastdata_load;
-	dest = &__fastdata_start;
-	while (dest < &__fastdata_end)
-	{
-		*(dest++) = *(src++);
-	}
-
-	// Copy the data segment initializers from flash to RAM (.data)
-	src = &__data_load;
-	dest = &__data_start;
-	while (dest < &__data_end)
-	{
-		*(dest++) = *(src++);
-	}
-
-	// Fill the bss segment with zero (.bss)
-	dest = &__bss_start;
-	while (dest < &__bss_end)
-	{
-		*(dest++) = 0;
+		uint32_t **table = (uint32_t**)__table_zero_start;
+		while(table < (uint32_t**)__table_zero_end)
+		{
+			uint32_t *dest = table[0]; // destination start
+			while (dest < table[1])    // destination end
+			{
+				*(dest++) = 0;
+			}
+			table += 2;
+		}
 	}
 
 %# Perform Platform Specific Setup
@@ -266,9 +238,9 @@ Reset_Handler(void)
 	// Setup NVIC
 	// Set vector table
 	%% if parameters.vector_table_in_ram
-	SCB->VTOR = (uint32_t)(&__vector_table_ram_start);
+	SCB->VTOR = (uint32_t)(__vector_table_ram_start);
 	%% else
-	SCB->VTOR = (uint32_t)(&__vector_table_rom_start);
+	SCB->VTOR = (uint32_t)(__vector_table_rom_start);
 	%% endif
 	// Enables handlers with priority -1 or -2 to ignore data BusFaults caused by load and store instructions.
 	// This applies to the hard fault, NMI, and FAULTMASK escalated handlers.

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -448,6 +448,33 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	.table.zero :
+	{
+		. = ALIGN(4);
+		__table_zero_start = .;
+		LONG (__bss_start)
+		LONG (__bss_end)
+		__table_zero_end = .;
+	} >FLASH
+
+	.table.copy :
+	{
+		. = ALIGN(4);
+		__table_copy_start = .;
+		LONG (__data_load)
+		LONG (__data_start)
+		LONG (__data_end)
+		LONG (__fastdata_load)
+		LONG (__fastdata_start)
+		LONG (__fastdata_end)
+%% if parameters.vector_table_in_ram
+		LONG (__vector_table_ram_load)
+		LONG (__vector_table_ram_start)
+		LONG (__vector_table_ram_end)
+%% endif
+		__table_copy_end = .;
+	} >FLASH
+
 	. = ALIGN(4);
 	_end = . ;
 	__end = . ;

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -219,7 +219,7 @@ SECTIONS
 
 		. = ALIGN(4);
 		__fastdata_end = .;
-	} >CCM AT>FLASH
+	} >CCM AT >FLASH
 
 %% if parameters.allocator == "tlsf"
 	.heap0 (NOLOAD) :
@@ -386,7 +386,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__data_end = .;
-	} >RAM AT>FLASH
+	} >RAM AT >FLASH
 
 	/* uninitialized variables */
 	.bss (NOLOAD) :

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -259,7 +259,7 @@ SECTIONS
 		 *
 		 * Might be replaced by ELF section groups in newer versions of ld.
 		 */
-		*(.fastcode .text .text.* .gnu.linkonce.t.*)
+		*(.text .text.* .gnu.linkonce.t.*)
 		. = ALIGN (4);
 
 		/* From the Cortex-M3 Technical Reference Manual:
@@ -284,9 +284,8 @@ SECTIONS
 		 *
 		 * So for STM32's where the CCM is _not_ connected to the I-Bus, we execute .fastcode from Flash.
 		 */
-		__fastcode_load = .;
-		__fastcode_start = .;
-		__fastcode_end = .;
+		*(.fastcode)
+		. = ALIGN(4);
 
 		/* Position independent code will call non-static functions via the
 		 * Procedure Linkage Table or PLT. This PLT does not exist in .o files.
@@ -372,7 +371,6 @@ SECTIONS
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 		__exidx_end = .;
 	} >FLASH
-	_etext = .;
 
 	/* initialized variables */
 	.data : ALIGN (8)

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -403,6 +403,36 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	.table.zero :
+	{
+		. = ALIGN(4);
+		__table_zero_start = .;
+		LONG (__bss_start)
+		LONG (__bss_end)
+		__table_zero_end = .;
+	} >FLASH
+
+	.table.copy :
+	{
+		. = ALIGN(4);
+		__table_copy_start = .;
+		LONG (__data_load)
+		LONG (__data_start)
+		LONG (__data_end)
+		LONG (__fastdata_load)
+		LONG (__fastdata_start)
+		LONG (__fastdata_end)
+		LONG (__fastcode_load)
+		LONG (__fastcode_start)
+		LONG (__fastcode_end)
+%% if parameters.vector_table_in_ram
+		LONG (__vector_table_ram_load)
+		LONG (__vector_table_ram_start)
+		LONG (__vector_table_ram_end)
+%% endif
+		__table_copy_end = .;
+	} >FLASH
+
 	. = ALIGN(4);
 	_end = . ;
 	__end = . ;

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -333,7 +333,6 @@ SECTIONS
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 		__exidx_end = .;
 	} >FLASH
-	_etext = .;
 
 	.stack (NOLOAD) :
 	{

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -195,7 +195,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__fastcode_end = .;
-	} >CCM AT>FLASH
+	} >CCM AT >FLASH
 
 	.fastdata :
 	{
@@ -206,7 +206,7 @@ SECTIONS
 
 		. = ALIGN(4);
 		__fastdata_end = .;
-	} >CCM AT>FLASH
+	} >CCM AT >FLASH
 
 %% if parameters.allocator == "tlsf"
 	.heap4 (NOLOAD) :
@@ -363,7 +363,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__data_end = .;
-	} >RAM AT>FLASH
+	} >RAM AT >FLASH
 
 	/* uninitialized variables */
 	.bss (NOLOAD) :

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -377,7 +377,6 @@ SECTIONS
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 		__exidx_end = .;
 	} >FLASH
-	_etext = .;
 
 	/* initialized variables */
 	.data : ALIGN (8)

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -441,6 +441,36 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	.table.zero :
+	{
+		. = ALIGN(4);
+		__table_zero_start = .;
+		LONG (__bss_start)
+		LONG (__bss_end)
+		__table_zero_end = .;
+	} >FLASH
+
+	.table.copy :
+	{
+		. = ALIGN(4);
+		__table_copy_start = .;
+		LONG (__data_load)
+		LONG (__data_start)
+		LONG (__data_end)
+		LONG (__fastdata_load)
+		LONG (__fastdata_start)
+		LONG (__fastdata_end)
+		LONG (__fastcode_load)
+		LONG (__fastcode_start)
+		LONG (__fastcode_end)
+%% if parameters.vector_table_in_ram
+		LONG (__vector_table_ram_load)
+		LONG (__vector_table_ram_start)
+		LONG (__vector_table_ram_end)
+%% endif
+		__table_copy_end = .;
+	} >FLASH
+
 	. = ALIGN(4);
 	_end = . ;
 	__end = . ;

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -213,7 +213,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__fastcode_end = .;
-	} >ITCM AT>FLASH
+	} >ITCM AT >FLASH
 
 %% if parameters.allocator == "tlsf"
 	.heap4 (NOLOAD) :
@@ -250,7 +250,7 @@ SECTIONS
 
 		. = ALIGN(4);
 		__fastdata_end = .;
-	} >DTCM AT>FLASH
+	} >DTCM AT >FLASH
 
 %% if parameters.allocator == "tlsf"
 	.heap0 (NOLOAD) :
@@ -392,7 +392,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__data_end = .;
-	} >RAM AT>FLASH
+	} >RAM AT >FLASH
 
 	/* uninitialized variables */
 	.bss (NOLOAD) :

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -413,6 +413,30 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	.table.zero :
+	{
+		. = ALIGN(4);
+		__table_zero_start = .;
+		LONG (__bss_start)
+		LONG (__bss_end)
+		__table_zero_end = .;
+	} >FLASH
+
+	.table.copy :
+	{
+		. = ALIGN(4);
+		__table_copy_start = .;
+		LONG (__data_load)
+		LONG (__data_start)
+		LONG (__data_end)
+%% if parameters.vector_table_in_ram
+		LONG (__vector_table_ram_load)
+		LONG (__vector_table_ram_start)
+		LONG (__vector_table_ram_end)
+%% endif
+		__table_copy_end = .;
+	} >FLASH
+
 	. = ALIGN(4);
 	_end = . ;
 	__end = . ;

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -356,7 +356,7 @@ SECTIONS
 
 		. = ALIGN (4);
 		__data_end = .;
-	} >RAM AT>FLASH
+	} >RAM AT >FLASH
 
 	/* uninitialized variables */
 	.bss (NOLOAD) :

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -229,7 +229,7 @@ SECTIONS
 		 *
 		 * Might be replaced by ELF section groups in newer versions of ld.
 		 */
-		*(.fastcode .text .text.* .gnu.linkonce.t.*)
+		*(.text .text.* .gnu.linkonce.t.*)
 		. = ALIGN (4);
 
 		/* From the Cortex-M3 Technical Reference Manual:
@@ -254,9 +254,8 @@ SECTIONS
 		 *
 		 * So for STM32's where the CCM is _not_ connected to the I-Bus, we execute .fastcode from Flash.
 		 */
-		__fastcode_load = .;
-		__fastcode_start = .;
-		__fastcode_end = .;
+		*(.fastcode)
+		. = ALIGN (4);
 
 		/* Position independent code will call non-static functions via the
 		 * Procedure Linkage Table or PLT. This PLT does not exist in .o files.
@@ -342,7 +341,6 @@ SECTIONS
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 		__exidx_end = .;
 	} >FLASH
-	_etext = .;
 
 	/* initialized variables */
 	.data : ALIGN (8)
@@ -358,11 +356,6 @@ SECTIONS
 
 		. = ALIGN (4);
 		__data_end = .;
-
-		/* dummy symbols for start-up script */
-		__fastdata_load = .;
-		__fastdata_start = .;
-		__fastdata_end = .;
 	} >RAM AT>FLASH
 
 	/* uninitialized variables */


### PR DESCRIPTION
This change reduces the interface between the startup script and the linkerscript to a table of memory addresses to be copied and zeroed.
This reduces the startup scripts specialization on linker symbols and paves the way towards modifying the linkerscript generically in the future (ie. with external memory for example). 
