### PR TITLE
[vagrant] Add SHA1 checksum of vagrant box.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,4 +4,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "xpcc"
   config.vm.box_url = "http://box.xpcc.io/xpcc-vm.box"
+  config.vm.box_download_checksum = "7f9fa5dd2039d8c09d78419f79ae771c2e97bbb7"
+  config.vm.box_download_checksum_type = "sha1"
 end


### PR DESCRIPTION
Updates the virtualbox with openocd 0.10.0 and adds usb filters to connect ST-Links automatically.

See #132 and #133.
