### PR TITLE
Add F469I-DISCO display driver

### DIFF
--- a/examples/stm32f469_discovery/display/SConstruct
+++ b/examples/stm32f469_discovery/display/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f469_discovery/display/main.cpp
+++ b/examples/stm32f469_discovery/display/main.cpp
@@ -1,0 +1,39 @@
+#include <xpcc/architecture/platform.hpp>
+using namespace Board;
+using namespace xpcc::glcd;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::initializeDisplay();
+
+	xpcc::GraphicDisplay& display = Board::getDisplay();
+	display.setFont(xpcc::font::Assertion);
+
+	display.drawRectangle(0,0, 10, 10);
+	display.drawRectangle(0,470, 10, 10);
+	display.drawRectangle(790,0, 10, 10);
+	display.drawRectangle(790,470, 10, 10);
+
+	display.drawRectangle(-1,-1, 10, 10);
+	display.drawRectangle(-1,471, 10, 10);
+	display.drawRectangle(791, -1, 10, 10);
+	display.drawRectangle(791,471, 10, 10);
+
+	while (1)
+	{
+		xpcc::delayMilliseconds(50);
+
+		if (Button::read()) {
+			display.clear();
+		} else {
+			display.setCursor(rand() % 750, rand() % 460);
+			display << "Hello World!";
+			display.setColor(Color(uint16_t(rand())));
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32f469_discovery/display/project.cfg
+++ b/examples/stm32f469_discovery/display/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f469_discovery
+buildpath = ${xpccpath}/build/stm32f469_discovery/${name}

--- a/examples/stm32f469_discovery/touchscreen/SConstruct
+++ b/examples/stm32f469_discovery/touchscreen/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f469_discovery/touchscreen/main.cpp
+++ b/examples/stm32f469_discovery/touchscreen/main.cpp
@@ -1,0 +1,97 @@
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/processing/protothread.hpp>
+
+using namespace Board;
+using namespace xpcc::glcd;
+using namespace Board::ft6;
+
+class LineDrawer : public xpcc::pt::Protothread
+{
+public:
+	LineDrawer() :
+		touch(touchData),
+		display{Board::getDisplay()},
+		px{-1, -1}, py{-1, -1},
+		c{Color::white(), Color::white()}
+		{}
+
+	bool
+	update()
+	{
+		PT_BEGIN();
+
+		// Configure the touchscreen to sample with 60Hz in active and monitor mode.
+		PT_CALL(touch.configure(Touch::InterruptMode::Trigger, 60, 60));
+
+		while (1)
+		{
+			do {
+				// Wait for either touchscreen interrupt or clear screen button
+				PT_WAIT_UNTIL(Int::getExternalInterruptFlag() or Button::read());
+				if (Button::read()) display.clear();
+			} while (not Int::getExternalInterruptFlag());
+
+			Int::acknowledgeExternalInterruptFlag();
+			LedRed::set();
+
+			PT_CALL(touch.readTouches());
+
+			for (int ii=0; ii < 2; ii++)
+			{
+				Touch::touch_t tp;
+				touch.getData().getTouch(&tp, ii);
+				// mirror and rotate correctly
+				uint16_t x{tp.y}, y{uint16_t(480 - tp.x)};
+
+				if (tp.event == Touch::Event::PressDown or (px[tp.id] < 0))
+				{
+					// remember the start point
+					px[tp.id] = x; py[tp.id] = y;
+				}
+				else if (tp.event == Touch::Event::Contact)
+				{
+					// draw the line from the previous point to this one
+					display.setColor(c[tp.id]);
+					display.drawLine(px[tp.id], py[tp.id], x, y);
+					// remember this point for next time.
+					px[tp.id] = x; py[tp.id] = y;
+				}
+				else if (tp.event == Touch::Event::LiftUp)
+				{
+					// invalidate points
+					px[tp.id] = -1; py[tp.id] = -1;
+					// generate new random color
+					c[tp.id] = Color(uint16_t(rand()));
+				}
+			}
+			LedRed::reset();
+		}
+
+		PT_END();
+	}
+
+private:
+	Touch::Data touchData;
+	Touch touch;
+	xpcc::GraphicDisplay& display;
+	int16_t px[2], py[2];
+	Color c[2];
+};
+
+LineDrawer drawer;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::initializeDisplay();
+	Board::initializeTouchscreen();
+
+	while(1)
+	{
+		drawer.update();
+	}
+
+	return 0;
+}

--- a/examples/stm32f469_discovery/touchscreen/project.cfg
+++ b/examples/stm32f469_discovery/touchscreen/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f469_discovery
+buildpath = ${xpccpath}/build/stm32f469_discovery/${name}

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
@@ -1,10 +1,10 @@
 // coding: utf-8
 /* Copyright (c) 2015-2016, Roboterclub Aachen e.V.
-* All Rights Reserved.
-*
-* The file is part of the xpcc library and is released under the 3-clause BSD
-* license. See the file `LICENSE` for the full license governing this code.
-*/
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
 // ----------------------------------------------------------------------------
 
 //
@@ -28,146 +28,13 @@ xpcc::log::Logger xpcc::log::error(loggerDevice);
 extern "C" void
 xpcc_hook_hardware_init(void);
 
+extern void
+board_initialize_sdram();
+
 void
 xpcc_hook_hardware_init(void)
 {
 	// initialize system clock and external SDRAM before accessing external memories
 	Board::systemClock::enable();
-	Board::initializeSdram();
-}
-
-
-static void
-sdram_configure_gpio(GPIO_TypeDef * const port, const uint16_t mask)
-{
-	// For all GPIOs:
-	// - Pull-Up
-	// - Fast Speed
-	// - Alternate Function 12
-	// => MODER = 0b10
-	// => OTYPER = 0b0
-	// => OSPEEDR = 0b11
-	// => PUPDR = 0b01
-	// => AFR = 0b1100
-
-	// compute the 0b11 and 0b1111 spreads
-	uint32_t portMask2 = 0;
-	uint32_t portMask4[2] = {0,0};
-	for (int ii = 0; ii < 16; ii++) {
-		if (mask & (1 << ii)) {
-			portMask2 |= (0b11 << (ii * 2));
-			if (ii < 8) {
-				portMask4[0] |= (0b1111 << (ii * 4));
-			} else {
-				portMask4[1] |= (0b1111 << ((ii - 8) * 4));
-			}
-		}
-	}
-	// mask to get the actual bit masks
-	const uint32_t port01 = 0x55555555 & portMask2;
-	const uint32_t port10 = 0xAAAAAAAA & portMask2;
-	const uint32_t port1100L = 0xCCCCCCCC & portMask4[0];
-	const uint32_t port1100H = 0xCCCCCCCC & portMask4[1];
-
-	port->AFR[0]  = port1100L;
-	port->AFR[1]  = port1100H;
-	port->OSPEEDR = port10 | port01;
-	port->PUPDR   = port01;
-	port->MODER   = port10;
-	port->OTYPER &= ~mask;
-
-	// We lock the corresponding GPIO pins, so that users do not shoot
-	// themselves in their feet, if they accidentally use SDRAM GPIOs.
-	port->LCKR = 0x10000 | mask;
-	port->LCKR = 0x00000 | mask;
-	port->LCKR = 0x10000 | mask;
-	(void) port->LCKR;
-}
-
-static bool
-sdram_send_command(uint8_t mode, uint8_t auto_refresh = 1, uint16_t mode_register = 0)
-{
-	FMC_Bank5_6->SDCMR =	((uint32_t(mode_register) << 9) & FMC_SDCMR_MRD) |
-							(((uint32_t(auto_refresh) - 1) << 5) & FMC_SDCMR_NRFS) |
-							FMC_SDCMR_CTB1 | (mode & FMC_SDCMR_MODE);
-	uint16_t timeout = 10000;
-	while ((FMC_Bank5_6->SDSR & FMC_SDSR_BUSY) and timeout)
-	{
-		timeout--;
-		xpcc::delayMicroseconds(100);
-	}
-
-	return timeout;
-}
-
-void
-Board::initializeSdram()
-{
-	using namespace xpcc;
-	// Strongly inspired by the F469I-DISCO BSP from ST
-
-	// Configure all pins
-	// C0
-	sdram_configure_gpio(GPIOC, Bit0);
-	// D0, D1, D8, D9, D10, D14, D15
-	sdram_configure_gpio(GPIOD, Bit0 | Bit1 | Bit8 | Bit9 | Bit10 | Bit14 | Bit15);
-	// E0, E1, E7, E8, E9, E10, E11, E12, E13, E14, E15
-	sdram_configure_gpio(GPIOE, Bit0 | Bit1 | Bit7 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
-	// F0, F1, F2, F3, F4, F5, F11, F12, F13, F14, F15
-	sdram_configure_gpio(GPIOF, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
-	// G0, G1, G4, G5, G8, G15
-	sdram_configure_gpio(GPIOG, Bit0 | Bit1 | Bit4 | Bit5 | Bit8 | Bit15);
-	// H2, H3, H8, H9, H10, H11, H12, H13, H14, H15
-	sdram_configure_gpio(GPIOH, Bit2 | Bit3 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
-	// I0, I1, I2, I3, I4, I5, I6, I7, I9, I10
-	sdram_configure_gpio(GPIOI, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit6 | Bit7 | Bit9 | Bit10);
-
-	// Configure the SDRAM
-	// Enable FMC clock
-	RCC->AHB3ENR |= RCC_AHB3ENR_FMCEN;
-	(void) RCC->AHB3ENR;
-
-	/* SDRAM Control register (only bank 1 is used):
-	 * - RPIPE: 0b00 (0 cycle delay)
-	 * - RBURST: 0b1 (enabled)
-	 * - SDCLK: 0b10 (2x HCLK periods)
-	 * - WP: 0x0 (disabled)
-	 * - CAS: 0x11 (3 cycles)
-	 * - NB: 0b1 (4 internal banks)
-	 * - MWID: 0b10 (32bit data bus width)
-	 * - NR: 0b01 (12 bit)
-	 * - NC: 0b00 (8 bit)
-	 */
-	FMC_Bank5_6->SDCR[0] =  FMC_SDCR1_RBURST | FMC_SDCR1_SDCLK_1 | FMC_SDCR1_NB | FMC_SDCR1_NR_0 |
-							FMC_SDCR1_MWID_1 | FMC_SDCR1_CAS_1 | FMC_SDCR1_CAS_0;
-
-	/* SDRAM Timing register (for 90 MHz as SD clock frequency)
-	 * - TRCD: 0b0001 (2 cycles)
-	 * - TRP:  0b0001 (2 cycles)
-	 * - TWR:  0b0001 (2 cycles)
-	 * - TRC:  0b0110 (7 cycles)
-	 * - TRAS: 0b0011 (4 cycles)
-	 * - TXSR: 0b0110 (7 cycles)
-	 * - TMRD: 0b0001 (2 cycles)
-	 */
-	FMC_Bank5_6->SDTR[0] = 0x01116361;
-
-	// FMC_SDRAM_CMD_CLK_ENABLE
-	sdram_send_command(1);
-	xpcc::delayMilliseconds(1);
-	// FMC_SDRAM_CMD_PALL
-	sdram_send_command(2);
-	// FMC_SDRAM_CMD_AUTOREFRESH_MODE
-	sdram_send_command(3, 8);
-	/* FMC_SDRAM_CMD_LOAD_MODE:
-	 * - SDRAM_MODEREG_BURST_LENGTH_1
-	 * - SDRAM_MODEREG_BURST_TYPE_SEQUENTIAL
-	 * - SDRAM_MODEREG_CAS_LATENCY_3
-	 * - SDRAM_MODEREG_OPERATING_MODE_STANDARD
-	 * - SDRAM_MODEREG_WRITEBURST_MODE_SINGLE
-	 */
-	sdram_send_command(4, 1, 0x230);
-
-	// Set refresh rate:
-	FMC_Bank5_6->SDRTR = (0x0569 << 1);
+	board_initialize_sdram();
 }

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.cpp
@@ -34,6 +34,12 @@ board_initialize_sdram();
 void
 xpcc_hook_hardware_init(void)
 {
+	// Reset LCD
+	Board::DisplayReset::setOutput(xpcc::Gpio::Low);
+	xpcc::delayMilliseconds(20);
+	Board::DisplayReset::set();
+	xpcc::delayMilliseconds(10);
+
 	// initialize system clock and external SDRAM before accessing external memories
 	Board::systemClock::enable();
 	board_initialize_sdram();

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
@@ -1,5 +1,5 @@
 // coding: utf-8
-/* Copyright (c) 2015, Roboterclub Aachen e.V.
+/* Copyright (c) 2015-2016, Roboterclub Aachen e.V.
 * All Rights Reserved.
 *
 * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -80,11 +80,15 @@ struct systemClock
 		ClockControl::enableExternalCrystal(); // 8 MHz
 		ClockControl::enablePll(
 		ClockControl::PllSource::ExternalCrystal,
-			4,      // 8MHz / N=4 -> 2MHz
-			180,    // 2MHz * M=180 -> 360MHz
+			8,      // 8MHz / N=8 -> 1MHz   !!! Must be 1 MHz for PLLSAI !!!
+			360,    // 1MHz * M=360 -> 360MHz
 			2,      // 360MHz / P=2 -> 180MHz = F_cpu
-			7       // 360MHz / Q=7 -> ~51MHz = F_usb => bad for USB
+			7       // 360MHz / Q=7 -> ~51MHz (value ignored! PLLSAI generates 48MHz for F_usb)
 		);
+		// Enable overdrive mode
+		PWR->CR |= PWR_CR_ODEN;
+		// wait for it
+		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
 		ClockControl::setFlashLatency(Frequency);
 		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
 		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div4);
@@ -135,6 +139,7 @@ using LedD13    = GpioOutputD3;							// LED7 [Green]
 
 using Leds = xpcc::SoftwareGpioPort< LedBlue, LedRed, LedOrange, LedGreen >;
 
+using DisplayReset = GpioOutputH7;
 
 namespace stlink
 {

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
@@ -18,6 +18,7 @@
 
 #include <xpcc/architecture/platform.hpp>
 #include <xpcc/ui/display/graphic_display.hpp>
+#include <xpcc/driver/touch/ft6x06.hpp>
 #include <xpcc/debug/logger.hpp>
 #define XPCC_BOARD_HAS_LOGGER
 
@@ -142,11 +143,33 @@ using Leds = xpcc::SoftwareGpioPort< LedBlue, LedRed, LedOrange, LedGreen >;
 
 using DisplayReset = GpioOutputH7;
 
+namespace ft6
+{
+using Int = GpioInputJ5;
+using Scl = GpioB8;
+using Sda = GpioB9;
+using I2cMaster = I2cMaster1;
+using Touch = xpcc::Ft6x06< I2cMaster >;
+}
+
 namespace stlink
 {
 using Tx = GpioOutputB10;		// STLK_RX [STLINK V2-1_U2_RX]: USART3_TX
 using Rx = GpioInputB11;		// STLK_TX [STLINK V2-1_U2_TX]: USART3_RX
 using Uart = Usart3;
+}
+
+inline void
+initializeTouchscreen()
+{
+	ft6::Int::setInput();
+	ft6::Int::setInputTrigger(Gpio::InputTrigger::FallingEdge);
+	ft6::Int::enableExternalInterrupt();
+//	ft6::Int::enableExternalInterruptVector(12);
+
+	ft6::Scl::connect(ft6::I2cMaster::Scl);
+	ft6::Sda::connect(ft6::I2cMaster::Sda);
+	ft6::I2cMaster::initialize<systemClock, 360000>();
 }
 
 void

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
@@ -17,6 +17,7 @@
 #define XPCC_STM32_F469_DISCOVERY_HPP
 
 #include <xpcc/architecture/platform.hpp>
+#include <xpcc/ui/display/graphic_display.hpp>
 #include <xpcc/debug/logger.hpp>
 #define XPCC_BOARD_HAS_LOGGER
 
@@ -147,6 +148,12 @@ using Tx = GpioOutputB10;		// STLK_RX [STLINK V2-1_U2_RX]: USART3_TX
 using Rx = GpioInputB11;		// STLK_TX [STLINK V2-1_U2_TX]: USART3_RX
 using Uart = Usart3;
 }
+
+void
+initializeDisplay();
+
+xpcc::GraphicDisplay&
+getDisplay();
 
 inline void
 initialize()

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery.hpp
@@ -143,16 +143,11 @@ using Rx = GpioInputB11;		// STLK_TX [STLINK V2-1_U2_TX]: USART3_RX
 using Uart = Usart3;
 }
 
-void
-initializeSdram();
-
 inline void
 initialize()
 {
-	// initialized in `xpcc_hook_hardware_init`
+	// initialized in `xpcc_hook_hardware_init()`
 	// systemClock::enable();
-	// initializeSdram();
-
 	xpcc::cortex::SysTickTimer::initialize<systemClock>();
 
 	stlink::Tx::connect(stlink::Uart::Tx);

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_display.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_display.cpp
@@ -1,0 +1,96 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+//
+// STM32F469I-DISCO
+// Discovery kit for STM32F469 line
+// http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
+//
+
+#include "stm32f469_discovery.hpp"
+
+extern void
+board_initialize_display(uint8_t);
+
+// Basic implementation of display running on memory mapped buffer
+class DsiDisplay : public xpcc::GraphicDisplay
+{
+public:
+	DsiDisplay() : buffer(new (xpcc::MemoryExternal) uint16_t[800*480])
+	{
+		// ColorCoding: 0 = ARGB8888, 2 = RGB565
+		board_initialize_display(2);
+		// Configures the color frame buffer start address
+		LTDC_Layer1->CFBAR = uint32_t(buffer);
+		// Enable LTDC_Layer by setting LEN bit
+		LTDC_Layer1->CR = LTDC_LxCR_LEN;
+		// Sets the Reload type
+		LTDC->SRCR = LTDC_SRCR_IMR;
+	}
+
+	uint16_t
+	getWidth() const override
+	{ return 800; }
+
+	uint16_t
+	getHeight() const override
+	{ return 480; }
+
+	void
+	clear() override
+	{
+		for (int ii = 0; ii < 800*480; ii++)
+		{
+			buffer[ii] = this->backgroundColor.getValue();
+		}
+	}
+
+	void
+	update() override
+	{
+		// FIXME: avoid tearing by using double buffering!
+	}
+
+	void
+	setPixel(int16_t x, int16_t y) override
+	{
+		if (x < 0 or 800 <= x or y < 0 or 480 <= y) return;
+		buffer[y * 800 + x] = this->foregroundColor.getValue();
+	}
+
+	void
+	clearPixel(int16_t x, int16_t y) override
+	{
+		if (x < 0 or 800 <= x or y < 0 or 480 <= y) return;
+		buffer[y * 800 + x] = this->backgroundColor.getValue();
+	}
+
+	bool
+	getPixel(int16_t x, int16_t y) override
+	{
+		if (x < 0 or 800 <= x or y < 0 or 480 <= y) return false;
+		return (buffer[y * 800 + x] != this->backgroundColor.getValue());
+	}
+
+protected:
+	uint16_t * const buffer;
+};
+
+void
+Board::initializeDisplay()
+{
+	board_initialize_display(2);
+}
+
+xpcc::GraphicDisplay&
+Board::getDisplay()
+{
+	static DsiDisplay display;
+	return display;
+}

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_dsi.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_dsi.cpp
@@ -1,0 +1,193 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+//
+// STM32F469I-DISCO
+// Discovery kit for STM32F469 line
+// http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
+//
+
+#include "stm32f469_discovery.hpp"
+
+extern void
+otm8009a_init(uint8_t);
+
+// ---------------------------------- DISPLAY ----------------------------------
+void
+board_initialize_display(uint8_t ColorCoding)
+{
+	if (RCC->APB2ENR & RCC_APB2ENR_LTDCEN) return;
+	// Enable clock to LTDC interface
+	RCC->APB2ENR |= RCC_APB2ENR_LTDCEN;
+	RCC->APB2RSTR |=  RCC_APB2RSTR_LTDCRST;
+	RCC->APB2RSTR &= ~RCC_APB2RSTR_LTDCRST;
+	// Enable clock to DSI interface
+	RCC->APB2ENR |= RCC_APB2ENR_DSIEN;
+	RCC->APB2RSTR |=  RCC_APB2RSTR_DSIRST;
+	RCC->APB2RSTR &= ~RCC_APB2RSTR_DSIRST;
+
+	{
+		// Expanded `HAL_DSI_Init()`:
+		// Enable regulator
+		DSI->WRPCR = DSI_WRPCR_REGEN;
+		// Wait until stable
+		for (int t = 1024; not (DSI->WISR & DSI_WISR_RRS) and t; t--) {
+			xpcc::delayMilliseconds(1);
+		}
+		// Set up PLL and enable it
+		DSI->WRPCR |= (0 << 16) | (2 << 11) | (125 << 2) | DSI_WRPCR_PLLEN;
+		// Wait until stable
+		for (int t = 1024; not (DSI->WISR & DSI_WISR_PLLLS) and t; t--) {
+			xpcc::delayMilliseconds(1);
+		}
+		// D-PHY clock and digital enable
+		DSI->PCTLR = DSI_PCTLR_CKE | DSI_PCTLR_DEN;
+		// Clock lane configuration
+		DSI->CLCR = DSI_CLCR_DPCC;
+		// Configure the number of active data lanes
+		DSI->PCONFR = 1;
+		// Set the TX escape clock division factor
+		DSI->CCR = 4;
+		// Calculate the bit period in high-speed mode in unit of 0.25 ns (UIX4)
+		// The equation is : UIX4 = IntegerPart( (1000/F_PHY_Mhz) * 4 )
+		// Where : F_PHY_Mhz = (NDIV * HSE_Mhz) / (IDF * ODF)
+		// Set the bit period in high-speed mode
+		DSI->WPCR[0] = 8;
+		// Disable all error interrupts and reset the Error Mask
+		DSI->IER[0] = 0;
+		DSI->IER[1] = 0;
+	}
+
+	constexpr uint32_t VSA = 12;
+	constexpr uint32_t VBP = 12;
+	constexpr uint32_t VFP = 12;
+	constexpr uint32_t HSA = 120;
+	constexpr uint32_t HBP = 120;
+	constexpr uint32_t HFP = 120;
+	constexpr uint32_t HACT = 800;
+	constexpr uint32_t VACT = 480;
+	const uint8_t pixel_size = (ColorCoding == 0) ? sizeof(uint32_t) : sizeof(uint16_t);
+	constexpr float ClockRatio = 62500.f / 27429;
+
+	{
+		// Expanded `HAL_DSI_ConfigVideoMode()`
+		// Select video mode by resetting CMDM and DSIM bits
+		DSI->MCR = 0;
+		DSI->WCFGR = 0;
+		// Configure the video mode transmission type
+		DSI->VMCR = 2;
+		// Configure the video packet size
+		DSI->VPCR = HACT;
+		// Set the chunks number to be transmitted through the DSI link
+		DSI->VCCR = 0;
+		// Set the size of the null packet
+		DSI->VNPCR = 0xFFF;
+		// Select the virtual channel for the LTDC interface traffic
+		DSI->LVCIDR = 0;
+		// Configure the polarity of control signals
+		DSI->LPCR = 0;
+		// Select the color coding for the host
+		DSI->LCOLCR = ColorCoding;
+		// Select the color coding for the wrapper
+		DSI->WCFGR = ColorCoding << 1;
+		// Set the Horizontal Synchronization Active (HSA) in lane byte clock cycles
+		DSI->VHSACR = HSA * ClockRatio;
+		// Set the Horizontal Back Porch (HBP) in lane byte clock cycles
+		DSI->VHBPCR = HBP * ClockRatio;
+		// Set the total line time (HLINE=HSA+HBP+HACT+HFP) in lane byte clock cycles
+		DSI->VLCR = (HACT + HSA + HBP + HFP) * ClockRatio;
+		// Set the Vertical Synchronization Active (VSA)
+		DSI->VVSACR = VSA;
+		// Set the Vertical Back Porch (VBP)
+		DSI->VVBPCR = VBP;
+		// Set the Vertical Front Porch (VFP)
+		DSI->VVFPCR = VFP;
+		// Set the Vertical Active period
+		DSI->VVACR = VACT;
+		// Low power largest packet size
+		// Low power VACT largest packet size
+		DSI->LPMCR = (64 << 16) | 64;
+		// Configure the command transmission mode
+		// Enable LP transition in HFP period
+		// Enable LP transition in HBP period
+		DSI->VMCR |= DSI_VMCR_LPCE | DSI_VMCR_LPHFPE | DSI_VMCR_LPHBPE | DSI_VMCR_LPVAE |
+					 DSI_VMCR_LPVFPE | DSI_VMCR_LPVBPE | DSI_VMCR_LPVSAE;
+	}
+	{
+		// Enable the DSI host
+		DSI->CR = DSI_CR_EN;
+		// Enable the DSI wrapper
+		DSI->WCR = DSI_WCR_DSIEN;
+	}
+
+	{
+		// LCD clock configuration
+		// PLLSAI_VCO Input = HSE_VALUE/PLL_M = 1 Mhz
+		// PLLSAI_VCO Output = PLLSAI_VCO Input * PLLSAIN = 384 Mhz
+		// PLLLCDCLK = PLLSAI_VCO Output/PLLSAIR = 384 MHz / 7 = 54.857 MHz
+		// LTDC clock frequency = PLLLCDCLK / LTDC_PLLSAI_DIVR_2 = 54.857 MHz / 2 = 27.429 MHz
+		RCC->PLLSAICFGR = (7 << 28) | (15 << 24) | (3 << 16) | (384 << 6);
+		// Select PLLSAI clock for 48MHz clocks
+		RCC->DCKCFGR = RCC_DCKCFGR_CK48MSEL;
+		// Enable PLLSAI
+		RCC->CR |= RCC_CR_PLLSAION;
+		for (int t = 1024; not (RCC->CR & RCC_CR_PLLSAIRDY) and t; t--) {
+			xpcc::delayMilliseconds(1);
+		}
+	}
+
+	{
+		// HAL_LTDC_Init(&hltdc_eval);
+		// Configures the HS, VS, DE and PC polarity
+		LTDC->GCR = 0;
+		// Sets Synchronization size
+		LTDC->SSCR = ((HSA - 1) << 16) | (VSA - 1);
+		// Sets Accumulated Back porch
+		LTDC->BPCR = ((HSA + HBP - 1) << 16) | (VSA + VBP - 1);
+		// Sets Accumulated Active Width
+		LTDC->AWCR = ((HACT + HSA + HBP - 1) << 16) | (VACT + VSA + VBP - 1);
+		// Sets Total Width and Height
+		LTDC->TWCR = ((HACT + HSA + HBP + HFP - 1) << 16) | (VACT + VSA + VBP + VFP - 1);
+		// Sets the background color value
+		LTDC->BCCR = 0;
+		// Enable LTDC by setting LTDCEN bit
+		LTDC->GCR |= LTDC_GCR_LTDCEN;
+	}
+
+	otm8009a_init(ColorCoding);
+
+	{
+		// HAL_LTDC_ConfigLayer()
+		// Configures the horizontal start and stop position
+		LTDC_Layer1->WHPCR = ((HACT + HSA + HBP - 1) << 16) | (HSA + HBP);
+		// Configures the vertical start and stop position
+		LTDC_Layer1->WVPCR  = ((VACT + VSA + VBP - 1) << 16) | (VSA + VBP);
+		// Specifies the pixel format
+		LTDC_Layer1->PFCR = ColorCoding;
+		// Configures the default color values
+		LTDC_Layer1->DCCR = 0xff000000;
+		// Specifies the constant alpha value
+		LTDC_Layer1->CACR = 0xff;
+		// Specifies the blending factors
+		LTDC_Layer1->BFCR = 0x607;
+		// Configures the color frame buffer pitch in byte
+		LTDC_Layer1->CFBLR = ((HACT * pixel_size) << 16) | ((HACT * pixel_size) + 3);
+		// Configures the frame buffer line number
+		LTDC_Layer1->CFBLNR = VACT;
+
+		/* Configured in display.cpp
+		// Configures the color frame buffer start address
+		LTDC_Layer1->CFBAR = buffer_address;
+		// Enable LTDC_Layer by setting LEN bit
+		LTDC_Layer1->CR = LTDC_LxCR_LEN;
+		// Sets the Reload type
+		LTDC->SRCR = LTDC_SRCR_IMR;
+		*/
+	}
+}

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_otm8009a.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_otm8009a.cpp
@@ -1,0 +1,459 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+//
+// STM32F469I-DISCO
+// Discovery kit for STM32F469 line
+// http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
+//
+
+#include "stm32f469_discovery.hpp"
+
+static void dsi_write_command(uint32_t count, uint8_t *p)
+{
+	/* Wait for Command FIFO Empty */
+	for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+		xpcc::delayMilliseconds(1);
+	}
+
+	if(count <= 1)
+	{
+		DSI->GHCR = (0x00000015 | (0 << 6) | (p[0] << 8) | (p[1] << 16));
+	}
+	else
+	{
+		DSI->GPDR = p[count] |
+					(p[0] << 8) |
+					(p[1] << 16) |
+					(p[2] << 24);
+		uint16_t counter = 3;
+
+		for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+			xpcc::delayMilliseconds(1);
+		}
+
+		while(counter < count)
+		{
+			DSI->GPDR = p[counter] |
+						(p[counter + 1] << 8) |
+						(p[counter + 2] << 16) |
+						(p[counter + 3] << 24);
+			counter += 4;
+
+			for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+				xpcc::delayMilliseconds(1);
+			}
+		}
+
+		/* Configure the packet to send a long DCS command */
+		DSI->GHCR = (0x00000039 | (0 << 6) | (((count + 1) & 0xFF) << 8) | (((count + 1) & 0xFF00) << 8));
+	}
+}
+
+
+/**
+  ******************************************************************************
+  * @file    otm8009a.c
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    03-August-2015
+  * @brief   This file provides the LCD Driver for KoD KM-040TMP-02-0621 (WVGA)
+  *          DSI LCD Display OTM8009A.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+// This code is slightly modified!
+
+/* List of OTM8009A used commands                                  */
+/* Detailed in OTM8009A Data Sheet 'DATA_SHEET_OTM8009A_V0 92.pdf' */
+/* Version of 14 June 2012                                         */
+constexpr uint8_t OTM8009A_CMD_NOP                   = 0x00;  /* NOP command      */
+constexpr uint8_t OTM8009A_CMD_SWRESET               = 0x01;  /* Sw reset command */
+constexpr uint8_t OTM8009A_CMD_RDDMADCTL             = 0x0B;  /* Read Display MADCTR command : read memory display access ctrl */
+constexpr uint8_t OTM8009A_CMD_RDDCOLMOD             = 0x0C;  /* Read Display pixel format */
+constexpr uint8_t OTM8009A_CMD_SLPIN                 = 0x10;  /* Sleep In command */
+constexpr uint8_t OTM8009A_CMD_SLPOUT                = 0x11;  /* Sleep Out command */
+constexpr uint8_t OTM8009A_CMD_PTLON                 = 0x12;  /* Partial mode On command */
+constexpr uint8_t OTM8009A_CMD_DISPOFF               = 0x28;  /* Display Off command */
+constexpr uint8_t OTM8009A_CMD_DISPON                = 0x29;  /* Display On command */
+constexpr uint8_t OTM8009A_CMD_CASET                 = 0x2A;  /* Column address set command */
+constexpr uint8_t OTM8009A_CMD_PASET                 = 0x2B;  /* Page address set command */
+constexpr uint8_t OTM8009A_CMD_RAMWR                 = 0x2C;  /* Memory (GRAM) write command */
+constexpr uint8_t OTM8009A_CMD_RAMRD                 = 0x2E;  /* Memory (GRAM) read command  */
+constexpr uint8_t OTM8009A_CMD_PLTAR                 = 0x30;  /* Partial area command (4 parameters) */
+constexpr uint8_t OTM8009A_CMD_TEOFF                 = 0x34;  /* Tearing Effect Line Off command : command with no parameter */
+constexpr uint8_t OTM8009A_CMD_TEEON                 = 0x35;  /* Tearing Effect Line On command : command with 1 parameter 'TELOM' */
+constexpr uint8_t OTM8009A_CMD_MADCTR                = 0x36;  /* Memory Access write control command  */
+constexpr uint8_t OTM8009A_CMD_IDMOFF                = 0x38;  /* Idle mode Off command */
+constexpr uint8_t OTM8009A_CMD_IDMON                 = 0x39;  /* Idle mode On command  */
+constexpr uint8_t OTM8009A_CMD_COLMOD                = 0x3A;  /* Interface Pixel format command */
+constexpr uint8_t OTM8009A_CMD_RAMWRC                = 0x3C;  /* Memory write continue command */
+constexpr uint8_t OTM8009A_CMD_RAMRDC                = 0x3E;  /* Memory read continue command  */
+constexpr uint8_t OTM8009A_CMD_WRTESCN               = 0x44;  /* Write Tearing Effect Scan line command */
+constexpr uint8_t OTM8009A_CMD_RDSCNL                = 0x45;  /* Read  Tearing Effect Scan line command */
+/* CABC Management : ie : Content Adaptive Back light Control in IC OTM8009a */
+constexpr uint8_t OTM8009A_CMD_WRDISBV               = 0x51;  /* Write Display Brightness command          */
+constexpr uint8_t OTM8009A_CMD_WRCTRLD               = 0x53;  /* Write CTRL Display command                */
+constexpr uint8_t OTM8009A_CMD_WRCABC                = 0x55;  /* Write Content Adaptive Brightness command */
+constexpr uint8_t OTM8009A_CMD_WRCABCMB              = 0x5E;  /* Write CABC Minimum Brightness command     */
+
+/* Possible used values of MADCTR */
+constexpr uint8_t OTM8009A_MADCTR_MODE_PORTRAIT      = 0x00;
+constexpr uint8_t OTM8009A_MADCTR_MODE_LANDSCAPE     = 0x60;  /* MY = 0, MX = 1, MV = 1, ML = 0, RGB = 0 */
+/* Parameter TELOM : Tearing Effect Line Output Mode : possible values */
+constexpr uint8_t OTM8009A_TEEON_TELOM_VBLANKING_INFO_ONLY            = 0x00;
+constexpr uint8_t OTM8009A_TEEON_TELOM_VBLANKING_AND_HBLANKING_INFO   = 0x01;
+/* Possible values of COLMOD parameter corresponding to used pixel formats */
+constexpr uint8_t OTM8009A_COLMOD_RGB565             = 0x55;
+constexpr uint8_t OTM8009A_COLMOD_RGB888             = 0x77;
+
+constexpr uint8_t OTM8009A_480X800_FREQUENCY_DIVIDER  = 2;   /* LCD Frequency divider      */
+
+const uint8_t lcdRegData1[]  = {0x80,0x09,0x01,0xFF};
+const uint8_t lcdRegData2[]  = {0x80,0x09,0xFF};
+const uint8_t lcdRegData3[]  = {0x00,0x09,0x0F,0x0E,0x07,0x10,0x0B,0x0A,0x04,0x07,0x0B,0x08,0x0F,0x10,0x0A,0x01,0xE1};
+const uint8_t lcdRegData4[]  = {0x00,0x09,0x0F,0x0E,0x07,0x10,0x0B,0x0A,0x04,0x07,0x0B,0x08,0x0F,0x10,0x0A,0x01,0xE2};
+const uint8_t lcdRegData5[]  = {0x79,0x79,0xD8};
+const uint8_t lcdRegData6[]  = {0x00,0x01,0xB3};
+const uint8_t lcdRegData7[]  = {0x85,0x01,0x00,0x84,0x01,0x00,0xCE};
+const uint8_t lcdRegData8[]  = {0x18,0x04,0x03,0x39,0x00,0x00,0x00,0x18,0x03,0x03,0x3A,0x00,0x00,0x00,0xCE};
+const uint8_t lcdRegData9[]  = {0x18,0x02,0x03,0x3B,0x00,0x00,0x00,0x18,0x01,0x03,0x3C,0x00,0x00,0x00,0xCE};
+const uint8_t lcdRegData10[] = {0x01,0x01,0x20,0x20,0x00,0x00,0x01,0x02,0x00,0x00,0xCF};
+const uint8_t lcdRegData11[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData12[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData13[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData14[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData15[] = {0x00,0x04,0x04,0x04,0x04,0x04,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData16[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x04,0x04,0x04,0x04,0x04,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData17[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCB};
+const uint8_t lcdRegData18[] = {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xCB};
+const uint8_t lcdRegData19[] = {0x00,0x26,0x09,0x0B,0x01,0x25,0x00,0x00,0x00,0x00,0xCC};
+const uint8_t lcdRegData20[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x26,0x0A,0x0C,0x02,0xCC};
+const uint8_t lcdRegData21[] = {0x25,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCC};
+const uint8_t lcdRegData22[] = {0x00,0x25,0x0C,0x0A,0x02,0x26,0x00,0x00,0x00,0x00,0xCC};
+const uint8_t lcdRegData23[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x25,0x0B,0x09,0x01,0xCC};
+const uint8_t lcdRegData24[] = {0x26,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xCC};
+const uint8_t lcdRegData25[] = {0xFF,0xFF,0xFF,0xFF};
+/*
+  * CASET value (Column Address Set) : X direction LCD GRAM boundaries
+  * depending on LCD orientation mode and PASET value (Page Address Set) : Y direction
+  * LCD GRAM boundaries depending on LCD orientation mode
+  * XS[15:0] = 0x000 = 0, XE[15:0] = 0x31F = 799 for landscape mode : apply to CASET
+  * YS[15:0] = 0x000 = 0, YE[15:0] = 0x31F = 799 for portrait mode : : apply to PASET
+  */
+const uint8_t lcdRegData27[] = {0x00, 0x00, 0x03, 0x1F, OTM8009A_CMD_CASET};
+/*
+  * XS[15:0] = 0x000 = 0, XE[15:0] = 0x1DF = 479 for portrait mode : apply to CASET
+  * YS[15:0] = 0x000 = 0, YE[15:0] = 0x1DF = 479 for landscape mode : apply to PASET
+ */
+const uint8_t lcdRegData28[] = {0x00, 0x00, 0x01, 0xDF, OTM8009A_CMD_PASET};
+
+
+const uint8_t ShortRegData1[]  = {OTM8009A_CMD_NOP, 0x00};
+const uint8_t ShortRegData2[]  = {OTM8009A_CMD_NOP, 0x80};
+const uint8_t ShortRegData3[]  = {0xC4, 0x30};
+const uint8_t ShortRegData4[]  = {OTM8009A_CMD_NOP, 0x8A};
+const uint8_t ShortRegData5[]  = {0xC4, 0x40};
+const uint8_t ShortRegData6[]  = {OTM8009A_CMD_NOP, 0xB1};
+const uint8_t ShortRegData7[]  = {0xC5, 0xA9};
+const uint8_t ShortRegData8[]  = {OTM8009A_CMD_NOP, 0x91};
+const uint8_t ShortRegData9[]  = {0xC5, 0x34};
+const uint8_t ShortRegData10[] = {OTM8009A_CMD_NOP, 0xB4};
+const uint8_t ShortRegData11[] = {0xC0, 0x50};
+const uint8_t ShortRegData12[] = {0xD9, 0x4E};
+const uint8_t ShortRegData13[] = {OTM8009A_CMD_NOP, 0x81};
+const uint8_t ShortRegData14[] = {0xC1, 0x66};
+const uint8_t ShortRegData15[] = {OTM8009A_CMD_NOP, 0xA1};
+const uint8_t ShortRegData16[] = {0xC1, 0x08};
+const uint8_t ShortRegData17[] = {OTM8009A_CMD_NOP, 0x92};
+const uint8_t ShortRegData18[] = {0xC5, 0x01};
+const uint8_t ShortRegData19[] = {OTM8009A_CMD_NOP, 0x95};
+const uint8_t ShortRegData20[] = {OTM8009A_CMD_NOP, 0x94};
+const uint8_t ShortRegData21[] = {0xC5, 0x33};
+const uint8_t ShortRegData22[] = {OTM8009A_CMD_NOP, 0xA3};
+const uint8_t ShortRegData23[] = {0xC0, 0x1B};
+const uint8_t ShortRegData24[] = {OTM8009A_CMD_NOP, 0x82};
+const uint8_t ShortRegData25[] = {0xC5, 0x83};
+const uint8_t ShortRegData26[] = {0xC4, 0x83};
+const uint8_t ShortRegData27[] = {0xC1, 0x0E};
+const uint8_t ShortRegData28[] = {OTM8009A_CMD_NOP, 0xA6};
+const uint8_t ShortRegData29[] = {OTM8009A_CMD_NOP, 0xA0};
+const uint8_t ShortRegData30[] = {OTM8009A_CMD_NOP, 0xB0};
+const uint8_t ShortRegData31[] = {OTM8009A_CMD_NOP, 0xC0};
+const uint8_t ShortRegData32[] = {OTM8009A_CMD_NOP, 0xD0};
+const uint8_t ShortRegData33[] = {OTM8009A_CMD_NOP, 0x90};
+const uint8_t ShortRegData34[] = {OTM8009A_CMD_NOP, 0xE0};
+const uint8_t ShortRegData35[] = {OTM8009A_CMD_NOP, 0xF0};
+const uint8_t ShortRegData36[] = {OTM8009A_CMD_SLPOUT, 0x00};
+const uint8_t ShortRegData37[] = {OTM8009A_CMD_COLMOD, OTM8009A_COLMOD_RGB565};
+const uint8_t ShortRegData38[] = {OTM8009A_CMD_COLMOD, OTM8009A_COLMOD_RGB888};
+const uint8_t ShortRegData39[] = {OTM8009A_CMD_MADCTR, OTM8009A_MADCTR_MODE_LANDSCAPE};
+const uint8_t ShortRegData40[] = {OTM8009A_CMD_WRDISBV, 0x7F};
+const uint8_t ShortRegData41[] = {OTM8009A_CMD_WRCTRLD, 0x2C};
+const uint8_t ShortRegData42[] = {OTM8009A_CMD_WRCABC, 0x02};
+const uint8_t ShortRegData43[] = {OTM8009A_CMD_WRCABCMB, 0xFF};
+const uint8_t ShortRegData44[] = {OTM8009A_CMD_DISPON, 0x00};
+const uint8_t ShortRegData45[] = {OTM8009A_CMD_RAMWR, 0x00};
+const uint8_t ShortRegData46[] = {0xCF, 0x00};
+const uint8_t ShortRegData47[] = {0xC5, 0x66};
+const uint8_t ShortRegData48[] = {OTM8009A_CMD_NOP, 0xB6};
+const uint8_t ShortRegData49[] = {0xF5, 0x06};
+
+void otm8009a_init(uint8_t ColorCoding)
+{
+	/* Enable CMD2 to access vendor specific commands                               */
+	/* Enter in command 2 mode and set EXTC to enable address shift function (0x00) */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command( 3, (uint8_t *)lcdRegData1);
+
+	/* Enter ORISE Command 2 */
+	dsi_write_command(0, (uint8_t *)ShortRegData2); /* Shift address to 0x80 */
+	dsi_write_command( 2, (uint8_t *)lcdRegData2);
+
+	/////////////////////////////////////////////////////////////////////
+	/* SD_PCH_CTRL - 0xC480h - 129th parameter - Default 0x00          */
+	/* Set SD_PT                                                       */
+	/* -> Source output level during porch and non-display area to GND */
+	dsi_write_command(0, (uint8_t *)ShortRegData2);
+	dsi_write_command(0, (uint8_t *)ShortRegData3);
+	xpcc::delayMilliseconds(10);
+	/* Not documented */
+	dsi_write_command(0, (uint8_t *)ShortRegData4);
+	dsi_write_command(0, (uint8_t *)ShortRegData5);
+	xpcc::delayMilliseconds(10);
+	/////////////////////////////////////////////////////////////////////
+
+	/* PWR_CTRL4 - 0xC4B0h - 178th parameter - Default 0xA8 */
+	/* Set gvdd_en_test                                     */
+	/* -> enable GVDD test mode !!!                         */
+	dsi_write_command(0, (uint8_t *)ShortRegData6);
+	dsi_write_command(0, (uint8_t *)ShortRegData7);
+
+	/* PWR_CTRL2 - 0xC590h - 146th parameter - Default 0x79      */
+	/* Set pump 4 vgh voltage                                    */
+	/* -> from 15.0v down to 13.0v                               */
+	/* Set pump 5 vgh voltage                                    */
+	/* -> from -12.0v downto -9.0v                               */
+	dsi_write_command(0, (uint8_t *)ShortRegData8);
+	dsi_write_command(0, (uint8_t *)ShortRegData9);
+
+	/* P_DRV_M - 0xC0B4h - 181th parameter - Default 0x00 */
+	/* -> Column inversion                                */
+	dsi_write_command(0, (uint8_t *)ShortRegData10);
+	dsi_write_command(0, (uint8_t *)ShortRegData11);
+
+	/* VCOMDC - 0xD900h - 1st parameter - Default 0x39h */
+	/* VCOM Voltage settings                            */
+	/* -> from -1.0000v downto -1.2625v                 */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command(0, (uint8_t *)ShortRegData12);
+
+	/* Oscillator adjustment for Idle/Normal mode (LPDT only) set to 65Hz (default is 60Hz) */
+	dsi_write_command(0, (uint8_t *)ShortRegData13);
+	dsi_write_command(0, (uint8_t *)ShortRegData14);
+
+	/* Video mode internal */
+	dsi_write_command(0, (uint8_t *)ShortRegData15);
+	dsi_write_command(0, (uint8_t *)ShortRegData16);
+
+	/* PWR_CTRL2 - 0xC590h - 147h parameter - Default 0x00 */
+	/* Set pump 4&5 x6                                     */
+	/* -> ONLY VALID when PUMP4_EN_ASDM_HV = "0"           */
+	dsi_write_command(0, (uint8_t *)ShortRegData17);
+	dsi_write_command(0, (uint8_t *)ShortRegData18);
+
+	/* PWR_CTRL2 - 0xC590h - 150th parameter - Default 0x33h */
+	/* Change pump4 clock ratio                              */
+	/* -> from 1 line to 1/2 line                            */
+	dsi_write_command(0, (uint8_t *)ShortRegData19);
+	dsi_write_command(0, (uint8_t *)ShortRegData9);
+
+	/* GVDD/NGVDD settings */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command( 2, (uint8_t *)lcdRegData5);
+
+	/* PWR_CTRL2 - 0xC590h - 149th parameter - Default 0x33h */
+	/* Rewrite the default value !                           */
+	dsi_write_command(0, (uint8_t *)ShortRegData20);
+	dsi_write_command(0, (uint8_t *)ShortRegData21);
+
+	/* Panel display timing Setting 3 */
+	dsi_write_command(0, (uint8_t *)ShortRegData22);
+	dsi_write_command(0, (uint8_t *)ShortRegData23);
+
+	/* Power control 1 */
+	dsi_write_command(0, (uint8_t *)ShortRegData24);
+	dsi_write_command(0, (uint8_t *)ShortRegData25);
+
+	/* Source driver precharge */
+	dsi_write_command(0, (uint8_t *)ShortRegData13);
+	dsi_write_command(0, (uint8_t *)ShortRegData26);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData15);
+	dsi_write_command(0, (uint8_t *)ShortRegData27);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData28);
+	dsi_write_command( 2, (uint8_t *)lcdRegData6);
+
+	/* GOAVST */
+	dsi_write_command(0, (uint8_t *)ShortRegData2);
+	dsi_write_command( 6, (uint8_t *)lcdRegData7);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData29);
+	dsi_write_command( 14, (uint8_t *)lcdRegData8);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData30);
+	dsi_write_command( 14, (uint8_t *)lcdRegData9);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData31);
+	dsi_write_command( 10, (uint8_t *)lcdRegData10);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData32);
+	dsi_write_command(0, (uint8_t *)ShortRegData46);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData2);
+	dsi_write_command( 10, (uint8_t *)lcdRegData11);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData33);
+	dsi_write_command( 15, (uint8_t *)lcdRegData12);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData29);
+	dsi_write_command( 15, (uint8_t *)lcdRegData13);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData30);
+	dsi_write_command( 10, (uint8_t *)lcdRegData14);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData31);
+	dsi_write_command( 15, (uint8_t *)lcdRegData15);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData32);
+	dsi_write_command( 15, (uint8_t *)lcdRegData16);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData34);
+	dsi_write_command( 10, (uint8_t *)lcdRegData17);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData35);
+	dsi_write_command( 10, (uint8_t *)lcdRegData18);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData2);
+	dsi_write_command( 10, (uint8_t *)lcdRegData19);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData33);
+	dsi_write_command( 15, (uint8_t *)lcdRegData20);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData29);
+	dsi_write_command( 15, (uint8_t *)lcdRegData21);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData30);
+	dsi_write_command( 10, (uint8_t *)lcdRegData22);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData31);
+	dsi_write_command( 15, (uint8_t *)lcdRegData23);
+
+	dsi_write_command(0, (uint8_t *)ShortRegData32);
+	dsi_write_command( 15, (uint8_t *)lcdRegData24);
+
+	/////////////////////////////////////////////////////////////////////////////
+	/* PWR_CTRL1 - 0xc580h - 130th parameter - default 0x00 */
+	/* Pump 1 min and max DM                                */
+	dsi_write_command(0, (uint8_t *)ShortRegData13);
+	dsi_write_command(0, (uint8_t *)ShortRegData47);
+	dsi_write_command(0, (uint8_t *)ShortRegData48);
+	dsi_write_command(0, (uint8_t *)ShortRegData49);
+	/////////////////////////////////////////////////////////////////////////////
+
+	/* Exit CMD2 mode */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command( 3, (uint8_t *)lcdRegData25);
+
+	/*************************************************************************** */
+	/* Standard DCS Initialization TO KEEP CAN BE DONE IN HSDT                   */
+	/*************************************************************************** */
+
+	/* NOP - goes back to DCS std command ? */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+
+	/* Gamma correction 2.2+ table (HSDT possible) */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command( 16, (uint8_t *)lcdRegData3);
+
+	/* Gamma correction 2.2- table (HSDT possible) */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+	dsi_write_command( 16, (uint8_t *)lcdRegData4);
+
+	/* Send Sleep Out command to display : no parameter */
+	dsi_write_command(0, (uint8_t *)ShortRegData36);
+
+	/* Wait for sleep out exit */
+	xpcc::delayMilliseconds(120);
+
+	if (ColorCoding == 0) {
+		dsi_write_command(0, (uint8_t *)ShortRegData38);
+	} else {
+		dsi_write_command(0, (uint8_t *)ShortRegData37);
+	}
+
+	/* Send command to configure display in landscape orientation mode. By default
+	  the orientation mode is portrait  */
+	dsi_write_command(0, (uint8_t *)ShortRegData39);
+	dsi_write_command( 4, (uint8_t *)lcdRegData27);
+	dsi_write_command( 4, (uint8_t *)lcdRegData28);
+
+	/** CABC : Content Adaptive Backlight Control section start >> */
+	/* Note : defaut is 0 (lowest Brightness), 0xFF is highest Brightness, try 0x7F : intermediate value */
+	dsi_write_command(0, (uint8_t *)ShortRegData40);
+
+	/* defaut is 0, try 0x2C - Brightness Control Block, Display Dimming & BackLight on */
+	dsi_write_command(0, (uint8_t *)ShortRegData41);
+
+	/* defaut is 0, try 0x02 - image Content based Adaptive Brightness [Still Picture] */
+	dsi_write_command(0, (uint8_t *)ShortRegData42);
+
+	/* defaut is 0 (lowest Brightness), 0xFF is highest Brightness */
+	dsi_write_command(0, (uint8_t *)ShortRegData43);
+
+	/** CABC : Content Adaptive Backlight Control section end << */
+
+	/* Send Command Display On */
+	dsi_write_command(0, (uint8_t *)ShortRegData44);
+
+	/* NOP command */
+	dsi_write_command(0, (uint8_t *)ShortRegData1);
+
+	/* Send Command GRAM memory write (no parameters) : this initiates frame write via other DSI commands sent by */
+	/* DSI host from LTDC incoming pixels in video mode */
+	dsi_write_command(0, (uint8_t *)ShortRegData45);
+}

--- a/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_sdram.cpp
+++ b/src/xpcc/architecture/platform/board/stm32f469_discovery/stm32f469_discovery_sdram.cpp
@@ -1,0 +1,155 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+//
+// STM32F469I-DISCO
+// Discovery kit for STM32F469 line
+// http://www.st.com/web/catalog/tools/FM116/CL1620/SC959/SS1532/LN1848/PF262395
+//
+
+#include "stm32f469_discovery.hpp"
+#include <xpcc/utils/bit_constants.hpp>
+
+// ----------------------------------- SDRAM -----------------------------------
+static void
+sdram_configure_gpio(GPIO_TypeDef * const port, const uint16_t mask)
+{
+	// For all GPIOs:
+	// - Pull-Up
+	// - Fast Speed
+	// - Alternate Function 12
+	// => MODER = 0b10
+	// => OTYPER = 0b0
+	// => OSPEEDR = 0b11
+	// => PUPDR = 0b01
+	// => AFR = 0b1100
+
+	// compute the 0b11 and 0b1111 spreads
+	uint32_t portMask2 = 0;
+	uint32_t portMask4[2] = {0,0};
+	for (int ii = 0; ii < 16; ii++) {
+		if (mask & (1 << ii)) {
+			portMask2 |= (0b11 << (ii * 2));
+			if (ii < 8) {
+				portMask4[0] |= (0b1111 << (ii * 4));
+			} else {
+				portMask4[1] |= (0b1111 << ((ii - 8) * 4));
+			}
+		}
+	}
+	// mask to get the actual bit masks
+	const uint32_t port01 = 0x55555555 & portMask2;
+	const uint32_t port10 = 0xAAAAAAAA & portMask2;
+	const uint32_t port1100L = 0xCCCCCCCC & portMask4[0];
+	const uint32_t port1100H = 0xCCCCCCCC & portMask4[1];
+
+	port->AFR[0]  = port1100L;
+	port->AFR[1]  = port1100H;
+	port->OSPEEDR = port10 | port01;
+	port->PUPDR   = port01;
+	port->MODER   = port10;
+	port->OTYPER &= ~mask;
+
+	// We lock the corresponding GPIO pins, so that users do not shoot
+	// themselves in their feet, if they accidentally use SDRAM GPIOs.
+	port->LCKR = 0x10000 | mask;
+	port->LCKR = 0x00000 | mask;
+	port->LCKR = 0x10000 | mask;
+	(void) port->LCKR;
+}
+
+static bool
+sdram_send_command(uint8_t mode, uint8_t auto_refresh = 1, uint16_t mode_register = 0)
+{
+	FMC_Bank5_6->SDCMR =	((mode_register << 9) & FMC_SDCMR_MRD) |
+							(((auto_refresh - 1) << 5) & FMC_SDCMR_NRFS) |
+							FMC_SDCMR_CTB1 | (mode & FMC_SDCMR_MODE);
+
+	int t = 1024;
+	for (; (FMC_Bank5_6->SDSR & FMC_SDSR_BUSY) and t; t--) {
+		xpcc::delayMilliseconds(1);
+	}
+
+	return t;
+}
+
+void
+board_initialize_sdram()
+{
+	using namespace xpcc;
+	// Strongly inspired by the F469I-DISCO BSP from ST
+
+	// Configure all pins
+	// C0
+	sdram_configure_gpio(GPIOC, Bit0);
+	// D0, D1, D8, D9, D10, D14, D15
+	sdram_configure_gpio(GPIOD, Bit0 | Bit1 | Bit8 | Bit9 | Bit10 | Bit14 | Bit15);
+	// E0, E1, E7, E8, E9, E10, E11, E12, E13, E14, E15
+	sdram_configure_gpio(GPIOE, Bit0 | Bit1 | Bit7 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// F0, F1, F2, F3, F4, F5, F11, F12, F13, F14, F15
+	sdram_configure_gpio(GPIOF, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// G0, G1, G4, G5, G8, G15
+	sdram_configure_gpio(GPIOG, Bit0 | Bit1 | Bit4 | Bit5 | Bit8 | Bit15);
+	// H2, H3, H8, H9, H10, H11, H12, H13, H14, H15
+	sdram_configure_gpio(GPIOH, Bit2 | Bit3 | Bit8 | Bit9 | Bit10 | Bit11 | Bit12 | Bit13 | Bit14 | Bit15);
+	// I0, I1, I2, I3, I4, I5, I6, I7, I9, I10
+	sdram_configure_gpio(GPIOI, Bit0 | Bit1 | Bit2 | Bit3 | Bit4 | Bit5 | Bit6 | Bit7 | Bit9 | Bit10);
+
+	// Configure the SDRAM
+	// Enable FMC clock
+	RCC->AHB3ENR |= RCC_AHB3ENR_FMCEN;
+	(void) RCC->AHB3ENR;
+
+	/* SDRAM Control register (only bank 1 is used):
+	 * - RPIPE: 0b00 (0 cycle delay)
+	 * - RBURST: 0b1 (enabled)
+	 * - SDCLK: 0b10 (2x HCLK periods)
+	 * - WP: 0x0 (disabled)
+	 * - CAS: 0x11 (3 cycles)
+	 * - NB: 0b1 (4 internal banks)
+	 * - MWID: 0b10 (32bit data bus width)
+	 * - NR: 0b01 (12 bit)
+	 * - NC: 0b00 (8 bit)
+	 */
+	FMC_Bank5_6->SDCR[0] =  FMC_SDCR1_RBURST | FMC_SDCR1_SDCLK_1 | FMC_SDCR1_NB | FMC_SDCR1_NR_0 |
+							FMC_SDCR1_MWID_1 | FMC_SDCR1_CAS_1 | FMC_SDCR1_CAS_0;
+
+	/* SDRAM Timing register (for 90 MHz as SD clock frequency)
+	 * - TRCD: 0b0001 (2 cycles)
+	 * - TRP:  0b0001 (2 cycles)
+	 * - TWR:  0b0001 (2 cycles)
+	 * - TRC:  0b0110 (7 cycles)
+	 * - TRAS: 0b0011 (4 cycles)
+	 * - TXSR: 0b0110 (7 cycles)
+	 * - TMRD: 0b0001 (2 cycles)
+	 */
+	FMC_Bank5_6->SDTR[0] = 0x01116361;
+
+	// FMC_SDRAM_CMD_CLK_ENABLE
+	sdram_send_command(1);
+	xpcc::delayMilliseconds(1);
+	// FMC_SDRAM_CMD_PALL
+	sdram_send_command(2);
+	// FMC_SDRAM_CMD_AUTOREFRESH_MODE
+	sdram_send_command(3, 8);
+	/* FMC_SDRAM_CMD_LOAD_MODE:
+	 * - SDRAM_MODEREG_BURST_LENGTH_1
+	 * - SDRAM_MODEREG_BURST_TYPE_SEQUENTIAL
+	 * - SDRAM_MODEREG_CAS_LATENCY_3
+	 * - SDRAM_MODEREG_OPERATING_MODE_STANDARD
+	 * - SDRAM_MODEREG_WRITEBURST_MODE_SINGLE
+	 */
+	sdram_send_command(4, 1, 0x230);
+
+	// Set refresh rate:
+	FMC_Bank5_6->SDRTR = (0x0569 << 1);
+
+	// Zero the entire SDRAM
+	memset((void*)0xC0000000, 0, 16*1024*1024);
+}

--- a/src/xpcc/driver/touch/ft6x06.hpp
+++ b/src/xpcc/driver/touch/ft6x06.hpp
@@ -1,0 +1,207 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------- */
+
+#ifndef XPCC_FT6X06_HPP
+#define XPCC_FT6X06_HPP
+
+#include <xpcc/architecture/interface/i2c_device.hpp>
+
+namespace xpcc
+{
+
+// forward declaration for friending with ft6x06::Data
+template < class I2cMaster >
+class Ft6x06;
+
+struct ft6x06
+{
+protected:
+	/// @cond
+	/// The addresses of the Configuration and Data Registers
+	enum class
+	Register : uint8_t
+	{
+		DEV_MODE = 0x00,
+
+		GEST_ID = 0x01,
+		TD_STATUS = 0x02,
+
+		P1_XH = 0x03,
+		P1_XL = 0x04,
+		P1_YH = 0x05,
+		P1_YL = 0x06,
+		P1_WEIGHT = 0x07,
+		P1_MISC = 0x08,
+
+		P2_XH = 0x09,
+		P2_XL = 0x0A,
+		P2_YH = 0x0B,
+		P2_YL = 0x0C,
+		P2_WEIGHT = 0x0D,
+		P2_MISC = 0x0E,
+
+		TH_GROUP = 0x80,
+		TH_DIFF = 0x85,
+
+		CTRL = 0x86,
+		TIME_ENTER_MONITOR = 0x87,
+		PERIOD_ACTIVE = 0x88,
+		PERIOD_MONITOR = 0x89,
+		RADIAN_VALUE = 0x91,
+		OFFSET_LEFT_RIGHT = 0x92,
+		OFFSET_UP_DOWN = 0x93,
+		DISTANCE_LEFT_RIGHT = 0x94,
+		DISTANCE_UP_DOWN = 0x95,
+		DISTANCE_ZOOM = 0x96,
+
+		LIB_VER_H = 0xA1,
+		LIB_VER_L = 0xA2,
+		CIPHER = 0xA3,
+		G_MODE = 0xA4,
+		PWR_MODE = 0xA5,
+		FIRMID = 0xA6,
+		FOCALTECH_ID = 0xA8,
+		RELEASE_CODE_ID = 0xAF,
+
+		STATE = 0xBC,
+	};
+	/// @endcond
+
+public:
+	enum class
+	Gesture : uint8_t
+	{
+		NoGesture = 0x00,
+		MoveUp = 0x10,
+		MoveRight = 0x14,
+		MoveDown = 0x18,
+		MoveLeft = 0x1C,
+		ZoomIn = 0x48,
+		ZoomOut = 0x49,
+	};
+
+	enum class
+	Event : uint8_t
+	{
+		NoEvent = (0b11 << 6),
+		PressDown = (0b00 << 6),
+		LiftUp = (0b01 << 6),
+		Contact = (0b10 << 6),
+	};
+
+	enum class
+	InterruptMode : uint8_t
+	{
+		Polling = 0,
+		Trigger = 1
+	};
+
+public:
+	struct
+	touch_t
+	{
+		touch_t() : id(0), event(Event::NoEvent), x(0), y(0) {}
+
+		uint8_t id;
+		Event event;
+
+		uint16_t x;
+		uint16_t y;
+
+		// are always zero
+		// uint8_t weight;
+		// uint8_t area;
+	};
+
+	struct ATTRIBUTE_PACKED
+	Data
+	{
+		template< class I2cMaster >
+		friend class Ft6x06;
+
+		inline Gesture
+		getGesture() { return Gesture(data[0]); }
+
+		inline uint8_t
+		getPoints() { return data[1]; }
+
+		inline bool
+		getTouch(touch_t *t, uint8_t index)
+		{
+			if (index >= 2) return false;
+			// touches start at offset 2 and are 6B long
+			uint8_t *d = data + 2 + index * 6;
+
+			t->event = Event(d[0] & 0xc0);
+			t->x = ((d[0] & 0x0f) << 8) | d[1];
+			t->id = d[2] >> 4;
+			t->y = ((d[2] & 0x0f) << 8) | d[3];
+			// weight and area are always zero
+			// t->weight = d[4];
+			// t->area = d[5] >> 4;
+
+			return true;
+		}
+
+	private:
+		uint8_t data[14];
+	};
+}; // struct ft6x06
+
+/**
+ * FT6x06 capacitive touch panel driver.
+ *
+ * The driver is reasonably simple, due to the datasheet not being very
+ * descriptive.
+ *
+ * @author	Niklas Hauser
+ * @ingroup driver_touch
+ */
+template < typename I2cMaster >
+class Ft6x06 : public ft6x06, public xpcc::I2cDevice< I2cMaster, 3 >
+{
+public:
+	/// Constructor, requires an ft6x06::Data object, sets address to default of 0x2A
+	Ft6x06(Data &data, uint8_t address=0x2A);
+
+	xpcc::ResumableResult<bool>
+	configure(InterruptMode mode, uint8_t activeRate = 60, uint8_t monitorRate = 25);
+
+	/// Reads all touches and writes the result to the data object
+	xpcc::ResumableResult<bool>
+	readTouches();
+
+public:
+	/// Get the data object for this sensor.
+	inline Data&
+	getData()
+	{ return data; }
+
+protected:
+	/// @cond
+	/// write a 8bit value a register
+	xpcc::ResumableResult<bool>
+	write(Register reg, uint8_t value);
+
+	/// read multiple 8bit values from a start register
+	xpcc::ResumableResult<bool>
+	read(Register reg, uint8_t *buffer, uint8_t length);
+	/// @endcond
+
+protected:
+	/// @cond
+	Data &data;
+	// the read buffer is for a continous read from address 0x01 -> 0x0E
+	uint8_t buffer[14];
+	/// @endcond
+};
+
+}	// namespace xpcc
+
+#include "ft6x06_impl.hpp"
+
+#endif // XPCC_FT6X06_HPP

--- a/src/xpcc/driver/touch/ft6x06_impl.hpp
+++ b/src/xpcc/driver/touch/ft6x06_impl.hpp
@@ -1,0 +1,78 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------- */
+
+#ifndef XPCC_FT6X06_HPP
+#	error "Don't include this file directly, use 'ft6x06.hpp' instead!"
+#endif
+
+// ----------------------------------------------------------------------------
+template < typename I2cMaster >
+xpcc::Ft6x06<I2cMaster>::Ft6x06(Data &data, uint8_t address)
+:	I2cDevice<I2cMaster,3>(address), data(data)
+{
+}
+
+// MARK: - Tasks
+template < typename I2cMaster >
+xpcc::ResumableResult<bool>
+xpcc::Ft6x06<I2cMaster>::configure(InterruptMode mode, uint8_t activeRate, uint8_t monitorRate)
+{
+	RF_BEGIN();
+
+	if (RF_CALL(write(Register::G_MODE, uint8_t(mode))))
+	{
+		if (RF_CALL(write(Register::PERIOD_ACTIVE, activeRate)))
+		{
+			RF_RETURN_CALL(write(Register::PERIOD_MONITOR, monitorRate));
+		}
+	}
+
+	RF_END_RETURN(false);
+}
+
+template < typename I2cMaster >
+xpcc::ResumableResult<bool>
+xpcc::Ft6x06<I2cMaster>::readTouches()
+{
+	RF_BEGIN();
+
+	if (RF_CALL(read(Register::GEST_ID, buffer, 14)))
+	{
+		std::memcpy(data.data, buffer, 14);
+		RF_RETURN(true);
+	}
+
+	RF_END_RETURN(false);
+}
+
+// ----------------------------------------------------------------------------
+// MARK: write register
+template < class I2cMaster >
+xpcc::ResumableResult<bool>
+xpcc::Ft6x06<I2cMaster>::write(Register reg, uint8_t value)
+{
+	RF_BEGIN();
+
+	buffer[0] = uint8_t(reg);
+	buffer[1] = value;
+	this->transaction.configureWrite(buffer, 2);
+
+	RF_END_RETURN_CALL( this->runTransaction() );
+}
+
+// MARK: read multilength register
+template < class I2cMaster >
+xpcc::ResumableResult<bool>
+xpcc::Ft6x06<I2cMaster>::read(Register reg, uint8_t *buffer, uint8_t length)
+{
+	RF_BEGIN();
+
+	this->buffer[0] = uint8_t(reg);
+	this->transaction.configureWriteRead(this->buffer, 1, buffer, length);
+
+	RF_END_RETURN_CALL( this->runTransaction() );
+}


### PR DESCRIPTION
This commits enables and configures the DSI and LTDC peripherals for 16-bit RGB565 color and adds a working `xpcc::GraphicDisplay` implementation.

cc @ekiwi @daniel-k
