### PR TITLE
Add NUCLEO-F411RE board and blinky example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ env:
  - TEST_SUITE="check=examples examples=stm32f4_loa_v2b"
  - TEST_SUITE="check=examples examples=stm32f469_discovery"
  - TEST_SUITE="check=examples examples=nucleo_f103rb"
+ - TEST_SUITE="check=examples examples=nucleo_f411re"
  - TEST_SUITE="check=examples examples=unittest"
 
 script: "scons $TEST_SUITE"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Here is a list of supported **and tested** microcontrollers and development boar
 | STM32F103  | [STM32F103 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F303  | [STM32F3 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
 | STM32F407  | [STM32F4 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
+| STM32F411  | [STM32F411 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F429  | [STM32F429 Discovery][] | &#9733;&#9733;&#9733;&#9733;&#9733; |
 | STM32F469  | [STM32F469 Discovery][] | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F746  | [STM32F7 Discovery][]   | &#9733;&#9733;&#9733;&#9733;        |
@@ -218,6 +219,7 @@ Daniel Krebs ([@daniel-k](https://github.com/daniel-k)),
 [STM32F103 Nucleo]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF259875
 [STM32F3 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF254044
 [STM32F4 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF252419
+[STM32F411 Nucleo]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF260320
 [STM32F429 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF259090
 [STM32F469 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
 [STM32F7 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF261641

--- a/examples/nucleo_f411re/blink/SConstruct
+++ b/examples/nucleo_f411re/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/nucleo_f411re/blink/main.cpp
+++ b/examples/nucleo_f411re/blink/main.cpp
@@ -1,0 +1,29 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change XPCC_LOG_LEVEL above to enable or disable these messages
+	XPCC_LOG_DEBUG   << "debug"   << xpcc::endl;
+	XPCC_LOG_INFO    << "info"    << xpcc::endl;
+	XPCC_LOG_WARNING << "warning" << xpcc::endl;
+	XPCC_LOG_ERROR   << "error"   << xpcc::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		LedD13::toggle();
+		xpcc::delayMilliseconds(Button::read() ? 100 : 500);
+
+		XPCC_LOG_INFO << "loop: " << counter++ << xpcc::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f411re/blink/project.cfg
+++ b/examples/nucleo_f411re/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = nucleo_f411re
+buildpath = ${xpccpath}/build/nucleo_f411re/${name}

--- a/src/xpcc/architecture/platform/board/nucleo_f411re/board.cfg
+++ b/src/xpcc/architecture/platform/board/nucleo_f411re/board.cfg
@@ -1,0 +1,11 @@
+[build]
+device = stm32f411re
+
+[parameters]
+uart.stm32.2.tx_buffer = 2048
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = A
+core.cortex.0.hardfault_handler_led_pin = 5
+
+[openocd]
+configfile = board/st_nucleo_f4.cfg

--- a/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.cpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "nucleo_f411re.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);

--- a/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f411re/nucleo_f411re.hpp
@@ -1,0 +1,147 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+//
+// NUCLEO-F411RE
+// Nucleo kit for STM32F411RE
+//
+
+#ifndef XPCC_STM32_NUCLEO_F411RE_HPP
+#define XPCC_STM32_NUCLEO_F411RE_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+#define XPCC_BOARD_HAS_LOGGER
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F411RE running at 96MHz generated from the internal 16MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = 96 * MHz1;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb2;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+	static constexpr uint32_t Spi4   = Apb2;
+	static constexpr uint32_t Spi5   = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+	static constexpr uint32_t I2c3   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableInternalClock();	// 16MHz
+		ClockControl::enablePll(
+			ClockControl::PllSource::InternalClock,
+			4,	// 16MHz / N=4 -> 4MHz
+			96,	// 4MHz * M=96 -> 384MHz
+			4,	// 384MHz / P=4 -> 96MHz = F_cpu
+			8	// 384MHz / Q=8 -> 48MHz = F_usb
+		);
+		// set flash latency for 96MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		// APB1 has max. 50MHz
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = 31; // 3000 / 96 = 31.125 = ~31ns per delay loop
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA4;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+
+using D0  = GpioA3;
+using D1  = GpioA2;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB10;
+using D7  = GpioA8;
+using D8  = GpioA9;
+using D9  = GpioC7;
+using D10 = GpioB6;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+
+using Button = xpcc::GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = xpcc::SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	stlink::Tx::connect(stlink::Uart::Tx);
+	stlink::Rx::connect(stlink::Uart::Rx, Gpio::InputType::PullUp);
+	stlink::Uart::initialize<systemClock, 115200>(12);
+
+	Button::setInput();
+	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	Button::enableExternalInterrupt();
+//	Button::enableExternalInterruptVector(12);
+}
+
+}
+
+#endif	// XPCC_STM32_NUCLEO_F103RB_HPP


### PR DESCRIPTION
This adds support for the NUCLEO-F411RE board with the standard blinky example.
