### PR TITLE
[driver] Explicitly cast enum class assignments

### DIFF
--- a/src/xpcc/architecture/interface/register.hpp
+++ b/src/xpcc/architecture/interface/register.hpp
@@ -121,9 +121,9 @@
  * Prescaler : uint8_t
  * {
  *     Div1 = 0,				///< configuration documentation
- *     Div2 = Control::PRE0,
- *     Div4 = Control::PRE1,
- *     Div8 = Control::PRE1 | Control::PRE0,
+ *     Div2 = int(Control::PRE0),
+ *     Div4 = int(Control::PRE1),
+ *     Div8 = int(Control::PRE1) | int(Control::PRE0),
  * };
  * typedef Configuration< Control_t, Prescaler, (Bit5 | Bit4) >  Prescaler_t;
  * @endcode

--- a/src/xpcc/driver/inertial/hmc5843.hpp
+++ b/src/xpcc/driver/inertial/hmc5843.hpp
@@ -22,10 +22,10 @@ struct hmc5843 : public hmc58x3
 	Gain : uint8_t
 	{
 		Ga0_7 = 0,
-		Ga1_0 = ConfigB::GN0,
-		Ga1_5 = ConfigB::GN1,
+		Ga1_0 = int(ConfigB::GN0),
+		Ga1_5 = int(ConfigB::GN1),
 		Ga2_0 = int(ConfigB::GN1) | int(ConfigB::GN0),
-		Ga3_2 = ConfigB::GN2,
+		Ga3_2 = int(ConfigB::GN2),
 		Ga3_8 = int(ConfigB::GN2) | int(ConfigB::GN0),
 		Ga4_5 = int(ConfigB::GN2) | int(ConfigB::GN1),
 		Ga6_5 = int(ConfigB::GN2) | int(ConfigB::GN1) | int(ConfigB::GN0),
@@ -35,10 +35,10 @@ struct hmc5843 : public hmc58x3
 	MeasurementRate : uint8_t
 	{
 		Hz0_5 = 0,
-		Hz1 = ConfigA::DO0,
+		Hz1 = int(ConfigA::DO0),
 		Hz2 = int(ConfigA::DO1),
 		Hz5 = int(ConfigA::DO1) | int(ConfigA::DO0),
-		Hz10 = ConfigA::DO2,
+		Hz10 = int(ConfigA::DO2),
 		Hz20 = int(ConfigA::DO2) | int(ConfigA::DO0),
 		Hz50 = int(ConfigA::DO2) | int(ConfigA::DO1),
 	};

--- a/src/xpcc/driver/inertial/hmc5883l.hpp
+++ b/src/xpcc/driver/inertial/hmc5883l.hpp
@@ -22,8 +22,8 @@ struct hmc5883 : public hmc58x3
 	MeasurementAverage : uint8_t
 	{
 		Average8 = int(ConfigA::MA1) | int(ConfigA::MA0),
-		Average4 = ConfigA::MA1,
-		Average2 = ConfigA::MA0,
+		Average4 = int(ConfigA::MA1),
+		Average2 = int(ConfigA::MA0),
 		Average1 = 0
 	};
 
@@ -31,10 +31,10 @@ struct hmc5883 : public hmc58x3
 	Gain : uint8_t
 	{
 		Ga0_88 = 0,
-		Ga1_3 = ConfigB::GN0,
-		Ga1_9 = ConfigB::GN1,
+		Ga1_3 = int(ConfigB::GN0),
+		Ga1_9 = int(ConfigB::GN1),
 		Ga2_5 = int(ConfigB::GN1) | int(ConfigB::GN2),
-		Ga4_0 = ConfigB::GN2,
+		Ga4_0 = int(ConfigB::GN2),
 		Ga4_7 = int(ConfigB::GN2) | int(ConfigB::GN0),
 		Ga5_6 = int(ConfigB::GN2) | int(ConfigB::GN1),
 		Ga8_1 = int(ConfigB::GN2) | int(ConfigB::GN1) | int(ConfigB::GN0),
@@ -44,10 +44,10 @@ struct hmc5883 : public hmc58x3
 	MeasurementRate : uint8_t
 	{
 		Hz0_75 = 0,
-		Hz1_5 = ConfigA::DO0,
+		Hz1_5 = int(ConfigA::DO0),
 		Hz3 = int(ConfigA::DO1),
 		Hz7_5 = int(ConfigA::DO1) | int(ConfigA::DO0),
-		Hz15 = ConfigA::DO2,
+		Hz15 = int(ConfigA::DO2),
 		Hz30 = int(ConfigA::DO2) | int(ConfigA::DO0),
 		Hz75 = int(ConfigA::DO2) | int(ConfigA::DO1),
 	};

--- a/src/xpcc/driver/inertial/hmc58x3.hpp
+++ b/src/xpcc/driver/inertial/hmc58x3.hpp
@@ -104,8 +104,8 @@ public:
 	OperationMode : uint8_t
 	{
 		ContinousConversion = 0,
-		SingleConversion = Mode::MD0,
-		Idle = Mode::MD1,
+		SingleConversion = int(Mode::MD0),
+		Idle = int(Mode::MD1),
 		Sleep = int(Mode::MD1) | int(Mode::MD0),	///< *HMC5843 only*
 	};
 

--- a/src/xpcc/driver/inertial/hmc6343.hpp
+++ b/src/xpcc/driver/inertial/hmc6343.hpp
@@ -53,12 +53,12 @@ struct hmc6343
 	enum class
 	Register16 : uint8_t
 	{
-		DeviceSerial = Register::DeviceSerialLsb,		///< Device Serial Number
-		DeviationAngle = Register::DeviationAngleLsb,	///< Deviation Angle (+-1800) in tenth of a degree
-		VariationAngle = Register::VariationAngleLsb,	///< Variation Angle (+-1800) in tenth of a degree
-		X_Offset = Register::X_OffsetLsb,				///< Hard-Iron Calibration Offset for the X-axis
-		Y_Offset = Register::Y_OffsetLsb,				///< Hard-Iron Calibration Offset for the Y-axis
-		Z_Offset = Register::Z_OffsetLsb,				///< Hard-Iron Calibration Offset for the Z-axis
+		DeviceSerial = int(Register::DeviceSerialLsb),		///< Device Serial Number
+		DeviationAngle = int(Register::DeviationAngleLsb),	///< Deviation Angle (+-1800) in tenth of a degree
+		VariationAngle = int(Register::VariationAngleLsb),	///< Variation Angle (+-1800) in tenth of a degree
+		X_Offset = int(Register::X_OffsetLsb),				///< Hard-Iron Calibration Offset for the X-axis
+		Y_Offset = int(Register::Y_OffsetLsb),				///< Hard-Iron Calibration Offset for the Y-axis
+		Z_Offset = int(Register::Z_OffsetLsb),				///< Hard-Iron Calibration Offset for the Z-axis
 	};
 
 protected:
@@ -90,9 +90,9 @@ public:
 	enum class
 	Orientation : uint8_t
 	{
-		Level = Command::LevelOrientation,
-		UprightSideways = Command::UprightSidewaysOrientation,
-		UprightFlatFront = Command::UprightFlatFrontOrientation
+		Level = int(Command::LevelOrientation),
+		UprightSideways = int(Command::UprightSidewaysOrientation),
+		UprightFlatFront = int(Command::UprightFlatFrontOrientation)
 	};
 
 	enum class

--- a/src/xpcc/driver/inertial/itg3200.hpp
+++ b/src/xpcc/driver/inertial/itg3200.hpp
@@ -69,10 +69,10 @@ public:
 	LowPassFilter : uint8_t
 	{
 		Hz256 = 0,
-		Hz188 = Filter::DLPF_CFG0,
-		Hz98 = Filter::DLPF_CFG1,
+		Hz188 = int(Filter::DLPF_CFG0),
+		Hz98 = int(Filter::DLPF_CFG1),
 		Hz42 = int(Filter::DLPF_CFG1) | int(Filter::DLPF_CFG0),
-		Hz20 = Filter::DLPF_CFG2,
+		Hz20 = int(Filter::DLPF_CFG2),
 		Hz10 = int(Filter::DLPF_CFG2) | int(Filter::DLPF_CFG0),
 		Hz5 = int(Filter::DLPF_CFG2) | int(Filter::DLPF_CFG1),
 	};
@@ -128,10 +128,10 @@ public:
 	ClockSource : uint8_t
 	{
 		Internal = 0,						///< Internal oscillator
-		PllX = Power::CLK_SEL0,				///< PLL with X Gyro reference
-		PllY = Power::CLK_SEL1,				///< PLL with Y Gyro reference
+		PllX = int(Power::CLK_SEL0),		///< PLL with X Gyro reference
+		PllY = int(Power::CLK_SEL1),		///< PLL with Y Gyro reference
 		PllZ = int(Power::CLK_SEL1) | int(Power::CLK_SEL0),		///< PLL with Z Gyro reference
-		PllExternal32kHz = Power::CLK_SEL2,	///< PLL with external 32.768kHz reference
+		PllExternal32kHz = int(Power::CLK_SEL2),	///< PLL with external 32.768kHz reference
 		PllExternal19MHz = int(Power::CLK_SEL2) | int(Power::CLK_SEL0),	///< PLL with external 19.2MHz reference
 	};
 	typedef Configuration< Power_t, ClockSource, (Bit2 | Bit1 | Bit0) > ClockSource_t;

--- a/src/xpcc/driver/inertial/l3gd20.hpp
+++ b/src/xpcc/driver/inertial/l3gd20.hpp
@@ -224,10 +224,10 @@ public:
 	FifoMode : uint8_t
 	{
 		Bypass = 0,
-		Fifo = FifoControl::FM0,
-		Stream = FifoControl::FM1,
+		Fifo = int(FifoControl::FM0),
+		Stream = int(FifoControl::FM1),
 		StreamTriggerFifo = int(FifoControl::FM1) | int(FifoControl::FM0),
-		BypassTriggerStream = FifoControl::FM2,
+		BypassTriggerStream = int(FifoControl::FM2),
 		BypassTriggerFifo = int(FifoControl::FM2) | int(FifoControl::FM1) | int(FifoControl::FM0),
 	};
 
@@ -244,7 +244,7 @@ public:
 	Scale : uint8_t
 	{
 		Dps250 = 0,
-		Dps500 = Control4::FS0,
+		Dps500 = int(Control4::FS0),
 		Dps2000 = int(Control4::FS1) | int(Control4::FS0),
 	};
 

--- a/src/xpcc/driver/inertial/lis302dl.hpp
+++ b/src/xpcc/driver/inertial/lis302dl.hpp
@@ -214,14 +214,14 @@ public:
 	MeasurementRate : uint8_t
 	{
 		Hz100 = 0x00,
-		Hz400 = Control1::DR,
+		Hz400 = int(Control1::DR),
 	};
 
 	enum class
 	Scale : uint8_t
 	{
 		G2 = 0x00,
-		G8 = Control1::FS,
+		G8 = int(Control1::FS),
 	};
 
 	enum class

--- a/src/xpcc/driver/inertial/lis3dsh.hpp
+++ b/src/xpcc/driver/inertial/lis3dsh.hpp
@@ -387,10 +387,10 @@ public:
 	FifoMode : uint8_t
 	{
 		Bypass = 0,
-		Fifo = FifoControl::FMODE0,
-		Stream = FifoControl::FMODE1,
+		Fifo = int(FifoControl::FMODE0),
+		Stream = int(FifoControl::FMODE1),
 		StreamTriggerFifo = int(FifoControl::FMODE1) | int(FifoControl::FMODE0),
-		BypassTriggerStream = FifoControl::FMODE2,
+		BypassTriggerStream = int(FifoControl::FMODE2),
 		BypassTriggerFifo = int(FifoControl::FMODE2) | int(FifoControl::FMODE1) | int(FifoControl::FMODE0),
 	};
 
@@ -398,14 +398,14 @@ public:
 	MeasurementRate : uint8_t
 	{
 		Off = 0,
-		Hz3_125 = Control4::ODR0,
-		Hz6_25 = Control4::ODR1,
+		Hz3_125 = int(Control4::ODR0),
+		Hz6_25 = int(Control4::ODR1),
 		Hz12_5 = int(Control4::ODR1) | int(Control4::ODR0),
-		Hz25 = Control4::ODR2,
+		Hz25 = int(Control4::ODR2),
 		Hz50 = int(Control4::ODR2) | int(Control4::ODR0),
 		Hz100 = int(Control4::ODR2) | int(Control4::ODR1),
 		Hz400 = int(Control4::ODR2) | int(Control4::ODR1) | int(Control4::ODR0),
-		Hz800 = Control4::ODR3,
+		Hz800 = int(Control4::ODR3),
 		Hz1600 = int(Control4::ODR3) | int(Control4::ODR0),
 	};
 
@@ -413,10 +413,10 @@ public:
 	Scale : uint8_t
 	{
 		G2 = 0,
-		G4 = Control5::FSCALE0,
-		G6 = Control5::FSCALE1,
+		G4 = int(Control5::FSCALE0),
+		G6 = int(Control5::FSCALE1),
 		G8 = int(Control5::FSCALE1) | int(Control5::FSCALE0),
-		G16 = Control5::FSCALE2,
+		G16 = int(Control5::FSCALE2),
 	};
 
 	enum class

--- a/src/xpcc/driver/inertial/lsm303a.hpp
+++ b/src/xpcc/driver/inertial/lsm303a.hpp
@@ -276,8 +276,8 @@ public:
 	FifoMode : uint8_t
 	{
 		Bypass = 0,
-		Fifo = FifoControl::FM0,
-		Stream = FifoControl::FM1,
+		Fifo = int(FifoControl::FM0),
+		Stream = int(FifoControl::FM1),
 		Trigger = int(FifoControl::FM1) | int(FifoControl::FM0)
 	};
 
@@ -285,15 +285,15 @@ public:
 	MeasurementRate : uint8_t
 	{
 		Off = 0,
-		Hz1 = Control1::ODR0,
-		Hz10 = Control1::ODR1,
+		Hz1 = int(Control1::ODR0),
+		Hz10 = int(Control1::ODR1),
 		Hz25 = int(Control1::ODR1) | int(Control1::ODR0),
-		Hz50 = Control1::ODR2,
+		Hz50 = int(Control1::ODR2),
 		Hz100 = int(Control1::ODR2) | int(Control1::ODR0),
 		Hz200 = int(Control1::ODR2) | int(Control1::ODR1),
 		Hz400 = int(Control1::ODR2) | int(Control1::ODR1) | int(Control1::ODR0),
 
-		Hz1620 = Control1::ODR3,
+		Hz1620 = int(Control1::ODR3),
 		Hz5376 = int(Control1::ODR3) | int(Control1::ODR0),
 	};
 
@@ -301,8 +301,8 @@ public:
 	Scale : uint8_t
 	{
 		G2 = 0,
-		G4 = Control4::FS0,
-		G8 = Control4::FS1,
+		G4 = int(Control4::FS0),
+		G8 = int(Control4::FS1),
 		G16 = int(Control4::FS1) | int(Control4::FS0),
 	};
 

--- a/src/xpcc/driver/temperature/ds1631.hpp
+++ b/src/xpcc/driver/temperature/ds1631.hpp
@@ -66,14 +66,14 @@ public:
 	ConversionMode : uint8_t
 	{
 		Continous = 0,
-		OneShot = Config::OneShot
+		OneShot = int(Config::OneShot)
 	};
 
 	enum class
 	AlertPolarity : uint8_t
 	{
 		ActiveLow = 0,
-		ActiveHigh = Config::Polarity
+		ActiveHigh = int(Config::Polarity)
 	};
 
 	enum class

--- a/src/xpcc/driver/temperature/lm75.hpp
+++ b/src/xpcc/driver/temperature/lm75.hpp
@@ -57,14 +57,14 @@ public:
 	ThermostatMode : uint8_t
 	{
 		Comparator = 0,
-		Interrupt = Config1::ThermostatMode
+		Interrupt = int(Config1::ThermostatMode)
 	};
 
 	enum class
 	AlertPolarity : uint8_t
 	{
 		ActiveLow = 0,
-		ActiveHigh = Config1::Polarity
+		ActiveHigh = int(Config1::Polarity)
 	};
 
 	enum class


### PR DESCRIPTION
Assigning an enum class value with another enum class value is not
type compatible, and must be explicitly cast before assignment.

This bug seems to have been ignored by GCC until the 6.1 release.
Clang (used for hosted unit tests) does not ignore this bug.

Thanks to @daniel-k for reporting this bug in #151.
cc @ekiwi @strongly-typed 
