### PR TITLE
Add startup hooks and linkerscript extensions

### DIFF
--- a/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
+++ b/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
@@ -20,6 +20,10 @@
 		<parameter name="free_rtos_support" type="bool">false</parameter>
 		<parameter name="free_rtos_frequency" type="int" min="1000" max="10000">1000</parameter>
 
+		<parameter name="linkerscript_memory" type="string"></parameter>
+		<parameter name="linkerscript_sections" type="string"></parameter>
+		<parameter name="linkerscript_table_zero_extern" type="string"></parameter>
+		<parameter name="linkerscript_table_copy_extern" type="string"></parameter>
 
 		<!-- lpc -->
 		<template device-platform="lpc" out="linkerscript.ld">stm32/stm32_ram.ld.in</template>

--- a/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
@@ -144,6 +144,10 @@ __libc_init_array(void);
 extern void
 exit(int) __attribute__ ((noreturn, weak));
 
+// default implementation is empty and does nothing
+void xpcc_hook_hardware_init(void) __attribute__(( weak ));
+void xpcc_hook_hardware_init(void) {}
+
 %% if parameters.allocator in ["block_allocator", "tlsf"]
 extern void __xpcc_initialize_memory(void);
 %% endif
@@ -274,6 +278,9 @@ Reset_Handler(void)
 	// Enable GPIO Clock
 	xpcc_gpio_enable();
 %% endif
+
+	// Initialize external memories in this hook
+	xpcc_hook_hardware_init();
 
 %% if parameters.allocator in ["block_allocator", "tlsf"]
 	// initialize xpcc block or TLSF allocator

--- a/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/startup.c.in
@@ -124,11 +124,17 @@ FunctionPointer flashVectors[] =
 extern uint32_t __stack_start[];
 extern uint32_t __stack_end[];
 
-extern uint32_t __table_copy_start[];
-extern uint32_t __table_copy_end[];
+extern uint32_t __table_copy_intern_start[];
+extern uint32_t __table_copy_intern_end[];
 
-extern uint32_t __table_zero_start[];
-extern uint32_t __table_zero_end[];
+extern uint32_t __table_zero_intern_start[];
+extern uint32_t __table_zero_intern_end[];
+
+extern uint32_t __table_copy_extern_start[];
+extern uint32_t __table_copy_extern_end[];
+
+extern uint32_t __table_zero_extern_start[];
+extern uint32_t __table_zero_extern_end[];
 
 extern uint32_t __vector_table_rom_start[];
 extern uint32_t __vector_table_ram_start[];
@@ -155,6 +161,35 @@ extern void __xpcc_initialize_memory(void);
 %% if parameters.enable_gpio
 extern void xpcc_gpio_enable(void);
 %% endif
+
+static void
+table_copy(uint32_t **table, uint32_t **end)
+{
+	while(table < end)
+	{
+		uint32_t *src  = table[0]; // load address
+		uint32_t *dest = table[1]; // destination start
+		while (dest < table[2])    // destination end
+		{
+			*(dest++) = *(src++);
+		}
+		table += 3;
+	}
+}
+
+static void
+table_zero(uint32_t **table, uint32_t **end)
+{
+	while(table < end)
+	{
+		uint32_t *dest = table[0]; // destination start
+		while (dest < table[1])    // destination end
+		{
+			*(dest++) = 0;
+		}
+		table += 2;
+	}
+}
 
 // ----------------------------------------------------------------------------
 // This is the code that gets called when the processor first starts execution
@@ -189,36 +224,14 @@ Reset_Handler(void)
 		"bne   1b"                      "\n\t" // continue loop if not equal
 	);
 
-	// copy all memory declared in linkerscript table
-	{
-		uint32_t **table = (uint32_t**)__table_copy_start;
-		while(table < (uint32_t**)__table_copy_end)
-		{
-			uint32_t *src  = table[0]; // load address
-			uint32_t *dest = table[1]; // destination start
-			while (dest < table[2])    // destination end
-			{
-				*(dest++) = *(src++);
-			}
-			table += 3;
-		}
-	}
-	// zero all memory declared in linkerscript table
-	{
-		uint32_t **table = (uint32_t**)__table_zero_start;
-		while(table < (uint32_t**)__table_zero_end)
-		{
-			uint32_t *dest = table[0]; // destination start
-			while (dest < table[1])    // destination end
-			{
-				*(dest++) = 0;
-			}
-			table += 2;
-		}
-	}
-
 %# Perform Platform Specific Setup
 {{ platform.startupCode() }}
+
+	// copy all internal memory declared in linkerscript table
+	table_copy(	(uint32_t**)__table_copy_intern_start,
+				(uint32_t**)__table_copy_intern_end);
+	table_zero(	(uint32_t**)__table_zero_intern_start,
+				(uint32_t**)__table_zero_intern_end);
 
 %% if not (target is cortex_m0 or target is cortex_m7)
 	// Enable Tracing Debug Unit
@@ -281,6 +294,12 @@ Reset_Handler(void)
 
 	// Initialize external memories in this hook
 	xpcc_hook_hardware_init();
+
+	// copy all external memory declared in linkerscript table
+	table_copy(	(uint32_t**)__table_copy_extern_start,
+				(uint32_t**)__table_copy_extern_end);
+	table_zero(	(uint32_t**)__table_zero_extern_start,
+				(uint32_t**)__table_zero_extern_end);
 
 %% if parameters.allocator in ["block_allocator", "tlsf"]
 	// initialize xpcc block or TLSF allocator

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -142,6 +142,7 @@ MEMORY
 	%% endif
 %% endfor
 	RAM (rwx) : ORIGIN = {{ ram_origin[0] }}, LENGTH = {{ ram_sizes | sum }}k
+	{{ parameters.linkerscript_memory }}
 }
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
@@ -446,6 +447,7 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	{{ parameters.linkerscript_sections }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 	.table.zero.intern : ALIGN(4)
@@ -476,12 +478,14 @@ SECTIONS
 	.table.zero.extern : ALIGN(4)
 	{
 		__table_zero_extern_start = .;
+		{{ parameters.linkerscript_table_zero_extern }}
 		__table_zero_extern_end = .;
 	} >FLASH
 
 	.table.copy.extern : ALIGN(4)
 	{
 		__table_copy_extern_start = .;
+		{{ parameters.linkerscript_table_copy_extern }}
 		__table_copy_extern_end = .;
 	} >FLASH
 

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -446,19 +446,19 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
-	.table.zero :
+
+	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
+	.table.zero.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_zero_start = .;
+		__table_zero_intern_start = .;
 		LONG (__bss_start)
 		LONG (__bss_end)
-		__table_zero_end = .;
+		__table_zero_intern_end = .;
 	} >FLASH
 
-	.table.copy :
+	.table.copy.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_copy_start = .;
+		__table_copy_intern_start = .;
 		LONG (__data_load)
 		LONG (__data_start)
 		LONG (__data_end)
@@ -470,7 +470,19 @@ SECTIONS
 		LONG (__vector_table_ram_start)
 		LONG (__vector_table_ram_end)
 %% endif
-		__table_copy_end = .;
+		__table_copy_intern_end = .;
+	} >FLASH
+
+	.table.zero.extern : ALIGN(4)
+	{
+		__table_zero_extern_start = .;
+		__table_zero_extern_end = .;
+	} >FLASH
+
+	.table.copy.extern : ALIGN(4)
+	{
+		__table_copy_extern_start = .;
+		__table_copy_extern_end = .;
 	} >FLASH
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -132,6 +132,7 @@ MEMORY
 	%% endif
 %% endfor
 	RAM (rwx) : ORIGIN = {{ ram_origin[0] }}, LENGTH = {{ ram_sizes | sum }}k
+	{{ parameters.linkerscript_memory }}
 }
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
@@ -402,6 +403,7 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	{{ parameters.linkerscript_sections }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 	.table.zero.intern : ALIGN(4)
@@ -435,12 +437,14 @@ SECTIONS
 	.table.zero.extern : ALIGN(4)
 	{
 		__table_zero_extern_start = .;
+		{{ parameters.linkerscript_table_zero_extern }}
 		__table_zero_extern_end = .;
 	} >FLASH
 
 	.table.copy.extern : ALIGN(4)
 	{
 		__table_copy_extern_start = .;
+		{{ parameters.linkerscript_table_copy_extern }}
 		__table_copy_extern_end = .;
 	} >FLASH
 

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_iccm.ld.in
@@ -402,19 +402,19 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
-	.table.zero :
+
+	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
+	.table.zero.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_zero_start = .;
+		__table_zero_intern_start = .;
 		LONG (__bss_start)
 		LONG (__bss_end)
-		__table_zero_end = .;
+		__table_zero_intern_end = .;
 	} >FLASH
 
-	.table.copy :
+	.table.copy.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_copy_start = .;
+		__table_copy_intern_start = .;
 		LONG (__data_load)
 		LONG (__data_start)
 		LONG (__data_end)
@@ -429,7 +429,19 @@ SECTIONS
 		LONG (__vector_table_ram_start)
 		LONG (__vector_table_ram_end)
 %% endif
-		__table_copy_end = .;
+		__table_copy_intern_end = .;
+	} >FLASH
+
+	.table.zero.extern : ALIGN(4)
+	{
+		__table_zero_extern_start = .;
+		__table_zero_extern_end = .;
+	} >FLASH
+
+	.table.copy.extern : ALIGN(4)
+	{
+		__table_copy_extern_start = .;
+		__table_copy_extern_end = .;
 	} >FLASH
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -440,19 +440,19 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
-	.table.zero :
+
+	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
+	.table.zero.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_zero_start = .;
+		__table_zero_intern_start = .;
 		LONG (__bss_start)
 		LONG (__bss_end)
-		__table_zero_end = .;
+		__table_zero_intern_end = .;
 	} >FLASH
 
-	.table.copy :
+	.table.copy.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_copy_start = .;
+		__table_copy_intern_start = .;
 		LONG (__data_load)
 		LONG (__data_start)
 		LONG (__data_end)
@@ -467,7 +467,19 @@ SECTIONS
 		LONG (__vector_table_ram_start)
 		LONG (__vector_table_ram_end)
 %% endif
-		__table_copy_end = .;
+		__table_copy_intern_end = .;
+	} >FLASH
+
+	.table.zero.extern : ALIGN(4)
+	{
+		__table_zero_extern_start = .;
+		__table_zero_extern_end = .;
+	} >FLASH
+
+	.table.copy.extern : ALIGN(4)
+	{
+		__table_copy_extern_start = .;
+		__table_copy_extern_end = .;
 	} >FLASH
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -150,6 +150,7 @@ MEMORY
 	%% endif
 %% endfor
 	RAM (rwx) : ORIGIN = {{ ram_origin[0] }}, LENGTH = {{ ram_sizes | sum }}k
+	{{ parameters.linkerscript_memory }}
 }
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
@@ -440,6 +441,7 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	{{ parameters.linkerscript_sections }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 	.table.zero.intern : ALIGN(4)
@@ -473,12 +475,14 @@ SECTIONS
 	.table.zero.extern : ALIGN(4)
 	{
 		__table_zero_extern_start = .;
+		{{ parameters.linkerscript_table_zero_extern }}
 		__table_zero_extern_end = .;
 	} >FLASH
 
 	.table.copy.extern : ALIGN(4)
 	{
 		__table_copy_extern_start = .;
+		{{ parameters.linkerscript_table_copy_extern }}
 		__table_copy_extern_end = .;
 	} >FLASH
 

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -406,19 +406,19 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
-	.table.zero :
+
+	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
+	.table.zero.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_zero_start = .;
+		__table_zero_intern_start = .;
 		LONG (__bss_start)
 		LONG (__bss_end)
-		__table_zero_end = .;
+		__table_zero_intern_end = .;
 	} >FLASH
 
-	.table.copy :
+	.table.copy.intern : ALIGN(4)
 	{
-		. = ALIGN(4);
-		__table_copy_start = .;
+		__table_copy_intern_start = .;
 		LONG (__data_load)
 		LONG (__data_start)
 		LONG (__data_end)
@@ -427,7 +427,19 @@ SECTIONS
 		LONG (__vector_table_ram_start)
 		LONG (__vector_table_ram_end)
 %% endif
-		__table_copy_end = .;
+		__table_copy_intern_end = .;
+	} >FLASH
+
+	.table.zero.extern : ALIGN(4)
+	{
+		__table_zero_extern_start = .;
+		__table_zero_extern_end = .;
+	} >FLASH
+
+	.table.copy.extern : ALIGN(4)
+	{
+		__table_copy_extern_start = .;
+		__table_copy_extern_end = .;
 	} >FLASH
 
 	. = ALIGN(4);

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_ram.ld.in
@@ -107,6 +107,7 @@ MEMORY
 	%% endif
 %% endfor
 	RAM (rwx) : ORIGIN = {{ ram_origin[0] }}, LENGTH = {{ ram_sizes | sum }}k
+	{{ parameters.linkerscript_memory }}
 }
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
@@ -406,6 +407,7 @@ SECTIONS
 		PROVIDE (__heap_end = .);
 	} >RAM
 
+	{{ parameters.linkerscript_sections }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 	.table.zero.intern : ALIGN(4)
@@ -433,12 +435,14 @@ SECTIONS
 	.table.zero.extern : ALIGN(4)
 	{
 		__table_zero_extern_start = .;
+		{{ parameters.linkerscript_table_zero_extern }}
 		__table_zero_extern_end = .;
 	} >FLASH
 
 	.table.copy.extern : ALIGN(4)
 	{
 		__table_copy_extern_start = .;
+		{{ parameters.linkerscript_table_copy_extern }}
 		__table_copy_extern_end = .;
 	} >FLASH
 

--- a/tools/device_files/driver.py
+++ b/tools/device_files/driver.py
@@ -281,7 +281,7 @@ class Parameter:
 	This represents a Parameter that can be specified in a
 	XML Driver File
 	"""
-	TYPES = ['int', 'bool', 'enum']
+	TYPES = ['int', 'bool', 'enum', 'string']
 
 	def __init__(self, node, logger=None):
 		if logger == None:
@@ -326,9 +326,9 @@ class Parameter:
 			sub_dict['parameters'][self.name] = value
 
 	def evaluateValue(self, value):
-		if isinstance(value, basestring):
-			value = value.strip(' \t\n\r')
 		if self.type == 'int':
+			if isinstance(value, basestring):
+				value = value.strip(' \t\n\r')
 			if isinstance(value, basestring) and not value.isdigit():
 				self.log.error("Invalid value '%s' for %s. The value is not a number!"
 					% (value, self.name))
@@ -344,6 +344,8 @@ class Parameter:
 				return None
 			return value
 		elif self.type == 'bool':
+			if isinstance(value, basestring):
+				value = value.strip(' \t\n\r')
 			if isinstance(value, bool):
 				return value
 			if value.lower() == 'true' or value == '1':
@@ -353,12 +355,16 @@ class Parameter:
 			self.log.error("Invalid value '%s' for %s." % (value, self.name))
 			return None
 		elif self.type == 'enum':
+			if isinstance(value, basestring):
+				value = value.strip(' \t\n\r')
 			if value in self.values:
 				return value
 			else:
 				self.log.error("Invalid value '%s' for %s. Valid values are: %s"
 					% (value, self.name, self.values))
 				return None
+		elif self.type == 'string':
+			return value
 		return None
 
 	def _evaluate(self):
@@ -380,6 +386,8 @@ class Parameter:
 				return False
 			else:
 				self.values = self.values.split(';')
+		elif self.type == 'string':
+			pass
 		if self.instances != None:
 			self.instances = self.instances.split('|')
 		if self.default != None:


### PR DESCRIPTION
This adds two hooks to the startup script:
- `xpcc_hook_hardware_init()` to initialize hardware such as external SDRAM, and
- ~~`xpcc_hook_software_init()` to initialize the board before the main function.~~

The `hardware_init()` hook is called after the zero/copy of all internal memories and ARM Cortex-M initialization, but before zero/copy of all external memories, dynamic allocator init and libc_init.
It is therefore possible to place static data or bss regions into external SDRAM and have them initialize correctly.
~~The `software_init()` is called right before the main function and is primarily destined for initializing the board, so that the user does not have to.~~

The linkerscript can be extended using the parameter system, and arbitrary sections can be added for example in the `board.cfg`. See [this WIP for an example use case](https://github.com/salkinium/xpcc/commit/40897724562e0b1984bbe6019bc2e101def3b2d7#diff-68bd7e151b08f056fde5035d2f42bf72R11).

cc @ekiwi: See the addition of `string` as a parameter type, which includes `\t\n\r`. Are you ok with this?
