### PR TITLE
[scons] Add scons qtcreator alias

### DIFF
--- a/scons/SConstruct
+++ b/scons/SConstruct
@@ -54,6 +54,7 @@ program = env.Program(target = env['XPCC_PROJECT_NAME'], source = files.sources)
 env.Alias('size', env.Size(program))
 env.Alias('symbols', env.Symbols(program))
 env.Alias('defines', env.ShowDefines())
+env.Alias('qtcreator', env.QtCreatorProject(files))
 
 if env.CheckArchitecture('hosted'):
     env.Alias('build', program)


### PR DESCRIPTION
This PR adds the _qtcreator_ alias from PR #71 to xpcc's global `SConstruct` file.
