### PR TITLE
[DFG] Add `out` type to all STM32 timer channels.

### DIFF
--- a/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f072-c_r_v-8_b.xml
@@ -63,7 +63,7 @@
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
         <af id="1" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="4" peripheral="Uart4" name="Tx" type="out"/>
         <af id="4" peripheral="UartSpiMaster4" name="Mosi" type="out"/>
@@ -72,76 +72,76 @@
       <gpio port="A" id="1">
         <af id="1" peripheral="Uart2" name="De"/>
         <af id="1" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="2" peripheral="Timer2" name="Channel2"/>
+        <af id="2" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="4" peripheral="Uart4" name="Rx" type="in"/>
         <af id="4" peripheral="UartSpiMaster4" name="Miso" type="in"/>
-        <af id="5" peripheral="Timer15" name="Channel1N"/>
+        <af id="5" peripheral="Timer15" name="Channel1N" type="out"/>
         <!-- <af peripheral="Adc" name="Channel1" type="analog"/> -->
       </gpio>
       <gpio port="A" id="2">
-        <af id="0" peripheral="Timer15" name="Channel1"/>
+        <af id="0" peripheral="Timer15" name="Channel1" type="out"/>
         <af id="1" peripheral="Uart2" name="Tx" type="out"/>
         <af id="1" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="2" peripheral="Timer2" name="Channel3"/>
+        <af id="2" peripheral="Timer2" name="Channel3" type="out"/>
         <!-- <af peripheral="Adc" name="Channel2" type="analog"/> -->
       </gpio>
       <gpio port="A" id="3">
-        <af id="0" peripheral="Timer15" name="Channel2"/>
+        <af id="0" peripheral="Timer15" name="Channel2" type="out"/>
         <af id="1" peripheral="Uart2" name="Rx" type="in"/>
         <af id="1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="2" peripheral="Timer2" name="Channel4"/>
+        <af id="2" peripheral="Timer2" name="Channel4" type="out"/>
         <!-- <af peripheral="Adc" name="Channel3" type="analog"/> -->
       </gpio>
       <gpio port="A" id="4">
         <af id="0" peripheral="SpiMaster1" name="Nss"/>
         <af id="1" peripheral="Uart2" name="Ck" type="out"/>
         <af id="1" peripheral="UartSpiMaster2" name="Sck" type="out"/>
-        <af id="4" peripheral="Timer14" name="Channel1"/>
+        <af id="4" peripheral="Timer14" name="Channel1" type="out"/>
         <!-- <af peripheral="Adc" name="Channel4" type="analog"/> -->
       </gpio>
       <gpio port="A" id="5">
         <af id="0" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <!-- <af peripheral="Adc" name="Channel5" type="analog"/> -->
       </gpio>
       <gpio port="A" id="6">
         <af id="0" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="1" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer1" name="BreakIn" type="in"/>
         <af id="4" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="5" peripheral="Timer16" name="Channel1"/>
+        <af id="5" peripheral="Timer16" name="Channel1" type="out"/>
         <!-- <af peripheral="Adc" name="Channel6" type="analog"/> -->
       </gpio>
       <gpio port="A" id="7">
         <af id="0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="1" peripheral="Timer3" name="Channel2"/>
-        <af id="2" peripheral="Timer1" name="Channel1N"/>
-        <af id="4" peripheral="Timer14" name="Channel1"/>
-        <af id="5" peripheral="Timer17" name="Channel1"/>
+        <af id="1" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="4" peripheral="Timer14" name="Channel1" type="out"/>
+        <af id="5" peripheral="Timer17" name="Channel1" type="out"/>
         <!-- <af peripheral="Adc" name="Channel7" type="analog"/> -->
       </gpio>
       <gpio port="A" id="8">
         <!-- <af id="0" peripheral="ClockOutput" type="out"/> -->
         <af id="1" peripheral="Uart1" name="Ck" type="out"/>
         <af id="1" peripheral="UartSpiMaster1" name="Sck" type="out"/>
-        <af id="2" peripheral="Timer1" name="Channel1"/>
+        <af id="2" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="9">
         <af id="0" peripheral="Timer15" name="BreakIn" type="in"/>
         <af id="1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="2" peripheral="Timer1" name="Channel2"/>
+        <af id="2" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="0" peripheral="Timer17" name="BreakIn" type="in"/>
         <af id="1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="2" peripheral="Timer1" name="Channel3"/>
+        <af id="2" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="11">
         <af id="1" peripheral="Uart1" name="Cts" type="in"/>
-        <af id="2" peripheral="Timer1" name="Channel4"/>
+        <af id="2" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="4" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="A" id="12">
@@ -159,22 +159,22 @@
         <af id="0" peripheral="SpiMaster1" name="Nss"/>
         <af id="1" peripheral="Uart2" name="Rx" type="in"/>
         <af id="1" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="4" peripheral="Uart4" name="De"/>
         <af id="4" peripheral="Uart4" name="Rts" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer3" name="Channel3"/>
-        <af id="2" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="4" peripheral="Uart3" name="Ck" type="out"/>
         <af id="4" peripheral="UartSpiMaster3" name="Sck" type="out"/>
         <!-- <af peripheral="Adc" name="Channel8" type="analog"/> -->
       </gpio>
       <gpio port="B" id="1">
-        <af id="0" peripheral="Timer14" name="Channel1"/>
-        <af id="1" peripheral="Timer3" name="Channel4"/>
-        <af id="2" peripheral="Timer1" name="Channel3N"/>
+        <af id="0" peripheral="Timer14" name="Channel1" type="out"/>
+        <af id="1" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="4" peripheral="Uart3" name="De"/>
         <af id="4" peripheral="Uart3" name="Rts" type="out"/>
         <!-- <af peripheral="Adc" name="Channel9" type="analog"/> -->
@@ -182,52 +182,52 @@
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="2" peripheral="Timer2" name="Channel2"/>
+        <af id="2" peripheral="Timer2" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="1" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="Timer17" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="1" peripheral="Timer3" name="Channel2"/>
+        <af id="1" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="2" peripheral="Timer16" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="6">
         <af id="0" peripheral="Uart1" name="Tx" type="out"/>
         <af id="0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="2" peripheral="Timer16" name="Channel1N"/>
+        <af id="2" peripheral="Timer16" name="Channel1N" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="0" peripheral="Uart1" name="Rx" type="in"/>
         <af id="0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
         <af id="1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="2" peripheral="Timer17" name="Channel1N"/>
+        <af id="2" peripheral="Timer17" name="Channel1N" type="out"/>
         <af id="4" peripheral="Uart4" name="Cts" type="in"/>
       </gpio>
       <gpio port="B" id="8">
         <af id="1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="2" peripheral="Timer16" name="Channel1"/>
+        <af id="2" peripheral="Timer16" name="Channel1" type="out"/>
         <af id="4" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
         <af id="1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="2" peripheral="Timer17" name="Channel1"/>
+        <af id="2" peripheral="Timer17" name="Channel1" type="out"/>
         <af id="4" peripheral="Can1" name="Tx" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio port="B" id="10">
         <af id="1" peripheral="I2cMaster2" name="Scl" type="out"/>
-        <af id="2" peripheral="Timer2" name="Channel3"/>
+        <af id="2" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="11">
         <af id="1" peripheral="I2cMaster2" name="Sda"/>
-        <af id="2" peripheral="Timer2" name="Channel4"/>
+        <af id="2" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4" peripheral="UartSpiMaster3" name="Miso" type="in"/>
       </gpio>
@@ -240,23 +240,23 @@
       </gpio>
       <gpio port="B" id="13">
         <af id="0" peripheral="SpiMaster2" name="Sck" type="out"/>
-        <af id="2" peripheral="Timer1" name="Channel1N"/>
+        <af id="2" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="4" peripheral="Uart3" name="Cts" type="in"/>
         <af id="5" peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio port="B" id="14">
         <af id="0" peripheral="SpiMaster2" name="Miso" type="in"/>
-        <af id="1" peripheral="Timer15" name="Channel1"/>
-        <af id="2" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer15" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="4" peripheral="Uart3" name="De"/>
         <af id="4" peripheral="Uart3" name="Rts" type="out"/>
         <af id="5" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="15">
         <af id="0" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="1" peripheral="Timer15" name="Channel2"/>
-        <af id="2" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer15" name="Channel1N"/>
+        <af id="1" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer15" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="0">
         <!-- <af peripheral="Adc" name="Channel10" type="analog"/> -->
@@ -283,16 +283,16 @@
         <!-- <af peripheral="Adc" name="Channel15" type="analog"/> -->
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="0" peripheral="Timer3" name="Channel1"/>
+        <af id="0" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="0" peripheral="Timer3" name="Channel2"/>
+        <af id="0" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="0" peripheral="Timer3" name="Channel3"/>
+        <af id="0" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
-        <af id="0" peripheral="Timer3" name="Channel4"/>
+        <af id="0" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
         <af id="0" peripheral="Uart4" name="Tx" type="out"/>
@@ -372,51 +372,51 @@
       <gpio device-pin-id="v" port="D" id="14"/>
       <gpio device-pin-id="v" port="D" id="15"/>
       <gpio device-pin-id="v" port="E" id="0">
-        <af id="0" peripheral="Timer16" name="Channel1"/>
+        <af id="0" peripheral="Timer16" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="1">
-        <af id="0" peripheral="Timer17" name="Channel1"/>
+        <af id="0" peripheral="Timer17" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="2">
         <af id="0" peripheral="Timer3" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="3">
-        <af id="0" peripheral="Timer3" name="Channel1"/>
+        <af id="0" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="4">
-        <af id="0" peripheral="Timer3" name="Channel2"/>
+        <af id="0" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="5">
-        <af id="0" peripheral="Timer3" name="Channel3"/>
+        <af id="0" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="6">
-        <af id="0" peripheral="Timer3" name="Channel4"/>
+        <af id="0" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="7">
         <af id="0" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="8">
-        <af id="0" peripheral="Timer1" name="Channel1N"/>
+        <af id="0" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="9">
-        <af id="0" peripheral="Timer1" name="Channel1"/>
+        <af id="0" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="10">
-        <af id="0" peripheral="Timer1" name="Channel2N"/>
+        <af id="0" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="11">
-        <af id="0" peripheral="Timer1" name="Channel2"/>
+        <af id="0" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="12">
-        <af id="0" peripheral="Timer1" name="Channel3N"/>
+        <af id="0" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="1" peripheral="SpiMaster1" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="13">
-        <af id="0" peripheral="Timer1" name="Channel3"/>
+        <af id="0" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="1" peripheral="SpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="14">
-        <af id="0" peripheral="Timer1" name="Channel4"/>
+        <af id="0" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="1" peripheral="SpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="15">
@@ -429,10 +429,10 @@
       <gpio device-pin-id="v" port="F" id="3"/>
       <gpio device-pin-id="v" port="F" id="6"/>
       <gpio device-pin-id="v" port="F" id="9">
-        <af id="0" peripheral="Timer15" name="Channel1"/>
+        <af id="0" peripheral="Timer15" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="F" id="10">
-        <af id="0" peripheral="Timer15" name="Channel2"/>
+        <af id="0" peripheral="Timer15" name="Channel2" type="out"/>
       </gpio>
     </driver>
   </device>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f100-c_r_v-8_b.xml
@@ -70,28 +70,28 @@
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">
         <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
         <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
         <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
-        <af peripheral="Timer15" name="Channel1"/>
+        <af peripheral="Timer15" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="3">
         <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
-        <af peripheral="Timer15" name="Channel2"/>
+        <af peripheral="Timer15" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="4">
         <af id="0,1,0" peripheral="SpiMaster1" name="Nss"/>
@@ -106,19 +106,19 @@
       <gpio port="A" id="6">
         <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
-        <af peripheral="Timer16" name="Channel1"/>
+        <af peripheral="Timer16" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="7">
         <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
-        <af peripheral="Timer17" name="Channel1"/>
+        <af peripheral="Timer17" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="8">
-        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="ClockOutput" type="out"/>
         <af peripheral="Uart1" name="Ck" type="out"/>
         <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
@@ -126,17 +126,17 @@
       <gpio port="A" id="9">
         <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2" type="out"/>
         <af peripheral="Timer15" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3" type="out"/>
         <af peripheral="Timer17" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel4" type="out"/>
         <af peripheral="Uart1" name="Cts" type="in"/>
       </gpio>
       <gpio port="A" id="12">
@@ -147,67 +147,67 @@
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
         <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
-        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
         <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Timer16" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="6">
         <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
-        <af peripheral="Timer16" name="Channel1N"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1" type="out"/>
+        <af peripheral="Timer16" name="Channel1N" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
         <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
-        <af peripheral="Timer17" name="Channel1N"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2" type="out"/>
+        <af peripheral="Timer17" name="Channel1N" type="out"/>
       </gpio>
       <gpio port="B" id="8">
         <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
-        <af peripheral="Timer16" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3" type="out"/>
+        <af peripheral="Timer16" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="9">
         <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
-        <af peripheral="Timer17" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4" type="out"/>
+        <af peripheral="Timer17" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="10">
         <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio port="B" id="11">
         <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="12">
@@ -218,20 +218,20 @@
       </gpio>
       <gpio port="B" id="13">
         <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="14">
         <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="SpiMaster2" name="Miso" type="in"/>
-        <af peripheral="Timer15" name="Channel1"/>
+        <af peripheral="Timer15" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af peripheral="Timer15" name="Channel1N"/>
-        <af peripheral="Timer15" name="Channel2"/>
+        <af peripheral="Timer15" name="Channel1N" type="out"/>
+        <af peripheral="Timer15" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -252,16 +252,16 @@
         <af peripheral="Adc1" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
-        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
         <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
@@ -318,16 +318,16 @@
       </gpio>
       <gpio device-pin-id="v" port="D" id="12">
         <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="13">
-        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="14">
-        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="15">
-        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="0">
         <af peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -342,25 +342,25 @@
         <af id="6,3,3" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="8">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="9">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="10">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="11">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="12">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="13">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="14">
-        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="15">
         <af id="6,3,3" peripheral="Timer1" name="BreakIn" type="in"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f101_102-c_r_t_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f101_102-c_r_t_v-8_b.xml
@@ -75,25 +75,25 @@
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">
         <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
         <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
         <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
         <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="4">
@@ -108,12 +108,12 @@
       </gpio>
       <gpio port="A" id="6">
         <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
         <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
@@ -141,60 +141,60 @@
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
         <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
-        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
         <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="6">
         <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
         <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="8">
         <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="9">
         <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="10">
         <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="11">
         <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="12">
@@ -232,16 +232,16 @@
         <af peripheral="Adc1" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
-        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
         <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
@@ -298,16 +298,16 @@
       </gpio>
       <gpio device-name="101" device-pin-id="v" port="D" id="12">
         <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio device-name="101" device-pin-id="v" port="D" id="13">
-        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-name="101" device-pin-id="v" port="D" id="14">
-        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-name="101" device-pin-id="v" port="D" id="15">
-        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-name="101" device-pin-id="v" port="E" id="0">
         <af peripheral="Timer4" name="ExternalTrigger" type="in"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f103-c_r_t_v-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f103-c_r_t_v-8_b.xml
@@ -79,28 +79,28 @@
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">
         <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
         <af peripheral="Adc2" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
         <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
         <af peripheral="Adc2" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
         <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
         <af peripheral="Adc2" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
         <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
         <af peripheral="Adc2" name="Channel3" type="analog"/>
       </gpio>
@@ -119,19 +119,19 @@
       <gpio port="A" id="6">
         <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
         <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
-        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="ClockOutput" type="out"/>
         <af peripheral="Uart1" name="Ck" type="out"/>
         <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
@@ -139,15 +139,15 @@
       <gpio port="A" id="9">
         <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="13,3,0" peripheral="Can1" name="Rx" type="in"/>
         <af peripheral="Uart1" name="Cts" type="in"/>
       </gpio>
@@ -160,66 +160,66 @@
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
         <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
-        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
         <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="6">
         <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
         <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="8">
         <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="9">
         <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="10">
         <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="11">
         <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="12">
@@ -230,16 +230,16 @@
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="13">
         <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="14">
         <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="c|r|v" port="B" id="15">
-        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="SpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="0">
@@ -267,16 +267,16 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
-        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
         <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
@@ -337,16 +337,16 @@
       </gpio>
       <gpio device-pin-id="v" port="D" id="12">
         <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="13">
-        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="14">
-        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="15">
-        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="0">
         <af peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -361,25 +361,25 @@
         <af id="6,3,3" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="8">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="9">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="10">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="11">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="12">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="13">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="14">
-        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="15">
         <af id="6,3,3" peripheral="Timer1" name="BreakIn" type="in"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f103-r_v_z-c_d_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f103-r_v_z-c_d_e.xml
@@ -96,39 +96,39 @@
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">
         <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
         <af peripheral="Adc2" name="Channel0" type="analog"/>
         <af peripheral="Adc3" name="Channel0" type="analog"/>
-        <af peripheral="Timer5" name="Channel1"/>
+        <af peripheral="Timer5" name="Channel1" type="out"/>
         <af peripheral="Timer8" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="A" id="1">
         <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
         <af peripheral="Adc2" name="Channel1" type="analog"/>
         <af peripheral="Adc3" name="Channel1" type="analog"/>
-        <af peripheral="Timer5" name="Channel2"/>
+        <af peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="2">
         <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
         <af peripheral="Adc2" name="Channel2" type="analog"/>
         <af peripheral="Adc3" name="Channel2" type="analog"/>
-        <af peripheral="Timer5" name="Channel3"/>
+        <af peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="3">
         <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
         <af peripheral="Adc2" name="Channel3" type="analog"/>
         <af peripheral="Adc3" name="Channel3" type="analog"/>
-        <af peripheral="Timer5" name="Channel4"/>
+        <af peripheral="Timer5" name="Channel4" type="out"/>
       </gpio>
       <gpio port="A" id="4">
         <af id="0,1,0" peripheral="SpiMaster1" name="Nss"/>
@@ -146,21 +146,21 @@
       <gpio port="A" id="6">
         <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
         <af peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="A" id="7">
         <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
-        <af peripheral="Timer8" name="Channel1N"/>
+        <af peripheral="Timer8" name="Channel1N" type="out"/>
       </gpio>
       <gpio port="A" id="8">
-        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="ClockOutput" type="out"/>
         <af peripheral="Uart1" name="Ck" type="out"/>
         <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
@@ -168,15 +168,15 @@
       <gpio port="A" id="9">
         <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="13,3,0" peripheral="Can1" name="Rx" type="in"/>
         <af peripheral="Uart1" name="Cts" type="in"/>
       </gpio>
@@ -189,73 +189,73 @@
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
         <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
-        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
         <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Nss"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
-        <af peripheral="Timer8" name="Channel2N"/>
+        <af peripheral="Timer8" name="Channel2N" type="out"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
-        <af peripheral="Timer8" name="Channel3N"/>
+        <af peripheral="Timer8" name="Channel3N" type="out"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="6">
         <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
         <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2" type="out"/>
         <af device-pin-id="v|z" peripheral="Fsmc" name="Nl"/>
       </gpio>
       <gpio port="B" id="8">
         <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
         <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
         <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio port="B" id="11">
         <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="12">
@@ -266,16 +266,16 @@
       </gpio>
       <gpio port="B" id="13">
         <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="14">
         <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="SpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="0">
@@ -307,20 +307,20 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
-        <af peripheral="Timer8" name="Channel1"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel1" type="out"/>
+        <af peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
-        <af peripheral="Timer8" name="Channel2"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel2" type="out"/>
+        <af peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
-        <af peripheral="Timer8" name="Channel3"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel3" type="out"/>
+        <af peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio port="C" id="9">
-        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
-        <af peripheral="Timer8" name="Channel4"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel4" type="out"/>
+        <af peripheral="Timer8" name="Channel4" type="out"/>
       </gpio>
       <gpio port="C" id="10">
         <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
@@ -401,20 +401,20 @@
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="12">
         <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1" type="out"/>
         <af peripheral="Fsmc" name="A17"/>
         <af peripheral="Fsmc" name="Ale"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="13">
-        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel2" type="out"/>
         <af peripheral="Fsmc" name="A18"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="14">
-        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel3" type="out"/>
         <af peripheral="Fsmc" name="D0"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="15">
-        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel4" type="out"/>
         <af peripheral="Fsmc" name="D1"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="0">
@@ -444,31 +444,31 @@
         <af peripheral="Fsmc" name="D4"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="8">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="Fsmc" name="D5"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="9">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="Fsmc" name="D6"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="10">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="Fsmc" name="D7"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="11">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2" type="out"/>
         <af peripheral="Fsmc" name="D8"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="12">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="Fsmc" name="D9"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="13">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3" type="out"/>
         <af peripheral="Fsmc" name="D10"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="14">
-        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel4" type="out"/>
         <af peripheral="Fsmc" name="D11"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="15">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f105_107-r_v-8_b_c.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f105_107-r_v-8_b_c.xml
@@ -95,34 +95,34 @@
     <driver type="gpio" name="stm32f1">
       <gpio port="A" id="0">
         <af id="3,1,0" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel1"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="8,3,0" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
         <af peripheral="Adc2" name="Channel0" type="analog"/>
-        <af peripheral="Timer5" name="Channel1"/>
+        <af peripheral="Timer5" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="1">
         <af id="3,1,0" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
         <af peripheral="Adc2" name="Channel1" type="analog"/>
-        <af peripheral="Timer5" name="Channel2"/>
+        <af peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="2">
         <af id="3,1,0" peripheral="Uart2" name="Tx" type="out"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
         <af peripheral="Adc2" name="Channel2" type="analog"/>
-        <af peripheral="Timer5" name="Channel3"/>
+        <af peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="3">
         <af id="3,1,0" peripheral="Uart2" name="Rx" type="in"/>
         <af id="3,1,0" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="8,3,0" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,0" peripheral="Timer2" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
         <af peripheral="Adc2" name="Channel3" type="analog"/>
-        <af peripheral="Timer5" name="Channel4"/>
+        <af peripheral="Timer5" name="Channel4" type="out"/>
       </gpio>
       <gpio port="A" id="4">
         <af id="0,1,0" peripheral="SpiMaster1" name="Nss"/>
@@ -140,19 +140,19 @@
       <gpio port="A" id="6">
         <af id="0,1,0" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6,3,1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
         <af id="0,1,0" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,1" peripheral="Timer1" name="Channel1N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel2"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
-        <af id="6,3,0" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="ClockOutput" type="out"/>
         <af peripheral="Uart1" name="Ck" type="out"/>
         <af peripheral="UartSpiMaster1" name="Sck" type="out"/>
@@ -160,15 +160,15 @@
       <gpio port="A" id="9">
         <af id="2,1,0" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="2,1,0" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,0" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="6,3,0" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="10" peripheral="Usb" name="Dm"/>
         <af id="13,3,0" peripheral="Can1" name="Rx" type="in"/>
         <af peripheral="Uart1" name="Cts" type="in"/>
@@ -183,36 +183,36 @@
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
         <af id="0,1,1" peripheral="SpiMaster1" name="Nss"/>
-        <af id="8,3,3" peripheral="Timer2" name="Channel1"/>
         <af id="8,3,1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
+        <af id="8,3,3" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Nss"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="6,3,1" peripheral="Timer1" name="Channel2N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel3"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="6,3,1" peripheral="Timer1" name="Channel3N"/>
-        <af id="10,3,0" peripheral="Timer3" name="Channel4"/>
+        <af id="6,3,1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="10,3,0" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
         <af id="0,1,1" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="8,3,1" peripheral="Timer2" name="Channel2"/>
+        <af id="8,3,1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
         <af id="0,1,1" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="0,1,1" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10,3,2" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="22,1,1" peripheral="Can2" name="Rx" type="in"/>
         <af id="28,1,0" peripheral="SpiMaster3" name="Mosi" type="out"/>
       </gpio>
@@ -220,35 +220,35 @@
         <af id="1,1,0" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="2,1,1" peripheral="Uart1" name="Tx" type="out"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="22,1,1" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
         <af id="1,1,0" peripheral="I2cMaster1" name="Sda"/>
         <af id="2,1,1" peripheral="Uart1" name="Rx" type="in"/>
         <af id="2,1,1" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="8">
         <af id="1,1,1" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
         <af id="1,1,1" peripheral="I2cMaster1" name="Sda"/>
-        <af id="12,1,0" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,0" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="13,3,2" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
         <af id="4,3,0" peripheral="Uart3" name="Tx" type="out"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel3"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel3" type="out"/>
         <af device-name="105" peripheral="I2cMaster2" name="Scl" type="out"/>
       </gpio>
       <gpio port="B" id="11">
         <af id="4,3,0" peripheral="Uart3" name="Rx" type="in"/>
         <af id="4,3,0" peripheral="UartSpiMaster3" name="Miso" type="in"/>
-        <af id="8,3,2" peripheral="Timer2" name="Channel4"/>
+        <af id="8,3,2" peripheral="Timer2" name="Channel4" type="out"/>
         <af device-name="105" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="12">
@@ -260,17 +260,17 @@
       </gpio>
       <gpio port="B" id="13">
         <af id="4,3,0" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="22,1,0" peripheral="Can2" name="Tx" type="out"/>
         <af peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="14">
         <af id="4,3,0" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="6,3,0" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="6,3,0" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,0" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="SpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="0">
@@ -298,16 +298,16 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="10,3,3" peripheral="Timer3" name="Channel1"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="10,3,3" peripheral="Timer3" name="Channel2"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="10,3,3" peripheral="Timer3" name="Channel3"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio port="C" id="9">
-        <af id="10,3,3" peripheral="Timer3" name="Channel4"/>
+        <af id="10,3,3" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio port="C" id="10">
         <af id="4,3,1" peripheral="Uart3" name="Tx" type="out"/>
@@ -375,16 +375,16 @@
       </gpio>
       <gpio device-pin-id="v" port="D" id="12">
         <af id="4,3,3" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="12,1,1" peripheral="Timer4" name="Channel1"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="13">
-        <af id="12,1,1" peripheral="Timer4" name="Channel2"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="14">
-        <af id="12,1,1" peripheral="Timer4" name="Channel3"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="15">
-        <af id="12,1,1" peripheral="Timer4" name="Channel4"/>
+        <af id="12,1,1" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="0">
         <af peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -399,25 +399,25 @@
         <af id="6,3,3" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="8">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="9">
-        <af id="6,3,3" peripheral="Timer1" name="Channel1"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="10">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="11">
-        <af id="6,3,3" peripheral="Timer1" name="Channel2"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="12">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3N"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="13">
-        <af id="6,3,3" peripheral="Timer1" name="Channel3"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="14">
-        <af id="6,3,3" peripheral="Timer1" name="Channel4"/>
+        <af id="6,3,3" peripheral="Timer1" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="15">
         <af id="6,3,3" peripheral="Timer1" name="BreakIn" type="in"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_k_r-6_8.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_k_r-6_8.xml
@@ -78,96 +78,96 @@
     <driver device-pin-id="c|r" type="uart" name="stm32" instances="3"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="De"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af id="9" peripheral="Timer15" name="Channel1N" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1"/>
+        <af id="9" peripheral="Timer15" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer15" name="Channel2"/>
+        <af id="9" peripheral="Timer15" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="4">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
         <af peripheral="Adc2" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc2" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af peripheral="Adc2" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1"/>
+        <af id="6" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="6" peripheral="Timer1" name="Channel2"/>
+        <af id="6" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Timer15" name="BreakIn" type="in"/>
-        <af id="10" peripheral="Timer2" name="Channel3"/>
+        <af id="10" peripheral="Timer2" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="1" peripheral="Timer17" name="BreakIn" type="in"/>
-        <af id="6" peripheral="Timer1" name="Channel3"/>
+        <af id="6" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="10" peripheral="Timer2" name="Channel4"/>
+        <af id="10" peripheral="Timer2" name="Channel4" type="out"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
-        <af id="11" peripheral="Timer1" name="Channel4"/>
+        <af id="11" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="A" id="12">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="7" peripheral="Uart1" name="De"/>
         <af id="7" peripheral="Uart1" name="Rts" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
         <af id="11" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="A" id="13">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
         <af device-pin-id="c|r" id="7" peripheral="Uart3" name="Cts" type="in"/>
       </gpio>
       <gpio port="A" id="14">
@@ -177,7 +177,7 @@
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
@@ -186,28 +186,28 @@
         <af id="9" peripheral="Timer1" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="Adc1" name="Channel11" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="6" peripheral="Timer1" name="Channel3N"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel12" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="2">
         <af peripheral="Adc2" name="Channel12" type="analog"/>
       </gpio>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af id="10" peripheral="Timer3" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
@@ -215,27 +215,27 @@
       </gpio>
       <gpio port="B" id="5">
         <af id="1" peripheral="Timer16" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
-        <af id="10" peripheral="Timer17" name="Channel1"/>
+        <af id="10" peripheral="Timer17" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1N"/>
+        <af id="1" peripheral="Timer17" name="Channel1N" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="10" peripheral="Timer3" name="Channel4"/>
+        <af id="10" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="8">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -243,19 +243,19 @@
         <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="9">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
       </gpio>
@@ -266,40 +266,40 @@
         <af peripheral="Adc2" name="Channel13" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="13">
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel13" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="14">
-        <af id="1" peripheral="Timer15" name="Channel1"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer15" name="Channel1" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
         <af peripheral="Adc2" name="Channel14" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="15">
-        <af id="1" peripheral="Timer15" name="Channel2"/>
-        <af id="2" peripheral="Timer15" name="Channel1N"/>
-        <af id="4" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer15" name="Channel1N" type="out"/>
+        <af id="4" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="0">
-        <af id="2" peripheral="Timer1" name="Channel1"/>
+        <af id="2" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="1">
-        <af id="2" peripheral="Timer1" name="Channel2"/>
+        <af id="2" peripheral="Timer1" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="2">
-        <af id="2" peripheral="Timer1" name="Channel3"/>
+        <af id="2" peripheral="Timer1" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="3">
-        <af id="2" peripheral="Timer1" name="Channel4"/>
+        <af id="2" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
@@ -317,16 +317,16 @@
         <af peripheral="Adc2" name="Channel11" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="9">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="10">
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
@@ -341,7 +341,7 @@
         <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="C" id="13">
-        <af id="4" peripheral="Timer1" name="Channel1N"/>
+        <af id="4" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="C" id="14"/>
       <gpio device-pin-id="c|r" port="C" id="15"/>
@@ -349,7 +349,7 @@
         <af id="2" peripheral="Timer3" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="F" id="0">
-        <af id="6" peripheral="Timer1" name="Channel3N"/>
+        <af id="6" peripheral="Timer1" name="Channel3N" type="out"/>
       </gpio>
       <gpio port="F" id="1"/>
     </driver>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_r_v_z-b_c_d_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f303-c_r_v_z-b_c_d_e.xml
@@ -124,7 +124,7 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="9" peripheral="Timer8" name="BreakIn" type="in"/>
@@ -132,28 +132,28 @@
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="De"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af id="9" peripheral="Timer15" name="Channel1N" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1"/>
+        <af id="9" peripheral="Timer15" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer15" name="Channel2"/>
+        <af id="9" peripheral="Timer15" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="4">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
@@ -161,89 +161,89 @@
         <af peripheral="Adc2" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc2" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="4" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af peripheral="Adc2" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="4" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput" type="out"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="3" peripheral="I2cMaster3" name="Scl" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1"/>
+        <af id="6" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
         <af id="10" peripheral="Timer4" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="A" id="9">
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel2"/>
+        <af id="6" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Timer15" name="BreakIn" type="in"/>
-        <af id="10" peripheral="Timer2" name="Channel3"/>
+        <af id="10" peripheral="Timer2" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="1" peripheral="Timer17" name="BreakIn" type="in"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
-        <af id="6" peripheral="Timer1" name="Channel3"/>
+        <af id="6" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="10" peripheral="Timer2" name="Channel4"/>
+        <af id="10" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="11" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="A" id="11">
         <af device-size-id="d|e" device-pin-id="r|v|z" id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
-        <af id="10" peripheral="Timer4" name="Channel1"/>
-        <af id="11" peripheral="Timer1" name="Channel4"/>
+        <af id="10" peripheral="Timer4" name="Channel1" type="out"/>
+        <af id="11" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
         <af device-size-id="b|c" device-pin-id="c|r|v" id="14" peripheral="Usb" name="Dm"/>
       </gpio>
       <gpio port="A" id="12">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="7" peripheral="Uart1" name="De"/>
         <af id="7" peripheral="Uart1" name="Rts" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
-        <af id="10" peripheral="Timer4" name="Channel2"/>
+        <af id="10" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="11" peripheral="Timer1" name="ExternalTrigger" type="in"/>
         <af device-size-id="b|c" device-pin-id="c|r|v" id="14" peripheral="Usb" name="Dp"/>
       </gpio>
       <gpio port="A" id="13">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="10" peripheral="Timer4" name="Channel3"/>
+        <af id="10" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="14">
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
-        <af id="5" peripheral="Timer8" name="Channel2"/>
+        <af id="5" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
@@ -252,24 +252,24 @@
         <af id="9" peripheral="Timer1" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="4" peripheral="Timer8" name="Channel2N"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel2N" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="Adc3" name="Channel12" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="4" peripheral="Timer8" name="Channel3N"/>
-        <af id="6" peripheral="Timer1" name="Channel3N"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel3N" type="out"/>
+        <af id="6" peripheral="Timer1" name="Channel3N" type="out"/>
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="B" id="2">
         <af peripheral="Adc2" name="Channel12" type="analog"/>
       </gpio>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
-        <af id="4" peripheral="Timer8" name="Channel1N"/>
+        <af id="4" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
@@ -277,9 +277,9 @@
         <af id="10" peripheral="Timer3" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="4" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
@@ -288,60 +288,60 @@
       </gpio>
       <gpio port="B" id="5">
         <af id="1" peripheral="Timer16" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="8" peripheral="I2cMaster3" name="Sda"/>
-        <af id="10" peripheral="Timer17" name="Channel1"/>
+        <af id="10" peripheral="Timer17" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
-        <af id="5" peripheral="Timer8" name="Channel1"/>
+        <af id="5" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="6" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="10" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1N"/>
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="1" peripheral="Timer17" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="10" peripheral="Timer3" name="Channel4"/>
+        <af id="10" peripheral="Timer3" name="Channel4" type="out"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
-        <af id="10" peripheral="Timer8" name="Channel2"/>
+        <af id="10" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="12" peripheral="Timer1" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
-        <af id="10" peripheral="Timer8" name="Channel3"/>
+        <af id="10" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" peripheral="Adc1" name="Channel14" type="analog"/>
@@ -356,42 +356,42 @@
       </gpio>
       <gpio port="B" id="13">
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
-        <af id="6" peripheral="Timer1" name="Channel1N"/>
+        <af id="6" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer15" name="Channel1"/>
+        <af id="1" peripheral="Timer15" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
-        <af id="6" peripheral="Timer1" name="Channel2N"/>
+        <af id="6" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
         <af peripheral="Adc4" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer15" name="Channel2"/>
-        <af id="2" peripheral="Timer15" name="Channel1N"/>
-        <af id="4" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer15" name="Channel1N" type="out"/>
+        <af id="4" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc4" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="0">
-        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel1"/>
+        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="1">
-        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel2"/>
+        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="2">
-        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel3"/>
+        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="3">
-        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel4"/>
+        <af device-size-id="d|e" id="2" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
@@ -409,46 +409,46 @@
         <af peripheral="Adc2" name="Channel11" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="4" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="4" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="4" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="4" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="9">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af device-size-id="d|e" id="3" peripheral="I2cMaster3" name="Sda"/>
-        <af id="4" peripheral="Timer8" name="Channel4"/>
+        <af id="4" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="6" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="10">
-        <af id="4" peripheral="Timer8" name="Channel1N"/>
+        <af id="4" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="Uart4" name="Tx" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="11">
-        <af id="4" peripheral="Timer8" name="Channel2N"/>
+        <af id="4" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="Uart4" name="Rx" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="r|v|z" port="C" id="12">
-        <af id="4" peripheral="Timer8" name="Channel3N"/>
+        <af id="4" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="Uart5" name="Tx" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart3" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="13">
-        <af id="4" peripheral="Timer1" name="Channel1N"/>
+        <af id="4" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio port="C" id="14"/>
       <gpio port="C" id="15"/>
@@ -456,7 +456,7 @@
         <af id="7" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="1">
-        <af id="4" peripheral="Timer8" name="Channel4"/>
+        <af id="4" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="6" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="7" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
@@ -466,12 +466,12 @@
         <af id="5" peripheral="Uart5" name="Rx" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="3">
-        <af id="2" peripheral="Timer2" name="Channel1"/>
+        <af id="2" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="4">
-        <af id="2" peripheral="Timer2" name="Channel2"/>
+        <af id="2" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="De"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
       </gpio>
@@ -480,12 +480,12 @@
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="6">
-        <af id="2" peripheral="Timer2" name="Channel4"/>
+        <af id="2" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="7">
-        <af id="2" peripheral="Timer2" name="Channel3"/>
+        <af id="2" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
       </gpio>
@@ -511,97 +511,97 @@
         <af peripheral="Adc4" name="Channel8" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
         <af peripheral="Adc3" name="Channel9" type="analog"/>
         <af peripheral="Adc4" name="Channel9" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af peripheral="Adc3" name="Channel10" type="analog"/>
         <af peripheral="Adc4" name="Channel10" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af peripheral="Adc3" name="Channel11" type="analog"/>
         <af peripheral="Adc4" name="Channel11" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="6" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
-        <af id="4" peripheral="Timer16" name="Channel1"/>
+        <af id="4" peripheral="Timer16" name="Channel1" type="out"/>
         <af device-size-id="d|e" id="6" peripheral="Timer20" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="1">
-        <af id="4" peripheral="Timer17" name="Channel1"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel4"/>
+        <af id="4" peripheral="Timer17" name="Channel1" type="out"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="2">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel1"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="3">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Nss"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel2"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="4">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Nss"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel1N"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="5">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel2N"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="6">
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
-        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel3N"/>
+        <af device-size-id="d|e" id="6" peripheral="Timer20" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="7">
         <af id="2" peripheral="Timer1" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc3" name="Channel13" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="8">
-        <af id="2" peripheral="Timer1" name="Channel1N"/>
+        <af id="2" peripheral="Timer1" name="Channel1N" type="out"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
         <af peripheral="Adc4" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="9">
-        <af id="2" peripheral="Timer1" name="Channel1"/>
+        <af id="2" peripheral="Timer1" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="10">
-        <af id="2" peripheral="Timer1" name="Channel2N"/>
+        <af id="2" peripheral="Timer1" name="Channel2N" type="out"/>
         <af peripheral="Adc3" name="Channel14" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="11">
-        <af id="2" peripheral="Timer1" name="Channel2"/>
+        <af id="2" peripheral="Timer1" name="Channel2" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Nss"/>
         <af peripheral="Adc3" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="12">
-        <af id="2" peripheral="Timer1" name="Channel3N"/>
+        <af id="2" peripheral="Timer1" name="Channel3N" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
         <af peripheral="Adc3" name="Channel16" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="13">
-        <af id="2" peripheral="Timer1" name="Channel3"/>
+        <af id="2" peripheral="Timer1" name="Channel3" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af peripheral="Adc3" name="Channel3" type="analog"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="14">
-        <af id="2" peripheral="Timer1" name="Channel4"/>
+        <af id="2" peripheral="Timer1" name="Channel4" type="out"/>
         <af device-size-id="d|e" id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af id="6" peripheral="Timer1" name="BreakIn" type="in"/>
         <af peripheral="Adc4" name="Channel1" type="analog"/>
@@ -615,33 +615,33 @@
       <gpio port="F" id="0">
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="5" peripheral="SpiMaster2" name="Nss"/>
-        <af id="6" peripheral="Timer1" name="Channel3N"/>
+        <af id="6" peripheral="Timer1" name="Channel3N" type="out"/>
       </gpio>
       <gpio port="F" id="1">
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af device-size-id="d|e" device-pin-id="r|v|z" id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="F" id="2">
-        <af device-size-id="d|e" id="2" peripheral="Timer20" name="Channel3"/>
+        <af device-size-id="d|e" id="2" peripheral="Timer20" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel10" type="analog"/>
         <af peripheral="Adc2" name="Channel10" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="3">
-        <af id="2" peripheral="Timer20" name="Channel4"/>
+        <af id="2" peripheral="Timer20" name="Channel4" type="out"/>
       </gpio>
       <gpio device-size-id="b|c" device-pin-id="r|v" port="F" id="4">
-        <af device-pin-id="z" id="3" peripheral="Timer20" name="Channel1N"/>
+        <af device-pin-id="z" id="3" peripheral="Timer20" name="Channel1N" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-size-id="d|e" device-pin-id="z" port="F" id="4">
-        <af device-pin-id="z" id="3" peripheral="Timer20" name="Channel1N"/>
+        <af device-pin-id="z" id="3" peripheral="Timer20" name="Channel1N" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="5">
-        <af id="2" peripheral="Timer20" name="Channel2N"/>
+        <af id="2" peripheral="Timer20" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="F" id="6">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
@@ -654,37 +654,37 @@
       </gpio>
       <gpio device-pin-id="v|z" port="F" id="9">
         <af device-size-id="d|e" id="2" peripheral="Timer20" name="BreakIn" type="in"/>
-        <af id="3" peripheral="Timer15" name="Channel1"/>
+        <af id="3" peripheral="Timer15" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="F" id="10">
         <af device-size-id="d|e" id="2" peripheral="Timer20" name="BreakIn" type="in"/>
-        <af id="3" peripheral="Timer15" name="Channel2"/>
+        <af id="3" peripheral="Timer15" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="11">
         <af id="2" peripheral="Timer20" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="12">
-        <af id="2" peripheral="Timer20" name="Channel1"/>
+        <af id="2" peripheral="Timer20" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="13">
-        <af id="2" peripheral="Timer20" name="Channel2"/>
+        <af id="2" peripheral="Timer20" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="14">
-        <af id="2" peripheral="Timer20" name="Channel3"/>
+        <af id="2" peripheral="Timer20" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="15">
-        <af id="2" peripheral="Timer20" name="Channel4"/>
+        <af id="2" peripheral="Timer20" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="G" id="0">
-        <af id="2" peripheral="Timer20" name="Channel1N"/>
+        <af id="2" peripheral="Timer20" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="G" id="1">
-        <af id="2" peripheral="Timer20" name="Channel2N"/>
+        <af id="2" peripheral="Timer20" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="G" id="2">
-        <af id="2" peripheral="Timer20" name="Channel3N"/>
+        <af id="2" peripheral="Timer20" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="G" id="3">
         <af id="2" peripheral="Timer20" name="BreakIn" type="in"/>
@@ -706,10 +706,10 @@
       <gpio device-pin-id="z" port="G" id="14"/>
       <gpio device-pin-id="z" port="G" id="15"/>
       <gpio device-pin-id="z" port="H" id="0">
-        <af id="2" peripheral="Timer20" name="Channel1"/>
+        <af id="2" peripheral="Timer20" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="H" id="1">
-        <af id="2" peripheral="Timer20" name="Channel2"/>
+        <af id="2" peripheral="Timer20" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="H" id="2"/>
     </driver>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f373-c_r_v-8_b_c.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f373-c_r_v-8_b_c.xml
@@ -102,78 +102,78 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
-        <af id="11" peripheral="Timer19" name="Channel1"/>
+        <af id="11" peripheral="Timer19" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af id="7" peripheral="Uart2" name="De"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1N"/>
-        <af id="11" peripheral="Timer19" name="Channel2"/>
+        <af id="9" peripheral="Timer15" name="Channel1N" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1"/>
-        <af id="11" peripheral="Timer19" name="Channel3"/>
+        <af id="9" peripheral="Timer15" name="Channel1" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel3" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer15" name="Channel2"/>
-        <af id="11" peripheral="Timer19" name="Channel4"/>
+        <af id="9" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
       </gpio>
       <gpio port="A" id="4">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
-        <af id="10" peripheral="Timer12" name="Channel1"/>
+        <af id="10" peripheral="Timer12" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
-        <af id="10" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
+        <af id="10" peripheral="Timer12" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="A" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <!--<af id="0" peripheral="MCO" type="out"/>-->
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
@@ -181,13 +181,13 @@
         <af id="10" peripheral="Timer4" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="2" peripheral="Timer13" name="Channel1"/>
+        <af id="2" peripheral="Timer13" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Timer15" name="BreakIn" type="in"/>
-        <af id="10" peripheral="Timer2" name="Channel3"/>
+        <af id="10" peripheral="Timer2" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="10">
         <af id="1" peripheral="Timer17" name="BreakIn" type="in"/>
@@ -195,168 +195,168 @@
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
-        <af id="10" peripheral="Timer2" name="Channel4"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
+        <af id="10" peripheral="Timer2" name="Channel4" type="out"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="6" peripheral="SpiMaster1" name="Nss"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
-        <af id="10" peripheral="Timer4" name="Channel1"/>
+        <af id="10" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="14" peripheral="Usb" name="Dm"/>
       </gpio>
       <gpio port="A" id="12">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
         <af id="6" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="7" peripheral="Uart1" name="De"/>
         <af id="7" peripheral="Uart1" name="Rts" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
-        <af id="10" peripheral="Timer4" name="Channel2"/>
+        <af id="10" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="14" peripheral="Usb" name="Dp"/>
       </gpio>
       <gpio port="A" id="13">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="6" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
-        <af id="10" peripheral="Timer4" name="Channel3"/>
+        <af id="10" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio port="A" id="14">
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
-        <af id="10" peripheral="Timer12" name="Channel1"/>
+        <af id="10" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
-        <af id="10" peripheral="Timer12" name="Channel2"/>
+        <af id="10" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="10" peripheral="Timer3" name="Channel2"/>
+        <af id="10" peripheral="Timer3" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af id="10" peripheral="Timer3" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer15" name="Channel1N"/>
+        <af id="9" peripheral="Timer15" name="Channel1N" type="out"/>
         <af id="10" peripheral="Timer17" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="B" id="5">
         <af id="1" peripheral="Timer16" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
-        <af id="10" peripheral="Timer17" name="Channel1"/>
+        <af id="10" peripheral="Timer17" name="Channel1" type="out"/>
         <af id="11" peripheral="Timer19" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="1" peripheral="Timer16" name="Channel1N"/>
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="1" peripheral="Timer16" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer15" name="Channel1"/>
-        <af id="10" peripheral="Timer3" name="Channel3"/>
-        <af id="11" peripheral="Timer19" name="Channel1"/>
+        <af id="9" peripheral="Timer15" name="Channel1" type="out"/>
+        <af id="10" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="1" peripheral="Timer17" name="Channel1N"/>
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="1" peripheral="Timer17" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer15" name="Channel2"/>
-        <af id="10" peripheral="Timer3" name="Channel4"/>
-        <af id="11" peripheral="Timer19" name="Channel2"/>
+        <af id="9" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="10" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="11" peripheral="Timer19" name="Channel2" type="out"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="1" peripheral="Timer16" name="Channel1"/>
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="1" peripheral="Timer16" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
-        <af id="11" peripheral="Timer19" name="Channel3"/>
+        <af id="11" peripheral="Timer19" name="Channel3" type="out"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="1" peripheral="Timer17" name="Channel1"/>
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="1" peripheral="Timer17" name="Channel1" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
-        <af id="11" peripheral="Timer19" name="Channel4"/>
+        <af id="11" peripheral="Timer19" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer15" name="Channel1"/>
+        <af id="1" peripheral="Timer15" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer15" name="Channel2"/>
-        <af id="2" peripheral="Timer15" name="Channel1N"/>
+        <af id="1" peripheral="Timer15" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer15" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="0">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="2" peripheral="Timer5" name="ExternalTrigger" type="in"/>
         <af peripheral="Adc1" name="Channel10" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="1">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel11" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="2">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel12" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="3">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel13" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="4">
-        <af id="2" peripheral="Timer13" name="Channel1"/>
+        <af id="2" peripheral="Timer13" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel14" type="analog"/>
@@ -367,35 +367,35 @@
         <af peripheral="Adc1" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
-        <af id="2" peripheral="Timer19" name="Channel1"/>
+        <af id="2" peripheral="Timer19" name="Channel1" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="11">
-        <af id="2" peripheral="Timer19" name="Channel2"/>
+        <af id="2" peripheral="Timer19" name="Channel2" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="12">
-        <af id="2" peripheral="Timer19" name="Channel3"/>
+        <af id="2" peripheral="Timer19" name="Channel3" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart3" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Sck" type="out"/>
@@ -404,7 +404,7 @@
       <gpio port="C" id="14"/>
       <gpio port="C" id="15"/>
       <gpio device-pin-id="v" port="D" id="0">
-        <af id="2" peripheral="Timer19" name="Channel4"/>
+        <af id="2" peripheral="Timer19" name="Channel4" type="out"/>
         <af id="7" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="1">
@@ -454,18 +454,18 @@
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -502,7 +502,7 @@
       <gpio device-pin-id="v" port="F" id="2"/>
       <gpio device-pin-id="v" port="F" id="4"/>
       <gpio port="F" id="6">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart3" name="De"/>
@@ -514,7 +514,7 @@
         <af id="7" peripheral="UartSpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="F" id="9">
-        <af id="2" peripheral="Timer14" name="Channel1"/>
+        <af id="2" peripheral="Timer14" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="F" id="10"/>
     </driver>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f401_411-c_r_v-b_c_d_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f401_411-c_r_v-b_c_d_e.xml
@@ -103,31 +103,31 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af device-name="411" id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -140,43 +140,43 @@
         <af peripheral="Adc1" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
@@ -194,7 +194,7 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
@@ -202,20 +202,20 @@
         <af device-name="411" id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Nss"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
         <af device-name="411" id="7" peripheral="Uart1" name="Rx" type="in"/>
@@ -223,49 +223,49 @@
         <af id="9" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="9" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
         <af device-name="411" id="9" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af device-name="411" id="9" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="12">
@@ -275,16 +275,16 @@
         <af device-name="411" id="7" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster4" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="0">
@@ -308,24 +308,24 @@
         <af peripheral="Adc1" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af device-name="411" id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="9">
         <af id="0" peripheral="ClockOutput2" type="out"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio device-pin-id="r|v" port="C" id="10">
@@ -369,16 +369,16 @@
       <gpio device-pin-id="v" port="D" id="10"/>
       <gpio device-pin-id="v" port="D" id="11"/>
       <gpio device-pin-id="v" port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -394,12 +394,12 @@
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="6">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
       </gpio>
@@ -407,31 +407,31 @@
         <af id="1" peripheral="Timer1" name="ExternalTrigger" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v" port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af device-name="411" id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
       </gpio>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f405_407_415_417-i_o_r_v_z-e_g.xml
@@ -125,9 +125,9 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="8" peripheral="Uart4" name="Tx" type="out"/>
@@ -136,8 +136,8 @@
         <af peripheral="Adc3" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af id="8" peripheral="Uart4" name="Rx" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
@@ -145,9 +145,9 @@
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
@@ -155,9 +155,9 @@
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -173,50 +173,50 @@
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
         <af peripheral="Adc2" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
         <af id="10" peripheral="Usb" name="Dm"/>
@@ -230,78 +230,78 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
         <af device-pin-id="i|o|v|z" id="12" peripheral="Fsmc" name="Nl"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -314,23 +314,23 @@
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -363,27 +363,27 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="9">
         <af id="0" peripheral="ClockOutput2" type="out"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio port="C" id="10">
@@ -464,21 +464,21 @@
         <af id="12" peripheral="Fsmc" name="Cle"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
         <af id="12" peripheral="Fsmc" name="A17"/>
         <af id="12" peripheral="Fsmc" name="Ale"/>
       </gpio>
       <gpio device-pin-id="i|v|z" port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="12" peripheral="Fsmc" name="A18"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="12" peripheral="Fsmc" name="D0"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="12" peripheral="Fsmc" name="D1"/>
       </gpio>
       <gpio device-pin-id="i|v|z" port="E" id="0">
@@ -498,11 +498,11 @@
         <af id="12" peripheral="Fsmc" name="A20"/>
       </gpio>
       <gpio device-pin-id="i|v|z" port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="A21"/>
       </gpio>
       <gpio device-pin-id="i|v|z" port="E" id="6">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="12" peripheral="Fsmc" name="A22"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="7">
@@ -510,31 +510,31 @@
         <af id="12" peripheral="Fsmc" name="D4"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="12" peripheral="Fsmc" name="D5"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="D6"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="12" peripheral="Fsmc" name="D7"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="12" peripheral="Fsmc" name="D8"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="12" peripheral="Fsmc" name="D9"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="12" peripheral="Fsmc" name="D10"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="12" peripheral="Fsmc" name="D11"/>
       </gpio>
       <gpio device-pin-id="i|o|v|z" port="E" id="15">
@@ -565,22 +565,22 @@
         <af peripheral="Adc3" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="i|z" port="F" id="6">
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="Niord"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
       </gpio>
       <gpio device-pin-id="i|z" port="F" id="7">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="Nreg"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-pin-id="i|z" port="F" id="8">
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="Niowr"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="i|z" port="F" id="9">
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="Cd"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
       </gpio>
@@ -670,7 +670,7 @@
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="6">
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="7">
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
@@ -679,36 +679,36 @@
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="9">
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="10">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="11">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="12">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="13">
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="14">
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="H" id="15">
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="i|o" port="I" id="0">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio device-pin-id="i|o" port="I" id="1">
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="2">
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="3">
@@ -719,13 +719,13 @@
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="5">
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="6">
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="7">
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="i" port="I" id="8"/>
       <gpio device-pin-id="i" port="I" id="9">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f410-c_r_t-8_b.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f410-c_r_t-8_b.xml
@@ -89,25 +89,25 @@
     <driver device-pin-id="c|r" type="uart" name="stm32" instances="6"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel0" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="A" id="1">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -128,29 +128,29 @@
         <af peripheral="Adc1" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="c|r" port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
@@ -170,12 +170,12 @@
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="6" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="6" peripheral="SpiMaster5" name="Nss"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
       </gpio>
@@ -207,7 +207,7 @@
         <af device-pin-id="c|r" id="6" peripheral="SpiMaster5" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="9">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="I2cMaster2" name="Sda"/>
@@ -217,24 +217,24 @@
         <af device-pin-id="c|r" id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="B" id="11">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
       </gpio>
       <gpio port="B" id="12">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af device-pin-id="c|r" id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="c|r" port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="0">
@@ -252,11 +252,11 @@
         <af peripheral="Adc1" name="Channel13" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="4">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel14" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="5">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af peripheral="Adc1" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="6">
@@ -276,13 +276,13 @@
         <af id="0" peripheral="ClockOutput2" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="10">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="11">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="r" port="C" id="12">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
       </gpio>
       <gpio port="C" id="13"/>
       <gpio port="C" id="14"/>

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f427_429_437_439-a_b_i_n_v_z-e_g_i.xml
@@ -140,9 +140,9 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="8" peripheral="Uart4" name="Tx" type="out"/>
@@ -151,8 +151,8 @@
         <af peripheral="Adc3" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af id="8" peripheral="Uart4" name="Rx" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
@@ -160,9 +160,9 @@
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
@@ -170,9 +170,9 @@
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -188,50 +188,50 @@
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
         <af peripheral="Adc2" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
         <af id="10" peripheral="Usb" name="Dm"/>
@@ -245,78 +245,78 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
         <af device-pin-id="i|o|v|z" id="12" peripheral="Fsmc" name="Nl"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -329,23 +329,23 @@
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -378,27 +378,27 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="9">
         <af id="0" peripheral="ClockOutput2" type="out"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio port="C" id="10">
@@ -481,21 +481,21 @@
         <af id="12" peripheral="Fsmc" name="Cle"/>
       </gpio>
       <gpio port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
         <af id="12" peripheral="Fsmc" name="A17"/>
         <af id="12" peripheral="Fsmc" name="Ale"/>
       </gpio>
       <gpio port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="12" peripheral="Fsmc" name="A18"/>
       </gpio>
       <gpio port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="12" peripheral="Fsmc" name="D0"/>
       </gpio>
       <gpio port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="12" peripheral="Fsmc" name="D1"/>
       </gpio>
       <gpio port="E" id="0">
@@ -519,12 +519,12 @@
         <af id="12" peripheral="Fsmc" name="A20"/>
       </gpio>
       <gpio port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af id="12" peripheral="Fsmc" name="A21"/>
       </gpio>
       <gpio port="E" id="6">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af id="12" peripheral="Fsmc" name="A22"/>
       </gpio>
@@ -534,35 +534,35 @@
         <af id="12" peripheral="Fsmc" name="D4"/>
       </gpio>
       <gpio port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
         <af id="12" peripheral="Fsmc" name="D5"/>
       </gpio>
       <gpio port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="12" peripheral="Fsmc" name="D6"/>
       </gpio>
       <gpio port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="12" peripheral="Fsmc" name="D7"/>
       </gpio>
       <gpio port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
         <af id="12" peripheral="Fsmc" name="D8"/>
       </gpio>
       <gpio port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
         <af id="12" peripheral="Fsmc" name="D9"/>
       </gpio>
       <gpio port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
         <af id="12" peripheral="Fsmc" name="D10"/>
       </gpio>
       <gpio port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
         <af id="12" peripheral="Fsmc" name="D11"/>
       </gpio>
@@ -594,14 +594,14 @@
         <af id="12" peripheral="Fsmc" name="A5"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="6">
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Nss"/>
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
         <af id="12" peripheral="Fsmc" name="Niord"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="7">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
@@ -609,13 +609,13 @@
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="8">
         <af id="5" peripheral="SpiMaster5" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
         <af id="12" peripheral="Fsmc" name="Niowr"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="9">
         <af id="5" peripheral="SpiMaster5" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
         <af id="12" peripheral="Fsmc" name="Cd"/>
       </gpio>
@@ -713,7 +713,7 @@
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="6">
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="7">
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
@@ -723,36 +723,36 @@
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="9">
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="10">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="11">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="12">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="13">
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="14">
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="H" id="15">
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="0">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="1">
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="2">
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="3">
@@ -763,13 +763,13 @@
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="5">
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="6">
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|i|n" port="I" id="7">
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="8"/>
       <gpio device-pin-id="a|b|i|n" port="I" id="9">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f446-m_r_v_z-c_e.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f446-m_r_v_z-c_e.xml
@@ -120,9 +120,9 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="8" peripheral="Uart4" name="Tx" type="out"/>
@@ -131,8 +131,8 @@
         <af peripheral="Adc3" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af id="8" peripheral="Uart4" name="Rx" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
@@ -140,9 +140,9 @@
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
@@ -150,9 +150,9 @@
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -168,51 +168,51 @@
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
         <af peripheral="Adc2" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
         <af id="10" peripheral="Usb" name="Dm"/>
@@ -226,89 +226,89 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
         <af id="8" peripheral="Uart4" name="Rts" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="7" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="8" peripheral="Uart4" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="7" peripheral="SpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="z" port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -321,23 +321,23 @@
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -374,29 +374,29 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart5" name="Rts" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="9">
         <af id="0" peripheral="ClockOutput2" type="out"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
         <af id="7" peripheral="Uart5" name="Cts" type="in"/>
       </gpio>
@@ -471,17 +471,17 @@
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -495,11 +495,11 @@
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="6">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="E" id="7">
@@ -507,29 +507,29 @@
         <af id="8" peripheral="Uart5" name="Rx" type="in"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="8" peripheral="Uart5" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="m|v|z" port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio device-pin-id="v|z" port="E" id="15">
@@ -552,19 +552,19 @@
         <af peripheral="Adc3" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="6">
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="7">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="8">
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="9">
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
       </gpio>
       <gpio device-pin-id="z" port="F" id="10">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f469_479-a_b_i_n-e_g_i.xml
@@ -136,9 +136,9 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="8" peripheral="Uart4" name="Tx" type="out"/>
@@ -147,8 +147,8 @@
         <af peripheral="Adc3" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af id="8" peripheral="Uart4" name="Rx" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
@@ -156,9 +156,9 @@
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
@@ -166,9 +166,9 @@
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -184,51 +184,51 @@
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
         <af peripheral="Adc2" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <af id="0" peripheral="ClockOutput1" type="out"/>
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
         <af id="10" peripheral="Usb" name="Dm"/>
@@ -242,77 +242,77 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
       <gpio port="B" id="2"/>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -325,23 +325,23 @@
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -375,27 +375,27 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="9">
         <af id="0" peripheral="ClockOutput2" type="out"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio port="C" id="10">
@@ -465,17 +465,17 @@
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
       </gpio>
       <gpio port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
       </gpio>
       <gpio port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
       </gpio>
       <gpio port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
       </gpio>
       <gpio port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
       </gpio>
       <gpio port="E" id="0">
         <af id="2" peripheral="Timer4" name="ExternalTrigger" type="in"/>
@@ -492,11 +492,11 @@
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio port="E" id="6">
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio port="E" id="7">
@@ -504,29 +504,29 @@
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
       </gpio>
       <gpio port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
       </gpio>
       <gpio port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
       </gpio>
       <gpio port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
       </gpio>
       <gpio port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
       </gpio>
       <gpio port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio port="E" id="15">
@@ -549,25 +549,25 @@
         <af peripheral="Adc3" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="F" id="6">
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Nss"/>
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="F" id="7">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="F" id="8">
         <af id="5" peripheral="SpiMaster5" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="F" id="9">
         <af id="5" peripheral="SpiMaster5" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="F" id="10">
@@ -630,7 +630,7 @@
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="6">
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="7">
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
@@ -640,36 +640,36 @@
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="9">
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="10">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="11">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="12">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="13">
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="14">
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="H" id="15">
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
       </gpio>
       <gpio port="I" id="0">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio port="I" id="1">
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="a|b|n" port="I" id="2">
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio port="I" id="3">
@@ -680,13 +680,13 @@
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio port="I" id="5">
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio port="I" id="6">
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio port="I" id="7">
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="8"/>
       <gpio port="I" id="9">

--- a/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
+++ b/src/xpcc/architecture/platform/devices/stm32/stm32f745_746_756-b_i_n_v_z-e_g.xml
@@ -141,9 +141,9 @@
     <driver type="usb" name="stm32_fs"/>
     <driver type="gpio" name="stm32">
       <gpio port="A" id="0">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="ExternalTrigger" type="in"/>
         <af id="7" peripheral="Uart2" name="Cts" type="in"/>
         <af id="8" peripheral="Uart4" name="Tx" type="out"/>
@@ -152,8 +152,8 @@
         <af peripheral="Adc3" name="Channel0" type="analog"/>
       </gpio>
       <gpio port="A" id="1">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rts" type="out"/>
         <af id="8" peripheral="Uart4" name="Rx" type="in"/>
         <af peripheral="Adc1" name="Channel1" type="analog"/>
@@ -161,9 +161,9 @@
         <af peripheral="Adc3" name="Channel1" type="analog"/>
       </gpio>
       <gpio port="A" id="2">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
-        <af id="2" peripheral="Timer5" name="Channel3"/>
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="7" peripheral="Uart2" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster2" name="Mosi" type="out"/>
         <af peripheral="Adc1" name="Channel2" type="analog"/>
@@ -171,9 +171,9 @@
         <af peripheral="Adc3" name="Channel2" type="analog"/>
       </gpio>
       <gpio port="A" id="3">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
-        <af id="2" peripheral="Timer5" name="Channel4"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="7" peripheral="Uart2" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster2" name="Miso" type="in"/>
         <af peripheral="Adc1" name="Channel3" type="analog"/>
@@ -189,52 +189,52 @@
         <af peripheral="Adc2" name="Channel4" type="analog"/>
       </gpio>
       <gpio port="A" id="5">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af peripheral="Adc1" name="Channel5" type="analog"/>
         <af peripheral="Adc2" name="Channel5" type="analog"/>
       </gpio>
       <gpio port="A" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel6" type="analog"/>
         <af peripheral="Adc2" name="Channel6" type="analog"/>
       </gpio>
       <gpio port="A" id="7">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc1" name="Channel7" type="analog"/>
         <af peripheral="Adc2" name="Channel7" type="analog"/>
       </gpio>
       <gpio port="A" id="8">
         <!--<af id="0" peripheral="ClockOutput1" type="out"/>-->
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Ck" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Sck" type="out"/>
       </gpio>
       <gpio port="A" id="9">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
       </gpio>
       <gpio port="A" id="10">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="A" id="11">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="7" peripheral="Uart1" name="Cts" type="in"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
         <af id="10" peripheral="Usb" name="Dm"/>
@@ -248,24 +248,24 @@
       <gpio port="A" id="13"/>
       <gpio port="A" id="14"/>
       <gpio port="A" id="15">
-        <af id="1" peripheral="Timer2" name="Channel1"/>
+        <af id="1" peripheral="Timer2" name="Channel1" type="out"/>
         <af id="1" peripheral="Timer2" name="ExternalTrigger" type="in"/>
         <af id="5" peripheral="SpiMaster1" name="Nss"/>
         <af id="6" peripheral="SpiMaster3" name="Nss"/>
         <af id="8" peripheral="Uart4" name="Rts" type="out"/>
       </gpio>
       <gpio port="B" id="0">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="8" peripheral="Uart4" name="Cts" type="in"/>
         <af peripheral="Adc1" name="Channel8" type="analog"/>
         <af peripheral="Adc2" name="Channel8" type="analog"/>
       </gpio>
       <gpio port="B" id="1">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af peripheral="Adc1" name="Channel9" type="analog"/>
         <af peripheral="Adc2" name="Channel9" type="analog"/>
       </gpio>
@@ -273,57 +273,57 @@
         <af id="7" peripheral="SpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="3">
-        <af id="1" peripheral="Timer2" name="Channel2"/>
+        <af id="1" peripheral="Timer2" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Sck" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Sck" type="out"/>
       </gpio>
       <gpio port="B" id="4">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Miso" type="in"/>
         <af id="6" peripheral="SpiMaster3" name="Miso" type="in"/>
         <af id="7" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio port="B" id="5">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster1" name="Mosi" type="out"/>
         <af id="6" peripheral="SpiMaster3" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="6">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="7" peripheral="Uart1" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster1" name="Mosi" type="out"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="7">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="7" peripheral="Uart1" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster1" name="Miso" type="in"/>
       </gpio>
       <gpio port="B" id="8">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Scl" type="out"/>
         <af id="9" peripheral="Can1" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="9">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster1" name="Sda"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="10">
-        <af id="1" peripheral="Timer2" name="Channel3"/>
+        <af id="1" peripheral="Timer2" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Scl" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Tx" type="out"/>
         <af id="7" peripheral="UartSpiMaster3" name="Mosi" type="out"/>
       </gpio>
       <gpio port="B" id="11">
-        <af id="1" peripheral="Timer2" name="Channel4"/>
+        <af id="1" peripheral="Timer2" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster2" name="Sda"/>
         <af id="7" peripheral="Uart3" name="Rx" type="in"/>
         <af id="7" peripheral="UartSpiMaster3" name="Miso" type="in"/>
@@ -336,23 +336,23 @@
         <af id="9" peripheral="Can2" name="Rx" type="in"/>
       </gpio>
       <gpio port="B" id="13">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
         <af id="9" peripheral="Can2" name="Tx" type="out"/>
       </gpio>
       <gpio port="B" id="14">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio port="B" id="15">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Mosi" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio port="C" id="0">
         <af peripheral="Adc1" name="Channel10" type="analog"/>
@@ -386,28 +386,28 @@
         <af peripheral="Adc2" name="Channel15" type="analog"/>
       </gpio>
       <gpio port="C" id="6">
-        <af id="2" peripheral="Timer3" name="Channel1"/>
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="2" peripheral="Timer3" name="Channel1" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart6" name="Tx" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Mosi" type="out"/>
       </gpio>
       <gpio port="C" id="7">
-        <af id="2" peripheral="Timer3" name="Channel2"/>
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="2" peripheral="Timer3" name="Channel2" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
         <af id="8" peripheral="Uart6" name="Rx" type="in"/>
         <af id="8" peripheral="UartSpiMaster6" name="Miso" type="in"/>
       </gpio>
       <gpio port="C" id="8">
-        <af id="2" peripheral="Timer3" name="Channel3"/>
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="2" peripheral="Timer3" name="Channel3" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
         <af id="7" peripheral="Uart5" name="Rts" type="out"/>
         <af id="8" peripheral="Uart6" name="Ck" type="out"/>
         <af id="8" peripheral="UartSpiMaster6" name="Sck" type="out"/>
       </gpio>
       <gpio port="C" id="9">
         <!--<af id="0" peripheral="ClockOutput2" type="out"/>-->
-        <af id="2" peripheral="Timer3" name="Channel4"/>
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="2" peripheral="Timer3" name="Channel4" type="out"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
         <af id="7" peripheral="Uart5" name="Cts" type="in"/>
       </gpio>
@@ -478,20 +478,20 @@
         <af id="7" peripheral="Uart3" name="Cts" type="in"/>
       </gpio>
       <gpio port="D" id="12">
-        <af id="2" peripheral="Timer4" name="Channel1"/>
+        <af id="2" peripheral="Timer4" name="Channel1" type="out"/>
         <af id="4" peripheral="I2cMaster4" name="Scl" type="out"/>
         <af id="7" peripheral="Uart3" name="Rts" type="out"/>
       </gpio>
       <gpio port="D" id="13">
-        <af id="2" peripheral="Timer4" name="Channel2"/>
+        <af id="2" peripheral="Timer4" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster4" name="Sda"/>
       </gpio>
       <gpio port="D" id="14">
-        <af id="2" peripheral="Timer4" name="Channel3"/>
+        <af id="2" peripheral="Timer4" name="Channel3" type="out"/>
         <af id="8" peripheral="Uart8" name="Cts" type="in"/>
       </gpio>
       <gpio port="D" id="15">
-        <af id="2" peripheral="Timer4" name="Channel4"/>
+        <af id="2" peripheral="Timer4" name="Channel4" type="out"/>
         <af id="8" peripheral="Uart8" name="Rts" type="out"/>
       </gpio>
       <gpio port="E" id="0">
@@ -509,12 +509,12 @@
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio port="E" id="5">
-        <af id="3" peripheral="Timer9" name="Channel1"/>
+        <af id="3" peripheral="Timer9" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio port="E" id="6">
         <af id="1" peripheral="Timer1" name="BreakIn" type="in"/>
-        <af id="3" peripheral="Timer9" name="Channel2"/>
+        <af id="3" peripheral="Timer9" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio port="E" id="7">
@@ -522,31 +522,31 @@
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
       </gpio>
       <gpio port="E" id="8">
-        <af id="1" peripheral="Timer1" name="Channel1N"/>
+        <af id="1" peripheral="Timer1" name="Channel1N" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
       </gpio>
       <gpio port="E" id="9">
-        <af id="1" peripheral="Timer1" name="Channel1"/>
+        <af id="1" peripheral="Timer1" name="Channel1" type="out"/>
         <af id="8" peripheral="Uart7" name="Rts" type="out"/>
       </gpio>
       <gpio port="E" id="10">
-        <af id="1" peripheral="Timer1" name="Channel2N"/>
+        <af id="1" peripheral="Timer1" name="Channel2N" type="out"/>
         <af id="8" peripheral="Uart7" name="Cts" type="in"/>
       </gpio>
       <gpio port="E" id="11">
-        <af id="1" peripheral="Timer1" name="Channel2"/>
+        <af id="1" peripheral="Timer1" name="Channel2" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Nss"/>
       </gpio>
       <gpio port="E" id="12">
-        <af id="1" peripheral="Timer1" name="Channel3N"/>
+        <af id="1" peripheral="Timer1" name="Channel3N" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Sck" type="out"/>
       </gpio>
       <gpio port="E" id="13">
-        <af id="1" peripheral="Timer1" name="Channel3"/>
+        <af id="1" peripheral="Timer1" name="Channel3" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Miso" type="in"/>
       </gpio>
       <gpio port="E" id="14">
-        <af id="1" peripheral="Timer1" name="Channel4"/>
+        <af id="1" peripheral="Timer1" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster4" name="Mosi" type="out"/>
       </gpio>
       <gpio port="E" id="15">
@@ -569,13 +569,13 @@
         <af peripheral="Adc3" name="Channel15" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="6">
-        <af id="3" peripheral="Timer10" name="Channel1"/>
+        <af id="3" peripheral="Timer10" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Nss"/>
         <af id="8" peripheral="Uart7" name="Rx" type="in"/>
         <af peripheral="Adc3" name="Channel4" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="7">
-        <af id="3" peripheral="Timer11" name="Channel1"/>
+        <af id="3" peripheral="Timer11" name="Channel1" type="out"/>
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
         <af id="8" peripheral="Uart7" name="Tx" type="out"/>
         <af peripheral="Adc3" name="Channel5" type="analog"/>
@@ -583,13 +583,13 @@
       <gpio device-pin-id="b|i|n|z" port="F" id="8">
         <af id="5" peripheral="SpiMaster5" name="Miso" type="in"/>
         <af id="8" peripheral="Uart7" name="Rts" type="out"/>
-        <af id="9" peripheral="Timer13" name="Channel1"/>
+        <af id="9" peripheral="Timer13" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel6" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="9">
         <af id="5" peripheral="SpiMaster5" name="Mosi" type="out"/>
         <af id="8" peripheral="Uart7" name="Cts" type="in"/>
-        <af id="9" peripheral="Timer14" name="Channel1"/>
+        <af id="9" peripheral="Timer14" name="Channel1" type="out"/>
         <af peripheral="Adc3" name="Channel7" type="analog"/>
       </gpio>
       <gpio device-pin-id="b|i|n|z" port="F" id="10">
@@ -656,7 +656,7 @@
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="6">
         <af id="5" peripheral="SpiMaster5" name="Sck" type="out"/>
-        <af id="9" peripheral="Timer12" name="Channel1"/>
+        <af id="9" peripheral="Timer12" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="7">
         <af id="4" peripheral="I2cMaster3" name="Scl" type="out"/>
@@ -666,31 +666,31 @@
         <af id="4" peripheral="I2cMaster3" name="Sda"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="9">
-        <af id="9" peripheral="Timer12" name="Channel2"/>
+        <af id="9" peripheral="Timer12" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="10">
-        <af id="2" peripheral="Timer5" name="Channel1"/>
+        <af id="2" peripheral="Timer5" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="11">
-        <af id="2" peripheral="Timer5" name="Channel2"/>
+        <af id="2" peripheral="Timer5" name="Channel2" type="out"/>
         <af id="4" peripheral="I2cMaster4" name="Scl" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="12">
-        <af id="2" peripheral="Timer5" name="Channel3"/>
+        <af id="2" peripheral="Timer5" name="Channel3" type="out"/>
         <af id="4" peripheral="I2cMaster4" name="Sda"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="13">
-        <af id="3" peripheral="Timer8" name="Channel1N"/>
+        <af id="3" peripheral="Timer8" name="Channel1N" type="out"/>
         <af id="9" peripheral="Can1" name="Tx" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="14">
-        <af id="3" peripheral="Timer8" name="Channel2N"/>
+        <af id="3" peripheral="Timer8" name="Channel2N" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="H" id="15">
-        <af id="3" peripheral="Timer8" name="Channel3N"/>
+        <af id="3" peripheral="Timer8" name="Channel3N" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="0">
-        <af id="2" peripheral="Timer5" name="Channel4"/>
+        <af id="2" peripheral="Timer5" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Nss"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="1">
@@ -698,7 +698,7 @@
         <af id="5" peripheral="SpiMaster2" name="Sck" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="2">
-        <af id="3" peripheral="Timer8" name="Channel4"/>
+        <af id="3" peripheral="Timer8" name="Channel4" type="out"/>
         <af id="5" peripheral="SpiMaster2" name="Miso" type="in"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="3">
@@ -709,13 +709,13 @@
         <af id="3" peripheral="Timer8" name="BreakIn" type="in"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="5">
-        <af id="3" peripheral="Timer8" name="Channel1"/>
+        <af id="3" peripheral="Timer8" name="Channel1" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="6">
-        <af id="3" peripheral="Timer8" name="Channel2"/>
+        <af id="3" peripheral="Timer8" name="Channel2" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="7">
-        <af id="3" peripheral="Timer8" name="Channel3"/>
+        <af id="3" peripheral="Timer8" name="Channel3" type="out"/>
       </gpio>
       <gpio device-pin-id="b|i|n" port="I" id="8"/>
       <gpio device-pin-id="b|i|n" port="I" id="9">

--- a/tools/device_file_generator/stm_reader.py
+++ b/tools/device_file_generator/stm_reader.py
@@ -376,7 +376,7 @@ class STMDeviceReader(XMLDeviceReader):
 						output_type = 'in'
 						if 'CH' in tname:
 							nice_name = tname.replace('CH', 'Channel')
-							output_type = None
+							output_type = 'out'
 						elif 'BKIN' in tname:
 							nice_name = 'BreakIn'
 						af = {'peripheral' : 'Timer' + tinstance,


### PR DESCRIPTION
Fixes #169.

cc @strongly-typed
