### PR TITLE
[ui] Fix line drawing

### DIFF
--- a/src/xpcc/ui/display/buffered_graphic_display_impl.hpp
+++ b/src/xpcc/ui/display/buffered_graphic_display_impl.hpp
@@ -59,7 +59,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawHorizontalLine(
 	if (this->foregroundColor == glcd::Color::black())
 	{
 		const uint8_t mask = 1 << (start.getY() & 0x07);
-		for (uint_fast16_t x = start.getX(); x <= static_cast<uint16_t>(start.getX() + length); ++x) {
+		for (uint_fast16_t x = start.getX(); x < static_cast<uint16_t>(start.getX() + length); ++x) {
 			if( x < Width && y < Height ) {
 				this->buffer[x][y] |= mask;
 			}
@@ -67,7 +67,7 @@ xpcc::BufferedGraphicDisplay<Width, Height>::drawHorizontalLine(
 	}
 	else {
 		const uint8_t mask = ~(1 << (start.getY() & 0x07));
-		for (uint_fast16_t x = start.getX(); x <= static_cast<uint16_t>(start.getX() + length); ++x) {
+		for (uint_fast16_t x = start.getX(); x < static_cast<uint16_t>(start.getX() + length); ++x) {
 			if( x < Width && y < Height ) {
 				this->buffer[x][y] &= mask;
 			}

--- a/src/xpcc/ui/display/graphic_display.cpp
+++ b/src/xpcc/ui/display/graphic_display.cpp
@@ -80,7 +80,7 @@ xpcc::GraphicDisplay::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 		if (y1 > y2) {
 			xpcc::swap(y1, y2);
 		}
-		this->drawVerticalLine(glcd::Point(x1, y1), y2 - y1);
+		this->drawVerticalLine(glcd::Point(x1, y1), y2 - y1 + 1);
 	}
 	else if (y1 == y2)
 	{
@@ -88,7 +88,7 @@ xpcc::GraphicDisplay::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 		if (x1 > x2) {
 			xpcc::swap(x1, x2);
 		}
-		this->drawHorizontalLine(glcd::Point(x1, y1), x2 - x1);
+		this->drawHorizontalLine(glcd::Point(x1, y1), x2 - x1 + 1);
 	}
 	else
 	{
@@ -137,7 +137,7 @@ xpcc::GraphicDisplay::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 void
 xpcc::GraphicDisplay::drawHorizontalLine(glcd::Point start, uint16_t length)
 {
-	for (int_fast16_t i = start.getX(); i <= static_cast<int16_t>(start.getX() + length); ++i) {
+	for (int_fast16_t i = start.getX(); i < static_cast<int16_t>(start.getX() + length); ++i) {
 		(this->*draw)(i, start.getY());
 	}
 }
@@ -145,7 +145,7 @@ xpcc::GraphicDisplay::drawHorizontalLine(glcd::Point start, uint16_t length)
 void
 xpcc::GraphicDisplay::drawVerticalLine(glcd::Point start, uint16_t length)
 {
-	for (int_fast16_t i = start.getY(); i <= static_cast<int16_t>(start.getY() + length); ++i) {
+	for (int_fast16_t i = start.getY(); i < static_cast<int16_t>(start.getY() + length); ++i) {
 		(this->*draw)(start.getX(), i);
 	}
 }


### PR DESCRIPTION
With 5b8f924d947a9cc5d9299171768ac7863bd08b58 I changed how line drawing works, but as I figured out, this breaks at least `drawRectangle`, because it changes the length of lines drawn with `drawHorizontalLine` and `drawVerticalLine` (for length `n` they draw `n+1` pixel length lines, which is in a way correct, if the coordinate points are in the middle of the pixels, but at the same time seems odd).

This commit partly reverts that change, and partly modifies it, so that lines drawn with `drawLine` are still symmetric, but everything else works the old way.
