### PR TITLE
[cortex] Revert default allocator to newlib.

### DIFF
--- a/examples/stm32f469_discovery/tlsf-allocator/project.cfg
+++ b/examples/stm32f469_discovery/tlsf-allocator/project.cfg
@@ -3,4 +3,5 @@ board = stm32f469_discovery
 buildpath = ${xpccpath}/build/stm32f469_discovery/${name}
 
 [parameters]
+core.cortex.0.allocator = tlsf
 uart.stm32.3.tx_buffer = 2048

--- a/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
+++ b/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
@@ -3,7 +3,7 @@
 <rca version="1.0">
 	<driver type="core" name="cortex">
 		<parameter name="allocator" type="enum" values="newlib;block_allocator;tlsf">
-			tlsf
+			newlib
 		</parameter>
 		<parameter name="enable_gpio" type="bool">true</parameter>
 		<parameter name="vector_table_in_ram" type="bool">false</parameter>


### PR DESCRIPTION
The TLSF integration into xpcc is not stable enough.

See #136.
