### PR TITLE
[bmp085] Fix integer calculation for hosted.

### DIFF
--- a/src/xpcc/driver/pressure/bmp085_impl.hpp
+++ b/src/xpcc/driver/pressure/bmp085_impl.hpp
@@ -113,7 +113,7 @@ xpcc::bmp085::Data::calculateCalibratedTemperature()
 {
 	int32_t x1, x2;
 	uint16_t ut = (uint16_t(raw[0]) << 8) | raw[1];
-	x1 = xpcc::math::mul(ut - calibration.ac6, calibration.ac5) >> 15;
+	x1 = xpcc::math::mul( int16_t(ut - calibration.ac6), int16_t(calibration.ac5)) >> 15;
 	x2 = (int32_t(calibration.mc) << 11) / (x1 + calibration.md);
 	b5 = x1 + x2;
 	calibratedTemperature = int16_t((b5 + 8) >> 4);


### PR DESCRIPTION
Without casting to int16_t the multiplication is incorrect on hosted. ut, ac6 and ac5 are uint16_t.

```
printf("ut  = %d\n", ut);
printf("ac6 = %d\n", calibration.ac6);
printf("ac5 = %d\n", calibration.ac5);
printf("(ut - ac6) = %d\n", (ut - calibration.ac6) );
printf("(       (ut-ac6)  *         (ac5) = %d\n", (ut - calibration.ac6) * (calibration.ac5));
printf("(       (ut-ac6) mul        (ac5) = %d\n", xpcc::math::mul(        (ut - calibration.ac6),        (calibration.ac5)));
printf("(int16_t(ut-ac6) mul int16_t(ac5) = %d\n", xpcc::math::mul( int16_t(ut - calibration.ac6), int16_t(calibration.ac5)));


ut  = 11178
ac6 = 18496
ac5 = 24983
(ut - ac6) = -7318
(       (ut-ac6)  *         (ac5) = -182825594
(       (ut-ac6) mul        (ac5) = 1454460294
(int16_t(ut-ac6) mul int16_t(ac5) = -182825594
```
