### PR TITLE
Add external SDRAM to F469 board

### DIFF
--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/board.cfg
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/board.cfg
@@ -3,9 +3,49 @@ device = stm32f469nih6
 
 [parameters]
 uart.stm32.3.tx_buffer = 2048
+
 core.cortex.0.enable_hardfault_handler_led = true
 core.cortex.0.hardfault_handler_led_port = K
 core.cortex.0.hardfault_handler_led_pin = 3
+
+core.cortex.0.linkerscript_memory =
+	SDRAM (rwx) : ORIGIN = 0xC0000000, LENGTH = 16M
+
+core.cortex.0.linkerscript_sections =
+	.sdramdata :
+	{
+		__sdramdata_load = LOADADDR (.sdramdata);	/* address in FLASH */
+		__sdramdata_start = .;						/* address in RAM */
+
+		KEEP(*(.sdramdata))
+
+		. = ALIGN(4);
+		__sdramdata_end = .;
+	} >SDRAM AT >FLASH
+
+	.heap_extern (NOLOAD) : ALIGN(4)
+	{
+		__heap_extern_start = .;
+		. = ORIGIN(SDRAM) + LENGTH(SDRAM);
+		__heap_extern_end = .;
+	} >SDRAM
+
+core.cortex.0.linkerscript_table_copy_extern =
+	LONG (__sdramdata_load)
+	LONG (__sdramdata_start)
+	LONG (__sdramdata_end)
+
+core.cortex.0.linkerscript_table_heap_extern =
+	LONG (0x801f)
+	LONG (__heap_extern_start)
+	LONG (__heap_extern_end)
+
+# Enable TLSF allocator, which can deal with non-continous heap
+core.cortex.0.allocator = tlsf
+
+[defines]
+# 2^24 = 16MB for external SDRAM
+XPCC_TLFS_FL_INDEX_MAX = 24
 
 [openocd]
 configfile = board/stm32f469discovery.cfg

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
@@ -1,5 +1,5 @@
 // coding: utf-8
-/* Copyright (c) 2015, Roboterclub Aachen e.V.
+/* Copyright (c) 2015-2016, Roboterclub Aachen e.V.
 * All Rights Reserved.
 *
 * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -14,6 +14,7 @@
 //
 
 #include "stm32f469_discovery.hpp"
+#include <xpcc/utils/bit_constants.hpp>
 
 // Create an IODeviceWrapper around the Uart Peripheral we want to use
 xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
@@ -23,3 +24,150 @@ xpcc::log::Logger xpcc::log::debug(loggerDevice);
 xpcc::log::Logger xpcc::log::info(loggerDevice);
 xpcc::log::Logger xpcc::log::warning(loggerDevice);
 xpcc::log::Logger xpcc::log::error(loggerDevice);
+
+extern "C" void
+xpcc_hook_hardware_init(void);
+
+void
+xpcc_hook_hardware_init(void)
+{
+	// initialize system clock and external SDRAM before accessing external memories
+	Board::systemClock::enable();
+	Board::initializeSdram();
+}
+
+
+static void
+sdram_configure_gpio(GPIO_TypeDef * const port, const uint16_t mask)
+{
+	// For all GPIOs:
+	// - Pull-Up
+	// - Fast Speed
+	// - Alternate Function 12
+	// => MODER = 0b10
+	// => OTYPER = 0b0
+	// => OSPEEDR = 0b11
+	// => PUPDR = 0b01
+	// => AFR = 0b1100
+
+	// compute the 0b11 and 0b1111 spreads
+	uint32_t portMask2 = 0;
+	uint32_t portMask4[2] = {0,0};
+	for (int ii = 0; ii < 16; ii++) {
+		if (mask & (1 << ii)) {
+			portMask2 |= (0b11 << (ii * 2));
+			if (ii < 8) {
+				portMask4[0] |= (0b1111 << (ii * 4));
+			} else {
+				portMask4[1] |= (0b1111 << ((ii - 8) * 4));
+			}
+		}
+	}
+	// mask to get the actual bit masks
+	const uint32_t port01 = 0x55555555 & portMask2;
+	const uint32_t port10 = 0xAAAAAAAA & portMask2;
+	const uint32_t port1100L = 0xCCCCCCCC & portMask4[0];
+	const uint32_t port1100H = 0xCCCCCCCC & portMask4[1];
+
+	port->AFR[0]  = port1100L;
+	port->AFR[1]  = port1100H;
+	port->OSPEEDR = port10 | port01;
+	port->PUPDR   = port01;
+	port->MODER   = port10;
+	port->OTYPER &= ~mask;
+
+	// We lock the corresponding GPIO pins, so that users do not shoot
+	// themselves in their feet, if they accidentally use SDRAM GPIOs.
+	port->LCKR = 0x10000 | mask;
+	port->LCKR = 0x00000 | mask;
+	port->LCKR = 0x10000 | mask;
+	(void) port->LCKR;
+}
+
+static bool
+sdram_send_command(uint8_t mode, uint8_t auto_refresh = 1, uint16_t mode_register = 0)
+{
+	FMC_Bank5_6->SDCMR =	((uint32_t(mode_register) << 9) & FMC_SDCMR_MRD) |
+							(((uint32_t(auto_refresh) - 1) << 5) & FMC_SDCMR_NRFS) |
+							FMC_SDCMR_CTB1 | (mode & FMC_SDCMR_MODE);
+	uint16_t timeout = 10000;
+	while ((FMC_Bank5_6->SDSR & FMC_SDSR_BUSY) and timeout)
+	{
+		timeout--;
+		xpcc::delayMicroseconds(100);
+	}
+
+	return timeout;
+}
+
+void
+Board::initializeSdram()
+{
+	using namespace xpcc;
+	// Strongly inspired by the F469I-DISCO BSP from ST
+
+	// Configure all pins
+	// C0
+	sdram_configure_gpio(GPIOC, Bit0);
+	// D0, D1, D8, D9, D10, D14, D15
+	sdram_configure_gpio(GPIOD, Bit0 | Bit1 | Bit8 | Bit9 | Bit10 | Bit14 | Bit15);
+	// E0, E1, E7, E8, E9, E10, E11, E12, E13, E14, E15
+	sdram_configure_gpio(GPIOE, Bit0 | Bit1 | Bit7 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// F0, F1, F2, F3, F4, F5, F11, F12, F13, F14, F15
+	sdram_configure_gpio(GPIOF, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// G0, G1, G4, G5, G8, G15
+	sdram_configure_gpio(GPIOG, Bit0 | Bit1 | Bit4 | Bit5 | Bit8 | Bit15);
+	// H2, H3, H8, H9, H10, H11, H12, H13, H14, H15
+	sdram_configure_gpio(GPIOH, Bit2 | Bit3 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// I0, I1, I2, I3, I4, I5, I6, I7, I9, I10
+	sdram_configure_gpio(GPIOI, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit6 | Bit7 | Bit9 | Bit10);
+
+	// Configure the SDRAM
+	// Enable FMC clock
+	RCC->AHB3ENR |= RCC_AHB3ENR_FMCEN;
+	(void) RCC->AHB3ENR;
+
+	/* SDRAM Control register (only bank 1 is used):
+	 * - RPIPE: 0b00 (0 cycle delay)
+	 * - RBURST: 0b1 (enabled)
+	 * - SDCLK: 0b10 (2x HCLK periods)
+	 * - WP: 0x0 (disabled)
+	 * - CAS: 0x11 (3 cycles)
+	 * - NB: 0b1 (4 internal banks)
+	 * - MWID: 0b10 (32bit data bus width)
+	 * - NR: 0b01 (12 bit)
+	 * - NC: 0b00 (8 bit)
+	 */
+	FMC_Bank5_6->SDCR[0] =  FMC_SDCR1_RBURST | FMC_SDCR1_SDCLK_1 | FMC_SDCR1_NB | FMC_SDCR1_NR_0 |
+							FMC_SDCR1_MWID_1 | FMC_SDCR1_CAS_1 | FMC_SDCR1_CAS_0;
+
+	/* SDRAM Timing register (for 90 MHz as SD clock frequency)
+	 * - TRCD: 0b0001 (2 cycles)
+	 * - TRP:  0b0001 (2 cycles)
+	 * - TWR:  0b0001 (2 cycles)
+	 * - TRC:  0b0110 (7 cycles)
+	 * - TRAS: 0b0011 (4 cycles)
+	 * - TXSR: 0b0110 (7 cycles)
+	 * - TMRD: 0b0001 (2 cycles)
+	 */
+	FMC_Bank5_6->SDTR[0] = 0x01116361;
+
+	// FMC_SDRAM_CMD_CLK_ENABLE
+	sdram_send_command(1);
+	xpcc::delayMilliseconds(1);
+	// FMC_SDRAM_CMD_PALL
+	sdram_send_command(2);
+	// FMC_SDRAM_CMD_AUTOREFRESH_MODE
+	sdram_send_command(3, 8);
+	/* FMC_SDRAM_CMD_LOAD_MODE:
+	 * - SDRAM_MODEREG_BURST_LENGTH_1
+	 * - SDRAM_MODEREG_BURST_TYPE_SEQUENTIAL
+	 * - SDRAM_MODEREG_CAS_LATENCY_3
+	 * - SDRAM_MODEREG_OPERATING_MODE_STANDARD
+	 * - SDRAM_MODEREG_WRITEBURST_MODE_SINGLE
+	 */
+	sdram_send_command(4, 1, 0x230);
+
+	// Set refresh rate:
+	FMC_Bank5_6->SDRTR = (0x0569 << 1);
+}

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
@@ -143,75 +143,16 @@ using Rx = GpioInputB11;		// STLK_TX [STLINK V2-1_U2_TX]: USART3_RX
 using Uart = Usart3;
 }
 
-namespace fmc
-{
-using Sdcke  = GpioOutputH2;	// SDCKE0 [MT48LC4M32B2B5-6A_CKE]: FMC_SDCKE0
-using Sdclk  = GpioOutputG8;	// SDCLK [MT48LC4M32B2B5-6A_CLK]: FMC_SDCLK
-using Sdncas = GpioOutputG15;	// SDNCAS [MT48LC4M32B2B5-6A_CAS]: FMC_SDNCAS
-using Sdnras = GpioOutputF11;	// SDNRAS [MT48LC4M32B2B5-6A_RAS]: FMC_SDNRAS
-using Sdnwe  = GpioOutputC0;	// SDNWE [MT48LC4M32B2B5-6A_WE]: FMC_SDNWE
-using Sdne   = GpioOutputH3;	// SDNE0 [MT48LC4M32B2B5-6A_CS]: FMC_SDNE0
-
-using Dqm0 = GpioOutputE0;		// FMC_NBL0 [MT48LC4M32B2B5-6A_DQM0]: FMC_NBL0
-using Dqm1 = GpioOutputE1;		// FMC_NBL1 [MT48LC4M32B2B5-6A_DQM1]: FMC_NBL1
-using Dqm2 = GpioOutputI4;		// FMC_NBL2 [MT48LC4M32B2B5-6A_DQM2]: FMC_NBL2
-using Dqm3 = GpioOutputI5;		// FMC_NBL3 [MT48LC4M32B2B5-6A_DQM3]: FMC_NBL3
-
-using Ba0 = GpioOutputG4;		// FMC_A14_BA0: FMC_A14_BA0
-using Ba1 = GpioOutputG5;		// FMC_A15_BA1: FMC_A15_BA1
-
-using A0  = GpioOutputF0;		// A0: FMC_A0
-using A1  = GpioOutputF1;		// A1: FMC_A1
-using A2  = GpioOutputF2;		// A2: FMC_A2
-using A3  = GpioOutputF3;		// A3: FMC_A3
-using A4  = GpioOutputF4;		// A4: FMC_A4
-using A5  = GpioOutputF5;		// A5: FMC_A5
-using A6  = GpioOutputF12;		// A6: FMC_A6
-using A7  = GpioOutputF13;		// A7: FMC_A7
-using A8  = GpioOutputF14;		// A8: FMC_A8
-using A9  = GpioOutputF15;		// A9: FMC_A9
-using A10 = GpioOutputG0;		// A10: FMC_A10
-using A11 = GpioOutputG1;		// A11: FMC_A11
-
-using D0  = GpioOutputD14;		// D0: FMC_D0_DA0
-using D1  = GpioOutputD15;		// D1: FMC_D1_DA1
-using D2  = GpioOutputD0;		// D2: FMC_D2_DA2
-using D3  = GpioOutputD1;		// D3: FMC_D3_DA3
-using D4  = GpioOutputE7;		// D4: FMC_D4_DA4
-using D5  = GpioOutputE8;		// D5: FMC_D5_DA5
-using D6  = GpioOutputE9;		// D6: FMC_D6_DA6
-using D7  = GpioOutputE10;		// D7: FMC_D7_DA7
-using D8  = GpioOutputE11;		// D8: FMC_D8_DA8
-using D9  = GpioOutputE12;		// D9: FMC_D9_DA9
-using D10 = GpioOutputE13;		// D10: FMC_D10_DA10
-using D11 = GpioOutputE14;		// D11: FMC_D11_DA11
-using D12 = GpioOutputE15;		// D12: FMC_D12_DA12
-using D13 = GpioOutputD8;		// D13: FMC_D13_DA13
-using D14 = GpioOutputD9;		// D14: FMC_D14_DA14
-using D15 = GpioOutputD10;		// D15: FMC_D15_DA15
-using D16 = GpioOutputH8;		// D16: FMC_D16
-using D17 = GpioOutputH9;		// D17: FMC_D17
-using D18 = GpioOutputH10;		// D18: FMC_D18
-using D19 = GpioOutputH11;		// D19: FMC_D19
-using D20 = GpioOutputH12;		// D20: FMC_D20
-using D21 = GpioOutputH13;		// D21: FMC_D21
-using D22 = GpioOutputH14;		// D22: FMC_D22
-using D23 = GpioOutputH15;		// D23: FMC_D23
-using D24 = GpioOutputI0;		// D24: FMC_D24
-using D25 = GpioOutputI1;		// D25: FMC_D25
-using D26 = GpioOutputI2;		// D26: FMC_D26
-using D27 = GpioOutputI3;		// D27: FMC_D27
-using D28 = GpioOutputI6;		// D28: FMC_D28
-using D29 = GpioOutputI7;		// D29: FMC_D29
-using D30 = GpioOutputI9;		// D30: FMC_D30
-using D31 = GpioOutputI10;		// D31: FMC_D31
-}
-
+void
+initializeSdram();
 
 inline void
 initialize()
 {
-	systemClock::enable();
+	// initialized in `xpcc_hook_hardware_init`
+	// systemClock::enable();
+	// initializeSdram();
+
 	xpcc::cortex::SysTickTimer::initialize<systemClock>();
 
 	stlink::Tx::connect(stlink::Uart::Tx);


### PR DESCRIPTION
This builds on #146 and #147 to add ~~backup SRAM to all F4 series and~~ external SDRAM to the F469I-DISCO board target.

cc @ekiwi 
