### PR TITLE
Add NUCLEO-F303K8 board and blinky example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ env:
  - TEST_SUITE="check=examples examples=stm32f4_loa_v2b"
  - TEST_SUITE="check=examples examples=stm32f469_discovery"
  - TEST_SUITE="check=examples examples=nucleo_f103rb"
+ - TEST_SUITE="check=examples examples=nucleo_f303k8"
  - TEST_SUITE="check=examples examples=nucleo_f411re"
  - TEST_SUITE="check=examples examples=nucleo_f429zi"
  - TEST_SUITE="check=examples examples=unittest"

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Here is a list of supported **and tested** microcontrollers and development boar
 | ATmega328p | [Arduino Uno][]         | &#9733;&#9733;&#9733;               |
 | STM32F072  | [STM32F072 Discovery][] | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F100  | [STM32F1 Discovery][]   | &#9733;&#9733;&#9733;&#9733;        |
-| STM32F103  | [STM32F103 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
+| STM32F103  | [Nucleo F103RB][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F303  | [STM32F3 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
 | STM32F407  | [STM32F4 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
-| STM32F411  | [STM32F411 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
+| STM32F411  | [Nucleo F411RE][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F429  | [STM32F429 Discovery][] | &#9733;&#9733;&#9733;&#9733;&#9733; |
-| STM32F429  | [STM32F429 Nucleo][]    | &#9733;&#9733;&#9733;&#9733;        |
+| STM32F429  | [Nucleo F429ZI][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F469  | [STM32F469 Discovery][] | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F746  | [STM32F7 Discovery][]   | &#9733;&#9733;&#9733;&#9733;        |
 | LPC11C24   | [LPCxpresso][]          | &#9733;&#9733;                      |
@@ -217,12 +217,12 @@ Daniel Krebs ([@daniel-k](https://github.com/daniel-k)),
 [Arduino Uno]: https://www.arduino.cc/en/Main/ArduinoBoardUno
 [STM32F072 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF259724
 [STM32F1 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF250863
-[STM32F103 Nucleo]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF259875
+[Nucleo F103RB]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF259875
 [STM32F3 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF254044
 [STM32F4 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF252419
-[STM32F411 Nucleo]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF260320
+[Nucleo F411RE]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF260320
 [STM32F429 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF259090
-[STM32F429 Nucleo]: http://www.st.com/web/en/catalog/tools/PF262637
+[Nucleo F429ZI]: http://www.st.com/web/en/catalog/tools/PF262637
 [STM32F469 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
 [STM32F7 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF261641
 [LPCxpresso]: https://www.lpcware.com/LPCXpressoV1Boards

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Here is a list of supported **and tested** microcontrollers and development boar
 | STM32F100  | [STM32F1 Discovery][]   | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F103  | [Nucleo F103RB][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F303  | [STM32F3 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
+| STM32F303  | [Nucleo F303K8][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F407  | [STM32F4 Discovery][]   | &#9733;&#9733;&#9733;&#9733;&#9733; |
 | STM32F411  | [Nucleo F411RE][]       | &#9733;&#9733;&#9733;&#9733;        |
 | STM32F429  | [STM32F429 Discovery][] | &#9733;&#9733;&#9733;&#9733;&#9733; |
@@ -219,6 +220,7 @@ Daniel Krebs ([@daniel-k](https://github.com/daniel-k)),
 [STM32F1 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF250863
 [Nucleo F103RB]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF259875
 [STM32F3 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF254044
+[Nucleo F303K8]: http://www.st.com/en/evaluation-tools/nucleo-f303k8.html
 [STM32F4 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF252419
 [Nucleo F411RE]: http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/LN1847/PF260320
 [STM32F429 Discovery]: http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF259090

--- a/examples/nucleo_f303k8/blink/SConstruct
+++ b/examples/nucleo_f303k8/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/nucleo_f303k8/blink/main.cpp
+++ b/examples/nucleo_f303k8/blink/main.cpp
@@ -1,0 +1,29 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change XPCC_LOG_LEVEL above to enable or disable these messages
+	XPCC_LOG_DEBUG   << "debug"   << xpcc::endl;
+	XPCC_LOG_INFO    << "info"    << xpcc::endl;
+	XPCC_LOG_WARNING << "warning" << xpcc::endl;
+	XPCC_LOG_ERROR   << "error"   << xpcc::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		LedD13::toggle();
+		xpcc::delayMilliseconds(Button::read() ? 100 : 500);
+
+		XPCC_LOG_INFO << "loop: " << counter++ << xpcc::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f303k8/blink/project.cfg
+++ b/examples/nucleo_f303k8/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = nucleo_f303k8
+buildpath = ${xpccpath}/build/nucleo_f303k8/${name}

--- a/src/xpcc/architecture/platform/board/nucleo_f303k8/board.cfg
+++ b/src/xpcc/architecture/platform/board/nucleo_f303k8/board.cfg
@@ -1,0 +1,11 @@
+[build]
+device = stm32f303k8
+
+[parameters]
+uart.stm32.2.tx_buffer = 2048
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = B
+core.cortex.0.hardfault_handler_led_pin = 3
+
+[openocd]
+configfile = board/st_nucleo_f3.cfg

--- a/src/xpcc/architecture/platform/board/nucleo_f303k8/nucleo_f303k8.cpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f303k8/nucleo_f303k8.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "nucleo_f303k8.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);

--- a/src/xpcc/architecture/platform/board/nucleo_f303k8/nucleo_f303k8.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f303k8/nucleo_f303k8.hpp
@@ -1,0 +1,132 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+//
+// NUCLEO-F303K8
+// Nucleo kit for STM32F303K8
+//
+
+#ifndef XPCC_STM32_NUCLEO_F303K8_HPP
+#define XPCC_STM32_NUCLEO_F303K8_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+#define XPCC_BOARD_HAS_LOGGER
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F303K8 running at 64MHz generated from the internal 8MHz clock
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = 64 * MHz1;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb2;
+	static constexpr uint32_t Adc2   = Apb2;
+
+	static constexpr uint32_t Can1   = Apb1;
+
+	static constexpr uint32_t Spi1   = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableInternalClock();	// 8MHz
+		// 4MHz * 16 = 64MHz
+		ClockControl::enablePll(ClockControl::PllSource::InternalClock, 16, 2);
+		// set flash latency for 64MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		// APB1 has max. 36MHz
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA3;
+using A3 = GpioA4;
+using A4 = GpioA5;
+using A5 = GpioA6;
+
+using D0  = GpioA10;
+using D1  = GpioA9;
+using D2  = GpioA12;
+using D3  = GpioB0;
+using D4  = GpioB7;
+using D5  = GpioB6;
+using D6  = GpioB1;
+using D7  = GpioF0;
+using D8  = GpioF1;
+using D9  = GpioA8;
+using D10 = GpioA11;
+using D11 = GpioB5;
+using D12 = GpioB4;
+using D13 = GpioB3;
+
+using Button = xpcc::GpioUnused;
+using LedD13 = D13;
+
+using Leds = xpcc::SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA15;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	stlink::Tx::connect(stlink::Uart::Tx);
+	stlink::Rx::connect(stlink::Uart::Rx, Gpio::InputType::PullUp);
+	stlink::Uart::initialize<systemClock, 115200>(12);
+}
+
+}
+
+#endif	// XPCC_STM32_NUCLEO_F303K8_HPP

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_k_r-6_8.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_k_r-6_8.xml
@@ -1,0 +1,357 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<rca version="1.0">
+  <!-- WARNING: This file is generated automatically, do not edit!
+ 		Please modify the xpcc/tools/device_file_generator code instead and rebuild this file.
+ 		Be aware, that regenerated files might have a different composition due to technical reasons. -->
+  <device platform="stm32" family="f3" name="303" pin_id="c|k|r" size_id="6|8">
+    <flash device-size-id="6">32768</flash>
+    <flash device-size-id="8">65536</flash>
+    <ram>16384</ram>
+    <core>cortex-m4f</core>
+    <pin-count device-pin-id="k">32</pin-count>
+    <pin-count device-pin-id="c">48</pin-count>
+    <pin-count device-pin-id="r">64</pin-count>
+    <header>stm32f3xx.h</header>
+    <define>STM32F303x8</define>
+    <driver type="core" name="cortex">
+      <parameter name="vector_table_in_ram">true</parameter>
+      <memory device-size-id="6" access="rx" start="0x8000000" name="flash" size="32"/>
+      <memory device-size-id="8" access="rx" start="0x8000000" name="flash" size="64"/>
+      <memory access="rwx" start="0x10000000" name="ccm" size="4"/>
+      <memory access="rwx" start="0x20000000" name="sram1" size="12"/>
+      <vector position="0" name="WWDG"/>
+      <vector position="1" name="PVD"/>
+      <vector position="2" name="TAMP_STAMP"/>
+      <vector position="3" name="RTC_WKUP"/>
+      <vector position="4" name="FLASH"/>
+      <vector position="5" name="RCC"/>
+      <vector position="6" name="EXTI0"/>
+      <vector position="7" name="EXTI1"/>
+      <vector position="8" name="EXTI2_TSC"/>
+      <vector position="9" name="EXTI3"/>
+      <vector position="10" name="EXTI4"/>
+      <vector position="11" name="DMA1_Channel1"/>
+      <vector position="12" name="DMA1_Channel2"/>
+      <vector position="13" name="DMA1_Channel3"/>
+      <vector position="14" name="DMA1_Channel4"/>
+      <vector position="15" name="DMA1_Channel5"/>
+      <vector position="16" name="DMA1_Channel6"/>
+      <vector position="17" name="DMA1_Channel7"/>
+      <vector position="18" name="ADC1_2"/>
+      <vector position="19" name="CAN_TX"/>
+      <vector position="20" name="CAN_RX0"/>
+      <vector position="21" name="CAN_RX1"/>
+      <vector position="22" name="CAN_SCE"/>
+      <vector position="23" name="EXTI9_5"/>
+      <vector position="24" name="TIM1_BRK_TIM15"/>
+      <vector position="25" name="TIM1_UP_TIM16"/>
+      <vector position="26" name="TIM1_TRG_COM_TIM17"/>
+      <vector position="27" name="TIM1_CC"/>
+      <vector position="28" name="TIM2"/>
+      <vector position="29" name="TIM3"/>
+      <vector position="31" name="I2C1_EV"/>
+      <vector position="32" name="I2C1_ER"/>
+      <vector position="35" name="SPI1"/>
+      <vector position="37" name="USART1"/>
+      <vector position="38" name="USART2"/>
+      <vector position="39" name="USART3"/>
+      <vector position="40" name="EXTI15_10"/>
+      <vector position="41" name="RTC_Alarm"/>
+      <vector position="54" name="TIM6_DAC1"/>
+      <vector position="55" name="TIM7_DAC2"/>
+      <vector position="64" name="COMP2"/>
+      <vector position="65" name="COMP4_6"/>
+      <vector position="81" name="FPU"/>
+    </driver>
+    <driver type="adc" name="stm32f3" instances="1,2"/>
+    <driver type="can" name="stm32" instances="1"/>
+    <driver type="clock" name="stm32"/>
+    <driver type="dma" name="stm32" instances="1"/>
+    <driver type="i2c" name="stm32" instances="1"/>
+    <driver type="id" name="stm32"/>
+    <driver type="spi" name="stm32" instances="1"/>
+    <driver type="spi" name="stm32_uart" instances="1,2"/>
+    <driver device-pin-id="c|r" type="spi" name="stm32_uart" instances="3"/>
+    <driver type="timer" name="stm32" instances="1,2,3,6,7,15,16,17"/>
+    <driver type="uart" name="stm32" instances="1,2"/>
+    <driver device-pin-id="c|r" type="uart" name="stm32" instances="3"/>
+    <driver type="gpio" name="stm32">
+      <gpio port="A" id="0">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="7" peripheral="Uart2" name="Cts" type="in"/>
+        <af peripheral="Adc1" name="Channel1" type="analog"/>
+      </gpio>
+      <gpio port="A" id="1">
+        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="7" peripheral="Uart2" name="De"/>
+        <af id="7" peripheral="Uart2" name="Rts" type="out"/>
+        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af peripheral="Adc1" name="Channel2" type="analog"/>
+      </gpio>
+      <gpio port="A" id="2">
+        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer15" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel3" type="analog"/>
+      </gpio>
+      <gpio port="A" id="3">
+        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer15" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel4" type="analog"/>
+      </gpio>
+      <gpio port="A" id="4">
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Nss"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af peripheral="Adc2" name="Channel1" type="analog"/>
+      </gpio>
+      <gpio port="A" id="5">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af peripheral="Adc2" name="Channel2" type="analog"/>
+      </gpio>
+      <gpio port="A" id="6">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af peripheral="Adc2" name="Channel3" type="analog"/>
+      </gpio>
+      <gpio port="A" id="7">
+        <af id="1" peripheral="Timer17" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af peripheral="Adc2" name="Channel4" type="analog"/>
+      </gpio>
+      <gpio port="A" id="8">
+        <af id="0" peripheral="ClockOutput" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel1"/>
+        <af id="7" peripheral="Uart1" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
+      </gpio>
+      <gpio port="A" id="9">
+        <af id="6" peripheral="Timer1" name="Channel2"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af id="9" peripheral="Timer15" name="BreakIn" type="in"/>
+        <af id="10" peripheral="Timer2" name="Channel3"/>
+      </gpio>
+      <gpio port="A" id="10">
+        <af id="1" peripheral="Timer17" name="BreakIn" type="in"/>
+        <af id="6" peripheral="Timer1" name="Channel3"/>
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="10" peripheral="Timer2" name="Channel4"/>
+      </gpio>
+      <gpio port="A" id="11">
+        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="7" peripheral="Uart1" name="Cts" type="in"/>
+        <af id="9" peripheral="Can1" name="Rx" type="in"/>
+        <af id="11" peripheral="Timer1" name="Channel4"/>
+        <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="A" id="12">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="7" peripheral="Uart1" name="De"/>
+        <af id="7" peripheral="Uart1" name="Rts" type="out"/>
+        <af id="9" peripheral="Can1" name="Tx" type="out"/>
+        <af id="11" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="A" id="13">
+        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af device-pin-id="c|r" id="7" peripheral="Uart3" name="Cts" type="in"/>
+      </gpio>
+      <gpio port="A" id="14">
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="A" id="15">
+        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="5" peripheral="SpiMaster1" name="Nss"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="9" peripheral="Timer1" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="0">
+        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af peripheral="Adc1" name="Channel11" type="analog"/>
+      </gpio>
+      <gpio port="B" id="1">
+        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="6" peripheral="Timer1" name="Channel3N"/>
+        <af peripheral="Adc1" name="Channel12" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="2">
+        <af peripheral="Adc2" name="Channel12" type="analog"/>
+      </gpio>
+      <gpio port="B" id="3">
+        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
+        <af id="7" peripheral="Uart2" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
+        <af id="10" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="B" id="4">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
+        <af id="7" peripheral="Uart2" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
+        <af id="10" peripheral="Timer17" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio port="B" id="5">
+        <af id="1" peripheral="Timer16" name="BreakIn" type="in"/>
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
+        <af id="7" peripheral="Uart2" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
+        <af id="10" peripheral="Timer17" name="Channel1"/>
+      </gpio>
+      <gpio port="B" id="6">
+        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+      </gpio>
+      <gpio port="B" id="7">
+        <af id="1" peripheral="Timer17" name="Channel1N"/>
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af id="10" peripheral="Timer3" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="8">
+        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+        <af id="9" peripheral="Can1" name="Rx" type="in"/>
+        <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="9">
+        <af id="1" peripheral="Timer17" name="Channel1"/>
+        <af id="4" peripheral="I2cMaster1" name="Sda"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+        <af id="9" peripheral="Can1" name="Tx" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="10">
+        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="11">
+        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="12">
+        <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af id="7" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+        <af peripheral="Adc2" name="Channel13" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="13">
+        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="7" peripheral="Uart3" name="Cts" type="in"/>
+        <af peripheral="Adc1" name="Channel13" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="14">
+        <af id="1" peripheral="Timer15" name="Channel1"/>
+        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="7" peripheral="Uart3" name="De"/>
+        <af id="7" peripheral="Uart3" name="Rts" type="out"/>
+        <af peripheral="Adc2" name="Channel14" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="B" id="15">
+        <af id="1" peripheral="Timer15" name="Channel2"/>
+        <af id="2" peripheral="Timer15" name="Channel1N"/>
+        <af id="4" peripheral="Timer1" name="Channel3N"/>
+        <af peripheral="Adc2" name="Channel15" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="0">
+        <af id="2" peripheral="Timer1" name="Channel1"/>
+        <af peripheral="Adc1" name="Channel6" type="analog"/>
+        <af peripheral="Adc2" name="Channel6" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="1">
+        <af id="2" peripheral="Timer1" name="Channel2"/>
+        <af peripheral="Adc1" name="Channel7" type="analog"/>
+        <af peripheral="Adc2" name="Channel7" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="2">
+        <af id="2" peripheral="Timer1" name="Channel3"/>
+        <af peripheral="Adc1" name="Channel8" type="analog"/>
+        <af peripheral="Adc2" name="Channel8" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="3">
+        <af id="2" peripheral="Timer1" name="Channel4"/>
+        <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
+        <af peripheral="Adc1" name="Channel9" type="analog"/>
+        <af peripheral="Adc2" name="Channel9" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="4">
+        <af id="2" peripheral="Timer1" name="ExternalTrigger" type="in"/>
+        <af id="7" peripheral="Uart1" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
+        <af peripheral="Adc2" name="Channel5" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="5">
+        <af id="2" peripheral="Timer15" name="BreakIn" type="in"/>
+        <af id="7" peripheral="Uart1" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
+        <af peripheral="Adc2" name="Channel11" type="analog"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="6">
+        <af id="2" peripheral="Timer3" name="Channel1"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="7">
+        <af id="2" peripheral="Timer3" name="Channel2"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="8">
+        <af id="2" peripheral="Timer3" name="Channel3"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="9">
+        <af id="2" peripheral="Timer3" name="Channel4"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="10">
+        <af id="7" peripheral="Uart3" name="Tx" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="11">
+        <af id="7" peripheral="Uart3" name="Rx" type="in"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
+      </gpio>
+      <gpio device-pin-id="r" port="C" id="12">
+        <af id="7" peripheral="Uart3" name="Ck" type="out"/>
+        <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="C" id="13">
+        <af id="4" peripheral="Timer1" name="Channel1N"/>
+      </gpio>
+      <gpio device-pin-id="c|r" port="C" id="14"/>
+      <gpio device-pin-id="c|r" port="C" id="15"/>
+      <gpio device-pin-id="r" port="D" id="2">
+        <af id="2" peripheral="Timer3" name="ExternalTrigger" type="in"/>
+      </gpio>
+      <gpio port="F" id="0">
+        <af id="6" peripheral="Timer1" name="Channel3N"/>
+      </gpio>
+      <gpio port="F" id="1"/>
+    </driver>
+  </device>
+</rca>

--- a/src/xpcc/architecture/platform/driver/adc/stm32f3/adc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f3/adc.hpp.in
@@ -9,8 +9,13 @@
 %#
 %#
 %% if id == 1
-	%# 11-14 reserved
-	%% set channels = [1,2,3,4,5,6,7,8,9,10,15,16,17,18]
+	%% if target is stm32f3
+		%# 13-14 reserved
+		%% set channels = [1,2,3,4,5,6,7,8,9,10,11,12,15,16,17,18]
+	%% else
+		%# 11-14 reserved
+		%% set channels = [1,2,3,4,5,6,7,8,9,10,15,16,17,18]
+	%% endif
 %% elif id == 2
 	%# 13-16 reserved
 	%% set channels = [1,2,3,4,5,6,7,8,9,10,11,12,17,18]
@@ -343,4 +348,3 @@ ENUM_CLASS_FLAG(Adc{{ id }}::InterruptFlag)
 #include "adc_{{ id }}_impl.hpp"
 
 #endif	// XPCC_STM32F3_ADC{{ id }}_HPP
-

--- a/src/xpcc/architecture/platform/driver/clock/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/driver.xml
@@ -10,7 +10,8 @@
 		<template device-family="f1|f3|f4">static.hpp.in</template>
 		<static device-family="f1|f3|f4">pll_calculator.hpp</static>
 
-		<usbprescaler device-name="042|048|070|072|078|102|103|302|303|373">True</usbprescaler>
+		<usbprescaler device-name="042|048|070|072|078|102|103|302|373">True</usbprescaler>
+		<usbprescaler device-name="303|358|398" device-size-id="b|c|d|e">True</usbprescaler>
 		<pllprediv device-family="f0|f3">True</pllprediv>
 		<pllprediv device-name="100|105|107">True</pllprediv>
 		<hsi48 device-name="042|048|071|072|078|091|098">True</hsi48>

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
@@ -46,7 +46,7 @@
 %% if target is stm32f3
 	// enable clock
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
-%%   if target.name != "373"
+%%   if target.name in ["302"] or (target.name in ["303"] and target.size_id in ["c", "e"])
 	// Remap USB Interrupts
 	SYSCFG->CFGR1 |= SYSCFG_CFGR1_USB_IT_RMP;
 %%   endif

--- a/src/xpcc/architecture/platform/driver/timer/stm32/basic.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/basic.cpp.in
@@ -40,6 +40,8 @@ xpcc::stm32::Timer{{ id }}::setMode(Mode mode)
 
 %% if (id == 6) and (target is stm32f2 or target is stm32f3 or target is stm32f4 or target is stm32f7)
 %%   set interrupt_vector = "TIM6_DAC_IRQn"
+%% elif (id == 7) and ((target.name in ["328", "334"]) or (target.name in ["303"] and target.size_id in ["8"]))
+%%   set interrupt_vector = "TIM7_DAC2_IRQn"
 %% elif (id == 18) and (target is stm32f3 and target.name == "373")
 %%   set interrupt_vector = "TIM18_DAC2_IRQn"
 %% else


### PR DESCRIPTION
Adds tested NUCLEO-F303K8 board target.

We need to find a better way to test board targets, than adding them to the examples.
It's slowing down Travis CI, since it starts a new instance for every example.
