### PR TITLE
[cortex] Enable use of backup SRAM for STM32.

### DIFF
--- a/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
@@ -7,7 +7,7 @@
   <device platform="stm32" family="f4" name="405|407|415|417" pin_id="i|o|r|v|z" size_id="e|g">
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
-    <ram>196608</ram>
+    <ram>200704</ram>
     <core>cortex-m4f</core>
     <pin-count device-pin-id="v">100</pin-count>
     <pin-count device-pin-id="z">144</pin-count>
@@ -26,6 +26,7 @@
       <memory access="rw" start="0x10000000" name="ccm" size="64"/>
       <memory access="rwx" start="0x20000000" name="sram1" size="112"/>
       <memory access="rwx" start="0x2001C000" name="sram2" size="16"/>
+      <memory access="rwx" start="0x40024000" name="backup" size="4"/>
       <vector position="0" name="WWDG"/>
       <vector position="1" name="PVD"/>
       <vector position="2" name="TAMP_STAMP"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
@@ -8,7 +8,7 @@
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
     <flash device-size-id="i">2097152</flash>
-    <ram>262144</ram>
+    <ram>266240</ram>
     <core>cortex-m4f</core>
     <pin-count device-pin-id="v">100</pin-count>
     <pin-count device-pin-id="z">144</pin-count>
@@ -30,6 +30,7 @@
       <memory access="rwx" start="0x20000000" name="sram1" size="112"/>
       <memory access="rwx" start="0x2001C000" name="sram2" size="16"/>
       <memory access="rwx" start="0x20020000" name="sram3" size="64"/>
+      <memory access="rwx" start="0x40024000" name="backup" size="4"/>
       <vector position="0" name="WWDG"/>
       <vector position="1" name="PVD"/>
       <vector position="2" name="TAMP_STAMP"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
@@ -8,7 +8,7 @@
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
     <flash device-size-id="i">2097152</flash>
-    <ram>393216</ram>
+    <ram>397312</ram>
     <core>cortex-m4f</core>
     <pin-count device-pin-id="a">169</pin-count>
     <pin-count device-pin-id="i">176</pin-count>
@@ -26,6 +26,7 @@
       <memory access="rwx" start="0x20000000" name="sram1" size="160"/>
       <memory access="rwx" start="0x20028000" name="sram2" size="32"/>
       <memory access="rwx" start="0x20030000" name="sram3" size="128"/>
+      <memory access="rwx" start="0x40024000" name="backup" size="4"/>
       <vector position="0" name="WWDG"/>
       <vector position="1" name="PVD"/>
       <vector position="2" name="TAMP_STAMP"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
@@ -7,7 +7,7 @@
   <device platform="stm32" family="f7" name="745|746|756" pin_id="b|i|n|v|z" size_id="e|g">
     <flash device-size-id="e">524288</flash>
     <flash device-size-id="g">1048576</flash>
-    <ram>409600</ram>
+    <ram>413696</ram>
     <core>cortex-m7f</core>
     <pin-count device-pin-id="v">100</pin-count>
     <pin-count device-pin-id="z">144</pin-count>
@@ -26,6 +26,7 @@
       <memory access="rwx" start="0x20000000" name="dtcm" size="64"/>
       <memory access="rwx" start="0x20010000" name="sram1" size="240"/>
       <memory access="rwx" start="0x2004C000" name="sram2" size="16"/>
+      <memory access="rwx" start="0x40024000" name="backup" size="4"/>
       <vector position="0" name="WWDG"/>
       <vector position="1" name="PVD"/>
       <vector position="2" name="TAMP_STAMP"/>

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32.macros
@@ -53,11 +53,19 @@
 %% endif
 
 %% if target is stm32f4
-	// Enable Core Coupled Memory (CCM)
-	RCC->AHB1ENR |= RCC_AHB1ENR_CCMDATARAMEN;
+	// Enable power to backup domain
+	RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+	// Enable write access to backup SRAM
+	PWR->CR |= PWR_CR_DBP;
+	// Enable Core Coupled Memory (CCM) and backup SRAM (BKPSRAM)
+	RCC->AHB1ENR |= RCC_AHB1ENR_CCMDATARAMEN | RCC_AHB1ENR_BKPSRAMEN;
 %% elif target is stm32f7
-	// Enable Data Tighly Coupled Memory (DTCM)
-	RCC->AHB1ENR |= RCC_AHB1ENR_DTCMRAMEN;
+	// Enable power to backup domain
+	RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+	// Enable write access to backup SRAM
+	PWR->CR1 |= PWR_CR1_DBP;
+	// Enable Data Tighly Coupled Memory (DTCM) and backup SRAM (BKPSRAM)
+	RCC->AHB1ENR |= RCC_AHB1ENR_DTCMRAMEN | RCC_AHB1ENR_BKPSRAMEN;
 %% endif
 %#
 %% endmacro

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_dccm.ld.in
@@ -10,6 +10,16 @@
  *
  * Example for STM32F427:
  *
+ *                        MEMORY MAP (BACKUP)
+ *
+ * Backup internal SRAM (4 kB):
+ *                |                                 | 0x4002 5000 <---- __backup_end
+ *      +-------> |---------------------------------| 0x4002 4FFF
+ *      |         |                                 |
+ *   .backup      |                                 |
+ *      |         |                                 |
+ *      +-------> |---------------------------------| 0x4002 4000 <--- __backup_start
+ *
  *                          MEMORY MAP (RAM)
  *
  * Auxiliary internal SRAM3 (64 kB):
@@ -230,6 +240,25 @@ SECTIONS
 		. = ORIGIN(CCM) + LENGTH(CCM);
 		__heap0_end = .;
 	} >CCM
+
+	.backup :
+	{
+		__backup_load = LOADADDR (.backup);			/* address in FLASH */
+		__backup_start = .;							/* address in RAM */
+
+		KEEP(*(.backup))
+
+		. = ALIGN(4);
+		__backup_end = .;
+	} >BACKUP AT >FLASH
+
+	.heap5 (NOLOAD) :
+	{
+		__heap5_start = .;
+
+		. = ORIGIN(BACKUP) + LENGTH(BACKUP);
+		__heap5_end = .;
+	} >BACKUP
 
 	.text :
 	{
@@ -463,6 +492,9 @@ SECTIONS
 		LONG (__fastdata_load)
 		LONG (__fastdata_start)
 		LONG (__fastdata_end)
+		LONG (__backup_load)
+		LONG (__backup_start)
+		LONG (__backup_end)
 %% if parameters.vector_table_in_ram
 		LONG (__vector_table_ram_load)
 		LONG (__vector_table_ram_start)
@@ -518,6 +550,9 @@ SECTIONS
 		LONG (0x2002) /* CCM */
 		LONG (__heap0_start)
 		LONG (__heap0_end)
+		LONG (0x4009) /* BKPSRAM */
+		LONG (__heap5_start)
+		LONG (__heap5_end)
 		{{ parameters.linkerscript_table_heap_extern }}
 		__table_heap_end = .;
 	} >FLASH

--- a/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/stm32/stm32_idtcm.ld.in
@@ -10,6 +10,16 @@
  *
  * Example for STM32F746:
  *
+ *                        MEMORY MAP (BACKUP)
+ *
+ * Backup internal SRAM (4 kB):
+ *                |                                 | 0x4002 5000 <---- __backup_end
+ *      +-------> |---------------------------------| 0x4002 4FFF
+ *      |         |                                 |
+ *   .backup      |                                 |
+ *      |         |                                 |
+ *      +-------> |---------------------------------| 0x4002 4000 <--- __backup_start
+ *
  *                          MEMORY MAP (RAM)
  *
  * Auxiliary internal SRAM2 (16 kB):
@@ -260,6 +270,25 @@ SECTIONS
 		__heap0_end = .;
 	} >DTCM
 
+	.backup :
+	{
+		__backup_load = LOADADDR (.backup);			/* address in FLASH */
+		__backup_start = .;							/* address in RAM */
+
+		KEEP(*(.backup))
+
+		. = ALIGN(4);
+		__backup_end = .;
+	} >BACKUP AT >FLASH
+
+	.heap5 (NOLOAD) :
+	{
+		__heap5_start = .;
+
+		. = ORIGIN(BACKUP) + LENGTH(BACKUP);
+		__heap5_end = .;
+	} >BACKUP
+
 	.text :
 	{
 		/* Create a symbol for each input file in the current section, set to
@@ -509,6 +538,9 @@ SECTIONS
 		LONG (0x2005) /* ITCM */
 		LONG (__heap4_start)
 		LONG (__heap4_end)
+		LONG (0x4009) /* BKPSRAM */
+		LONG (__heap5_start)
+		LONG (__heap5_end)
 		{{ parameters.linkerscript_table_heap_extern }}
 		__table_heap_end = .;
 	} >FLASH

--- a/tools/device_file_generator/stm.py
+++ b/tools/device_file_generator/stm.py
@@ -185,7 +185,8 @@ stm32_memory = \
 		'start': {
 			'flash': 0x08000000,
 			'ccm': 0x10000000,
-			'sram': 0x20000000
+			'sram': 0x20000000,
+			'backup': 0x40024000
 		},
 		'model': [
 			{
@@ -194,15 +195,15 @@ stm32_memory = \
 			},
 			{
 				'names': ['405', '407', '415', '417'],
-				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 16}
+				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 16, 'backup': 4}
 			},
 			{
 				'names': ['427', '429', '437', '439'],
-				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 16, 'sram3': 64}
+				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 16, 'sram3': 64, 'backup': 4}
 			},
 			{
 				'names': ['469', '479'],
-				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 32, 'sram3': 128}
+				'memories': {'flash': 0, 'ccm': 64, 'sram1': 0, 'sram2': 32, 'sram3': 128, 'backup': 4}
 			}
 		]
 	},
@@ -211,12 +212,13 @@ stm32_memory = \
 			'flash': 0x08000000,
 			'dtcm': 0x20000000,
 			'itcm': 0x00000000,
-			'sram': 0x20010000
+			'sram': 0x20010000,
+			'backup': 0x40024000
 		},
 		'model': [
 			{
 				'names': ['745', '746', '756'],
-				'memories': {'flash': 0, 'itcm': 16, 'dtcm': 64, 'sram1': 0, 'sram2': 16}
+				'memories': {'flash': 0, 'itcm': 16, 'dtcm': 64, 'sram1': 0, 'sram2': 16, 'backup': 4}
 			}
 		]
 	}

--- a/tools/device_file_generator/stm_reader.py
+++ b/tools/device_file_generator/stm_reader.py
@@ -110,6 +110,8 @@ class STMDeviceReader(XMLDeviceReader):
 		flash = int(flashs[sizeIndexFlash].text) + mem_model['memories']['flash']
 		if 'ccm' in mem_model['memories']:
 			total_ram += mem_model['memories']['ccm']
+		if 'backup' in mem_model['memories']:
+			total_ram += mem_model['memories']['backup']
 		if 'itcm' in mem_model['memories']:
 			total_ram += mem_model['memories']['itcm']
 			total_ram += mem_model['memories']['dtcm']


### PR DESCRIPTION
This modifies the device file generator to include the backup SRAM on the higher performance STM32F4 and STM32F7 series.

This increases the available total RAM by 4kB, but the default allocator (newlib) cannot make use of this memory.
Only with the TLSF allocator can the backup RAM be used.

Note that the TLSF overhead is about 1kB, which is unfortunate and O(1) access is not required for backup SRAM.
