### PR TITLE
Namespace util macros

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -289,13 +289,13 @@ namespace xpcc
 namespace clock
 {
 
-uint32_t ATTRIBUTE_FASTDATA fcpu(8000000);
-uint32_t ATTRIBUTE_FASTDATA fcpu_kHz(8000);
-uint16_t ATTRIBUTE_FASTDATA fcpu_MHz(8);
+uint32_t xpcc_fastdata fcpu(8000000);
+uint32_t xpcc_fastdata fcpu_kHz(8000);
+uint16_t xpcc_fastdata fcpu_MHz(8);
 // Cortex-M0: 4000 loops per MHz
 // Cortex-M7: 1000 loops per MHz
 // otherwise: 3000 loops per MHz
-uint16_t ATTRIBUTE_FASTDATA ns_per_loop(3000 / 8);
+uint16_t xpcc_fastdata ns_per_loop(3000 / 8);
 
 }
 }

--- a/doc/doxyfile
+++ b/doc/doxyfile
@@ -1549,7 +1549,7 @@ PREDEFINED             = __DOXYGEN__ \
                          XPCC_TYPE_FLAGS(x)= \
                          XPCC_INT_TYPE_FLAGS(x)= \
                          __attribute__(x)= \
-                         ATTRIBUTE_PACKED=
+                         xpcc_packed=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/doc/doxyfile
+++ b/doc/doxyfile
@@ -1542,7 +1542,7 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = __DOXYGEN__ \
                          __cplusplus \
                          "EXTERN_FLASH_STORAGE(x):=const x" \
-                         ALWAYS_INLINE=inline \
+                         xpcc_always_inline=inline \
                          "XPCC_FLAGS8(x):=typedef xpcc::Flags8< x > x ## _t" \
                          "XPCC_FLAGS16(x):=typedef xpcc::Flags16< x > x ## _t" \
                          "XPCC_FLAGS32(x):=typedef xpcc::Flags32< x > x ## _t" \

--- a/examples/linux/printf/main.cpp
+++ b/examples/linux/printf/main.cpp
@@ -33,7 +33,7 @@ main()
 
 	float ff_testvector[] = {123.556789, -123.4};
 
-	for (size_t ii = 0; ii < XPCC__ARRAY_SIZE(ff_testvector); ++ii) {
+	for (size_t ii = 0; ii < XPCC_ARRAY_SIZE(ff_testvector); ++ii) {
 		float ff = ff_testvector[ii];
 
 		for (uint_fast8_t width = 1; width < 10; ++width)

--- a/src/xpcc/architecture/driver/accessor.hpp
+++ b/src/xpcc/architecture/driver/accessor.hpp
@@ -51,7 +51,7 @@ namespace xpcc
 		 * \ingroup	accessor
 		 */
 		template<typename T>
-		ALWAYS_INLINE volatile T&
+		xpcc_always_inline volatile T&
 		asVolatile(T& value)
 		{
 			return (volatile T&) value;

--- a/src/xpcc/architecture/driver/accessor/flash.hpp
+++ b/src/xpcc/architecture/driver/accessor/flash.hpp
@@ -57,34 +57,34 @@ namespace xpcc
 		class Flash
 		{
 		public:
-			ALWAYS_INLINE
+			xpcc_always_inline
 			explicit Flash(const T* addr = 0) :
 				address(addr)
 			{
 			}
 			
 			template <typename U>
-			ALWAYS_INLINE
+			xpcc_always_inline
 			explicit Flash(const Flash<U>& rhs) :
 				address((T*) rhs.address)
 			{
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T
 			operator *() const
 			{
 				return FlashReader<T, sizeof(T)>::read(address);
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T
 			operator [](size_t index) const
 			{
 				return FlashReader<T, sizeof(T)>::read(address + index);
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash&
 			operator++()
 			{
@@ -92,7 +92,7 @@ namespace xpcc
 				return *this;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash
 			operator++(int)
 			{
@@ -101,7 +101,7 @@ namespace xpcc
 				return ret;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash&
 			operator--()
 			{
@@ -109,7 +109,7 @@ namespace xpcc
 				return *this;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash&
 			operator--(int)
 			{
@@ -118,7 +118,7 @@ namespace xpcc
 				return ret;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash&
 			operator+=(size_t rhs)
 			{
@@ -126,7 +126,7 @@ namespace xpcc
 				return *this;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Flash&
 			operator-=(size_t rhs)
 			{
@@ -134,14 +134,14 @@ namespace xpcc
 				return *this;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			bool
 			isValid() const
 			{
 				return (address != 0);
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T*
 			getPointer() const
 			{
@@ -163,7 +163,7 @@ namespace xpcc
 		 * \ingroup	accessor
 		 */
 		template<typename T>
-		ALWAYS_INLINE ::xpcc::accessor::Flash<T>
+		xpcc_always_inline ::xpcc::accessor::Flash<T>
 		asFlash(const T* ptr)
 		{
 			return ::xpcc::accessor::Flash<T>(ptr);

--- a/src/xpcc/architecture/driver/accessor/flash_reader.hpp
+++ b/src/xpcc/architecture/driver/accessor/flash_reader.hpp
@@ -81,7 +81,7 @@
 			template<typename T, std::size_t size>
 			struct FlashReader
 			{
-				ALWAYS_INLINE
+				xpcc_always_inline
 				static T
 				read(const T* p)
 				{

--- a/src/xpcc/architecture/driver/accessor/flash_reader_avr_impl.hpp
+++ b/src/xpcc/architecture/driver/accessor/flash_reader_avr_impl.hpp
@@ -48,7 +48,7 @@ namespace xpcc
 	template<typename T, std::size_t size>
 	struct FlashReader
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		static T
 		read(const void* p)
 		{
@@ -61,7 +61,7 @@ namespace xpcc
 	template<typename T>
 	struct FlashReader<T, 1>
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		static T
 		read(const void* p)
 		{
@@ -78,7 +78,7 @@ namespace xpcc
 	template<typename T>
 	struct FlashReader<T, 2>
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		static T
 		read(const void* p)
 		{
@@ -95,7 +95,7 @@ namespace xpcc
 	template<typename T>
 	struct FlashReader<T, 4>
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		static T
 		read(const void* p)
 		{

--- a/src/xpcc/architecture/driver/accessor/ram.hpp
+++ b/src/xpcc/architecture/driver/accessor/ram.hpp
@@ -48,34 +48,34 @@ namespace xpcc
 		class Ram
 		{
 		public:
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram(const T* addr = 0) :
 				address(addr)
 			{
 			}
 			
 			template <typename U>
-			ALWAYS_INLINE
+			xpcc_always_inline
 			explicit Ram(const Ram<U>& rhs) :
 				address((T*) rhs.address)
 			{
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T
 			operator *() const
 			{
 				return *address;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T
 			operator [](std::size_t index) const
 			{
 				return *(address + index);
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram&
 			operator ++ ()
 			{
@@ -83,7 +83,7 @@ namespace xpcc
 				return *this;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram
 			operator ++ (int)
 			{
@@ -92,7 +92,7 @@ namespace xpcc
 				return ret;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram&
 			operator -- ()
 			{
@@ -100,7 +100,7 @@ namespace xpcc
 				return *this;
 			}
 
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram&
 			operator -- (int)
 			{
@@ -109,7 +109,7 @@ namespace xpcc
 				return ret;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram&
 			operator += (std::size_t rhs)
 			{
@@ -117,7 +117,7 @@ namespace xpcc
 				return *this;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Ram&
 			operator -= (std::size_t rhs)
 			{
@@ -125,7 +125,7 @@ namespace xpcc
 				return *this;
 			}
 			
-			ALWAYS_INLINE
+			xpcc_always_inline
 			const T*
 			getPointer() const
 			{

--- a/src/xpcc/architecture/driver/accessor/unaligned.hpp
+++ b/src/xpcc/architecture/driver/accessor/unaligned.hpp
@@ -102,7 +102,7 @@ protected:
  * @ingroup	accessor
  */
 template< typename T, typename U>
-ALWAYS_INLINE unaligned_t<T>*
+xpcc_always_inline unaligned_t<T>*
 asUnaligned(U* value)
 {
 	return reinterpret_cast< unaligned_t<T>* >(value);

--- a/src/xpcc/architecture/driver/accessor/unaligned.hpp
+++ b/src/xpcc/architecture/driver/accessor/unaligned.hpp
@@ -94,7 +94,7 @@ protected:
 #else
 	T data;
 #endif
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 /**
  * Accesses a memory location using a unaligned-safe method.

--- a/src/xpcc/architecture/driver/atomic/lock.hpp
+++ b/src/xpcc/architecture/driver/atomic/lock.hpp
@@ -71,7 +71,7 @@ namespace xpcc
 			 * 
 			 * Disables interrupts.
 			 */
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Lock();
 			
 			/**
@@ -79,7 +79,7 @@ namespace xpcc
 			 * 
 			 * Restore the interrupt settings.
 			 */
-			ALWAYS_INLINE
+			xpcc_always_inline
 			~Lock();
 		
 		private:
@@ -108,7 +108,7 @@ namespace xpcc
 			 * 
 			 * Enable interrupts
 			 */
-			ALWAYS_INLINE
+			xpcc_always_inline
 			Unlock();
 			
 			/**
@@ -116,7 +116,7 @@ namespace xpcc
 			 * 
 			 * Restore the interrupt settings.
 			 */
-			ALWAYS_INLINE
+			xpcc_always_inline
 			~Unlock();
 		
 		private:
@@ -161,7 +161,7 @@ namespace xpcc
 
 #elif defined(XPCC__CPU_CORTEX_M0) || defined(XPCC__CPU_CORTEX_M3) || defined(XPCC__CPU_CORTEX_M4) || defined(XPCC__CPU_CORTEX_M7)
 
-	ALWAYS_INLINE
+	xpcc_always_inline
 	xpcc::atomic::Lock::Lock()
 	{
 		// cpsr = __get_PRIMASK();
@@ -175,14 +175,14 @@ namespace xpcc
 				:: "memory");
 	}
 
-	ALWAYS_INLINE
+	xpcc_always_inline
 	xpcc::atomic::Lock::~Lock()
 	{
 		// __set_PRIMASK(cpsr);
 		asm volatile ("msr PRIMASK, %0" : : "r" (cpsr) : "memory" );
 	}
 
-	ALWAYS_INLINE
+	xpcc_always_inline
 	xpcc::atomic::Unlock::Unlock()
 	{
 		// cpsr = __get_PRIMASK();
@@ -196,7 +196,7 @@ namespace xpcc
 				:: "memory");
 	}
 
-	ALWAYS_INLINE
+	xpcc_always_inline
 	xpcc::atomic::Unlock::~Unlock()
 	{
 		// __set_PRIMASK(cpsr);

--- a/src/xpcc/architecture/driver/atomic/queue.hpp
+++ b/src/xpcc/architecture/driver/atomic/queue.hpp
@@ -64,10 +64,10 @@ namespace xpcc
 		public:
 			Queue();
 			
-			ALWAYS_INLINE bool
+			xpcc_always_inline bool
 			isFull() const;
 			
-			ALWAYS_INLINE bool
+			xpcc_always_inline bool
 			isNotFull() const { return not isFull(); }
 
 			/**
@@ -79,7 +79,7 @@ namespace xpcc
 			bool
 			isNearlyFull() const;
 
-			ALWAYS_INLINE bool
+			xpcc_always_inline bool
 			isEmpty() const;
 			
 			/**
@@ -94,7 +94,7 @@ namespace xpcc
 			bool
 			isNearlyEmpty() const;
 			
-			ALWAYS_INLINE Size
+			xpcc_always_inline Size
 			getMaxSize() const;
 			
 			const T&

--- a/src/xpcc/architecture/driver/atomic/queue_impl.hpp
+++ b/src/xpcc/architecture/driver/atomic/queue_impl.hpp
@@ -43,7 +43,7 @@ xpcc::atomic::Queue<T, N>::Queue() :
 }
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE bool
+xpcc_always_inline bool
 xpcc::atomic::Queue<T, N>::isFull() const
 {
 	Index tmphead = xpcc::accessor::asVolatile(this->head) + 1;
@@ -75,7 +75,7 @@ xpcc::atomic::Queue<T, N>::isNearlyFull() const
 }
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE bool
+xpcc_always_inline bool
 xpcc::atomic::Queue<T, N>::isEmpty() const
 {
 	return (xpcc::accessor::asVolatile(this->head) == xpcc::accessor::asVolatile(this->tail));
@@ -103,21 +103,21 @@ xpcc::atomic::Queue<T, N>::isNearlyEmpty() const
 
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE typename xpcc::atomic::Queue<T, N>::Size
+xpcc_always_inline typename xpcc::atomic::Queue<T, N>::Size
 xpcc::atomic::Queue<T, N>::getMaxSize() const
 {
 	return N;
 }
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE const T&
+xpcc_always_inline const T&
 xpcc::atomic::Queue<T, N>::get() const
 {
 	return this->buffer[this->tail];
 }
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE bool
+xpcc_always_inline bool
 xpcc::atomic::Queue<T, N>::push(const T& value)
 {
 	Index tmphead = this->head + 1;
@@ -135,7 +135,7 @@ xpcc::atomic::Queue<T, N>::push(const T& value)
 }
 
 template<typename T, std::size_t N>
-ALWAYS_INLINE void
+xpcc_always_inline void
 xpcc::atomic::Queue<T, N>::pop()
 {
 	Index tmptail = this->tail + 1;

--- a/src/xpcc/architecture/driver/delay.hpp
+++ b/src/xpcc/architecture/driver/delay.hpp
@@ -70,19 +70,19 @@ namespace xpcc
 
 	namespace xpcc
 	{
-		void ALWAYS_INLINE
+		void xpcc_always_inline
 		delayNanoseconds(uint16_t /*ns*/)
 		{
 			_delay_us(1);
 		}
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMicroseconds(uint16_t us)
 		{
 			while(us--) _delay_us(1);
 		}
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMilliseconds(uint16_t ms)
 		{
 			while(ms--) _delay_ms(1);
@@ -95,19 +95,19 @@ namespace xpcc
 
 	namespace xpcc
 	{
-		void ALWAYS_INLINE
+		void xpcc_always_inline
 		delayNanoseconds(uint16_t /*ns*/)
 		{
 			usleep(1);
 		}
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMicroseconds(uint16_t us)
 		{
 			usleep(us);
 		}
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMilliseconds(uint16_t ms)
 		{
 			usleep(uint32_t(ms)*1000);
@@ -162,13 +162,13 @@ namespace xpcc
 	namespace xpcc
 	{
 		/// @warning    There is little to no timing guarantee with this method!
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayNanoseconds(uint16_t ns)
 		{
 			::_delay_ns(ns);
 		}
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMicroseconds(uint16_t us)
 		{
 			::_delay_us(us);
@@ -176,7 +176,7 @@ namespace xpcc
 
 		/// @warning    this method is _not_ guaranteed to work with inputs over 9000ms
 		///             since "It's Over 9000"! (meaning 32bit arithmetics).
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		delayMilliseconds(uint16_t ms)
 		{
 			::_delay_ms(ms);

--- a/src/xpcc/architecture/driver/heap/block_allocator.hpp
+++ b/src/xpcc/architecture/driver/heap/block_allocator.hpp
@@ -71,14 +71,14 @@ namespace xpcc
 		 * 		Needs to point directly above the last available memory
 		 * 		position.
 		 */
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		initialize(void * heapStart, void * heapEnd);
 		
 		/**
 		 * Allocate memory
 		 * 
 		 */
-		ALWAYS_INLINE void *
+		xpcc_always_inline void *
 		allocate(std::size_t requestedSize);
 		
 		/**
@@ -88,7 +88,7 @@ namespace xpcc
 		 * 		Must be the same pointer previously acquired by
 		 * 		allocate().
 		 */
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		free(void *ptr);
 		
 	public:
@@ -97,7 +97,7 @@ namespace xpcc
 		
 	private:
 		// Align the pointer to a multiple of XPCC__ALIGNMENT
-		ALWAYS_INLINE T *
+		xpcc_always_inline T *
 		alignPointer(void * ptr) const;
 		
 		//static const int MAX_BLOCK_PARTS = 2048;

--- a/src/xpcc/architecture/driver/heap/block_allocator_impl.hpp
+++ b/src/xpcc/architecture/driver/heap/block_allocator_impl.hpp
@@ -74,7 +74,7 @@
  *                             \-- end
  */
 template <typename T, unsigned int BLOCK_SIZE >
-ALWAYS_INLINE void
+xpcc_always_inline void
 xpcc::BlockAllocator<T, BLOCK_SIZE>::initialize(void * heapStart, void * heapEnd)
 {
 	start = alignPointer(heapStart);
@@ -99,7 +99,7 @@ xpcc::BlockAllocator<T, BLOCK_SIZE>::initialize(void * heapStart, void * heapEnd
  * 
  */
 template <typename T, unsigned int BLOCK_SIZE >
-ALWAYS_INLINE void *
+xpcc_always_inline void *
 xpcc::BlockAllocator<T, BLOCK_SIZE>::allocate(std::size_t requestedSize)
 {
 	requestedSize += 4;	// bytes needed for the management
@@ -146,7 +146,7 @@ xpcc::BlockAllocator<T, BLOCK_SIZE>::allocate(std::size_t requestedSize)
 
 // ----------------------------------------------------------------------------
 template <typename T, unsigned int BLOCK_SIZE >
-ALWAYS_INLINE void
+xpcc_always_inline void
 xpcc::BlockAllocator<T, BLOCK_SIZE>::free(void *ptr)
 {
 	if (ptr == 0) {
@@ -199,7 +199,7 @@ xpcc::BlockAllocator<T, BLOCK_SIZE>::free(void *ptr)
 
 // ----------------------------------------------------------------------------
 template <typename T, unsigned int BLOCK_SIZE >
-ALWAYS_INLINE std::size_t
+xpcc_always_inline std::size_t
 xpcc::BlockAllocator<T, BLOCK_SIZE>::getAvailableSize() const
 {
 	T *p = start;
@@ -224,7 +224,7 @@ xpcc::BlockAllocator<T, BLOCK_SIZE>::getAvailableSize() const
 
 // ----------------------------------------------------------------------------
 template<typename T, unsigned int BLOCK_SIZE >
-ALWAYS_INLINE T *
+xpcc_always_inline T *
 xpcc::BlockAllocator<T, BLOCK_SIZE>::alignPointer(void * ptr) const
 {
 	// (XPCC__ALIGNMENT - 1) is used as a bitmask

--- a/src/xpcc/architecture/interface/can_message.hpp
+++ b/src/xpcc/architecture/interface/can_message.hpp
@@ -80,7 +80,7 @@ struct Message
 
 public:
 	uint32_t identifier;
-	uint8_t ATTRIBUTE_ALIGNED(4) data[8];
+	uint8_t xpcc_aligned(4) data[8];
 	struct Flags
 	{
 		Flags() :

--- a/src/xpcc/architecture/interface/i2c_transaction.hpp
+++ b/src/xpcc/architecture/interface/i2c_transaction.hpp
@@ -245,7 +245,7 @@ public:
 	{
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configurePing()
 	{
 		return configureWriteRead(nullptr, 0, nullptr, 0);
@@ -302,7 +302,7 @@ public:
 	 * @return  `true` if adapter was not in use,
 	 *          `false` otherwise
 	 */
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureWrite(const uint8_t *buffer, std::size_t size)
 	{
 		return configureWriteRead(buffer, size, nullptr, 0);
@@ -317,7 +317,7 @@ public:
 	 * @return  `true` if adapter was not in use,
 	 *          `false` otherwise
 	 */
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureRead(uint8_t *buffer, std::size_t size)
 	{
 		return configureWriteRead(nullptr, 0, buffer, size);
@@ -412,13 +412,13 @@ public:
 	{
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configurePing()
 	{
 		return configureWrite(nullptr, 0);
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureWriteRead(const uint8_t *, std::size_t, uint8_t *, std::size_t)
 	{
 		return false;
@@ -436,7 +436,7 @@ public:
 		return false;
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureRead(uint8_t *, std::size_t)
 	{
 		return false;
@@ -487,19 +487,19 @@ public:
 	{
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configurePing()
 	{
 		return configureRead(nullptr, 0);
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureWriteRead(const uint8_t *, std::size_t, uint8_t *, std::size_t)
 	{
 		return false;
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	configureWrite(uint8_t *, std::size_t)
 	{
 		return false;

--- a/src/xpcc/architecture/interface/register.hpp
+++ b/src/xpcc/architecture/interface/register.hpp
@@ -427,7 +427,7 @@ struct FlagsOperators : public ::xpcc::Register<T>
 	friend constexpr bool operator!=(Enum const &a, FlagsOperators const &b);
 	/// @}
 #endif
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 /**
  * Class for operating on a register.
@@ -568,7 +568,7 @@ struct Flags : public ::xpcc::FlagsOperators<Enum, T>
 	constexpr bool none(Flags const &o) const
 	{ return (*this & o).value == 0; }
 	/// @}
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 /// @ingroup	register
 /// @{
@@ -583,7 +583,7 @@ using Flags32 = Flags<Enum, uint32_t>;	///< Flags class with 32-bit wide underly
 
 /// @cond
 template < typename... T >
-struct FlagsGroup {} ATTRIBUTE_PACKED;
+struct FlagsGroup {} xpcc_packed;
 
 
 template < typename T, typename... Ts >
@@ -601,7 +601,7 @@ struct FlagsGroup<T, Ts...> : public FlagsGroup<Ts...>
 	// Flags class
 	constexpr FlagsGroup(T value)
 	:	FlagsGroup<Ts...>(value.value) {}
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 /// @endcond
 
 /**
@@ -659,7 +659,7 @@ struct FlagsGroup<T> : public Register<typename T::UnderlyingType>
 	/// Flags type constructor
 	constexpr FlagsGroup(T value)
 	:	Register<typename T::UnderlyingType>(value.value) {}
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 /**
  * Class for accessing a configuration in a register.
@@ -781,7 +781,7 @@ public:
 	constexpr operator Parent() const
 	{	return Parent(FlagsOperators<EType, UType>::value); }
 	/// @endcond
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 /**
  * Class for accessing a numeric value in a register.
@@ -846,7 +846,7 @@ public:
 	constexpr operator Parent() const
 	{	return Parent(FlagsOperators<EType, UType>::value); }
 	/// @endcond
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 }	// namespace xpcc
 

--- a/src/xpcc/architecture/interface/register.hpp
+++ b/src/xpcc/architecture/interface/register.hpp
@@ -877,8 +877,8 @@ constexpr ::xpcc::Flags<Enum> operator^(Enum const &a, Enum const &b) { return :
  * @hideinitializer
  */
 #define XPCC_FLAGS8(Enum) \
-	typedef ::xpcc::Flags8<Enum> CONCAT(Enum, _t); \
-	XPCC_INT_TYPE_FLAGS(CONCAT(Enum, _t))
+	typedef ::xpcc::Flags8<Enum> XPCC_CONCAT(Enum, _t); \
+	XPCC_INT_TYPE_FLAGS(XPCC_CONCAT(Enum, _t))
 
 /**
  * @details
@@ -895,8 +895,8 @@ constexpr ::xpcc::Flags<Enum> operator^(Enum const &a, Enum const &b) { return :
  * @hideinitializer
  */
 #define XPCC_FLAGS16(Enum) \
-	typedef ::xpcc::Flags16<Enum> CONCAT(Enum, _t); \
-	XPCC_INT_TYPE_FLAGS(CONCAT(Enum, _t))
+	typedef ::xpcc::Flags16<Enum> XPCC_CONCAT(Enum, _t); \
+	XPCC_INT_TYPE_FLAGS(XPCC_CONCAT(Enum, _t))
 
 /**
  * @details
@@ -913,8 +913,8 @@ constexpr ::xpcc::Flags<Enum> operator^(Enum const &a, Enum const &b) { return :
  * @hideinitializer
  */
 #define XPCC_FLAGS32(Enum) \
-	typedef ::xpcc::Flags32<Enum> CONCAT(Enum, _t); \
-	XPCC_INT_TYPE_FLAGS(CONCAT(Enum, _t))
+	typedef ::xpcc::Flags32<Enum> XPCC_CONCAT(Enum, _t); \
+	XPCC_INT_TYPE_FLAGS(XPCC_CONCAT(Enum, _t))
 
 /**
  * @details

--- a/src/xpcc/architecture/legacy_macros.hpp
+++ b/src/xpcc/architecture/legacy_macros.hpp
@@ -1,0 +1,63 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_LEGACY_MACROS_HPP
+#define XPCC_LEGACY_MACROS_HPP
+
+#include "detect.hpp"
+
+#ifndef __DOXYGEN__
+
+#ifndef XPCC_DISABLE_LEGACY_MACROS
+
+#	define STRINGIFY(s)			XPCC_STRINGIFY(s)
+#	define CONCAT(a,b)			XPCC_CONCAT(a,b)
+#	define CONCAT3(a,b,c)		XPCC_CONCAT3(a,b,c)
+#	define CONCAT4(a,b,c,d)		XPCC_CONCAT4(a,b,c,d)
+#	define CONCAT5(a,b,c,d,e)	XPCC_CONCAT5(a,b,c,d,e)
+
+#	define ALWAYS_INLINE  		xpcc_always_inline
+#	define ATTRIBUTE_UNUSED		xpcc_unused
+#	define ATTRIBUTE_WEAK		xpcc_weak
+#	define ATTRIBUTE_ALIGNED(n)	xpcc_aligned(n)
+#	define ATTRIBUTE_PACKED		xpcc_packed
+#	define ATTRIBUTE_FASTCODE	xpcc_fastcode
+#	define ATTRIBUTE_FASTDATA	xpcc_fastdata
+#	define ATTRIBUTE_MAY_ALIAS	xpcc_may_alias
+#	define likely(x)			xpcc_likely(x)
+#	define unlikely(x)			xpcc_unlikely(x)
+
+#	ifdef XPCC__OS_HOSTED
+#		define 	MAIN_FUNCTION		int main( int argc, char* argv[] )
+#		define	MAIN_FUNCTION_NAKED	int main( int,      char**       )
+#	else
+#		define	MAIN_FUNCTION	int main(void)
+#		define	MAIN_FUNCTION_NAKED MAIN_FUNCTION
+#	endif
+
+#	define XPCC__ARRAY_SIZE(x)	XPCC_ARRAY_SIZE(x)
+
+#	define ENUM_CLASS_FLAG(name) \
+		inline name operator|(name a, name b) \
+		{return static_cast<name>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));} \
+		inline uint32_t operator&(name a, name b) \
+		{return (static_cast<uint32_t>(a) & static_cast<uint32_t>(b));} \
+		inline uint32_t operator&(uint32_t a, name b) \
+		{return ((a) & static_cast<uint32_t>(b));} \
+		inline uint32_t operator&(name a, uint32_t b) \
+		{return (static_cast<uint32_t>(a) & (b));}
+
+#endif
+
+#define XPCC_ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
+
+
+#endif	// !__DOXYGEN__
+
+#endif	// XPCC_LEGACY_MACROS_HPP

--- a/src/xpcc/architecture/platform/device.hpp.in
+++ b/src/xpcc/architecture/platform/device.hpp.in
@@ -32,7 +32,7 @@
 #define XPCC__DEVICE_HPP
 
 #include <stdint.h>
-// Defines for example the ALWAYS_INLINE macro
+// Defines for example the xpcc_always_inline macro
 #include <xpcc/architecture/utils.hpp>
 
 // Include external device headers

--- a/src/xpcc/architecture/platform/driver/adc/at90_tiny_mega/adc_interrupt.cpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/at90_tiny_mega/adc_interrupt.cpp.in
@@ -15,7 +15,7 @@ xpcc::{{ target.family }}::AdcInterrupt::Handler
 xpcc::{{ target.family }}::AdcInterrupt::handler(xpcc::dummy);
 
 // ----------------------------------------------------------------------------
-ISR(ADC_vect, ATTRIBUTE_WEAK)
+ISR(ADC_vect, xpcc_weak)
 {
 	xpcc::{{ target.family }}::AdcInterrupt::handler();
 }

--- a/src/xpcc/architecture/platform/driver/adc/stm32/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32/adc_impl.hpp.in
@@ -245,13 +245,13 @@ xpcc::stm32::Adc{{ id }}::readChannel(Channel channel)
 #ifndef XPCC_CUSTOM_NVIC_FUNCTIONS
 #define XPCC_CUSTOM_NVIC_FUNCTIONS
 
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicEnableInterrupt(const IRQn_Type IRQn)
 {
 	NVIC->ISER[(uint32_t(IRQn) >> 5)] = (1 << (uint32_t(IRQn) & 0x1F));
 }
 
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicDisableInterrupt(IRQn_Type IRQn)
 {
 	NVIC_DisableIRQ(IRQn);

--- a/src/xpcc/architecture/platform/driver/adc/stm32f3/adc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f3/adc.hpp.in
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "../../../type_ids.hpp"
 #include "../../../device.hpp"
+#include <xpcc/architecture/interface/register.hpp>
 
 namespace xpcc
 {
@@ -174,6 +175,7 @@ public:
 		AnalogWatchdog3 					= ADC_IER_AWD3,
 		InjectedContextQueueOverflow 		= ADC_IER_JQOVF,
 	};
+	XPCC_FLAGS32(Interrupt);
 
 	enum class InterruptFlag : uint32_t
 	{
@@ -189,6 +191,7 @@ public:
 		AnalogWatchdog3 					= ADC_ISR_AWD3,
 		InjectedContextQueueOverflow 		= ADC_ISR_JQOVF,
 	};
+	XPCC_FLAGS32(InterruptFlag);
 
 public:
 	/**
@@ -327,19 +330,17 @@ public:
 	enableInterruptVector(const uint32_t priority, const bool enable = true);
 
 	static inline void
-	enableInterrupt(const Interrupt interrupt);
+	enableInterrupt(const Interrupt_t interrupt);
 
 	static inline void
-	disableInterrupt(const Interrupt interrupt);
+	disableInterrupt(const Interrupt_t interrupt);
 
-	static inline InterruptFlag
+	static inline InterruptFlag_t
 	getInterruptFlags();
 
 	static inline void
-	acknowledgeInterruptFlag(const InterruptFlag flags);
+	acknowledgeInterruptFlag(const InterruptFlag_t flags);
 };
-ENUM_CLASS_FLAG(Adc{{ id }}::Interrupt)
-ENUM_CLASS_FLAG(Adc{{ id }}::InterruptFlag)
 
 }
 

--- a/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
@@ -178,14 +178,14 @@ xpcc::stm32::Adc{{ id }}::isConversionFinished(void)
 #ifndef XPCC_CUSTOM_NVIC_FUNCTIONS
 #define XPCC_CUSTOM_NVIC_FUNCTIONS
 
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicEnableInterrupt(const IRQn_Type IRQn)
 {
 	NVIC->ISER[(static_cast<uint32_t>(IRQn) >> 5)] =
 								(1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicDisableInterrupt(IRQn_Type IRQn)
 {
 	NVIC_DisableIRQ(IRQn);

--- a/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
@@ -87,8 +87,7 @@ xpcc::stm32::Adc{{ id }}::setPrescaler(const Prescaler pre)
 bool
 xpcc::stm32::Adc{{ id }}::isReady()
 {
-	return (static_cast<uint32_t>(getInterruptFlags()) &
-					static_cast<uint32_t>(InterruptFlag::Ready));
+	return (getInterruptFlags() & InterruptFlag::Ready);
 }
 
 void
@@ -155,9 +154,7 @@ void
 xpcc::stm32::Adc{{ id }}::startConversion(void)
 {
 	// TODO: maybe add more interrupt flags
-	acknowledgeInterruptFlag(static_cast<InterruptFlag>(
-		static_cast<uint32_t>(InterruptFlag::EndOfSampling) |
-		static_cast<uint32_t>(InterruptFlag::Overrun)));
+	acknowledgeInterruptFlag(InterruptFlag::EndOfSampling | InterruptFlag::Overrun);
 	// starts single conversion for the regular group
 	ADC{{ id }}->CR |= ADC_CR_ADSTART;
 }
@@ -165,8 +162,7 @@ xpcc::stm32::Adc{{ id }}::startConversion(void)
 bool
 xpcc::stm32::Adc{{ id }}::isConversionFinished(void)
 {
-	return (static_cast<uint32_t>(getInterruptFlags()) &
-			static_cast<uint32_t>(InterruptFlag::EndOfSampling));
+	return (getInterruptFlags() & InterruptFlag::EndOfSampling);
 }
 
 // ----------------------------------------------------------------------------
@@ -212,27 +208,27 @@ xpcc::stm32::Adc{{ id }}::enableInterruptVector(const uint32_t priority,
 }
 
 void
-xpcc::stm32::Adc{{ id }}::enableInterrupt(const Interrupt interrupt)
+xpcc::stm32::Adc{{ id }}::enableInterrupt(const Interrupt_t interrupt)
 {
-	ADC{{ id }}->IER |= static_cast<uint32_t>(interrupt);
+	ADC{{ id }}->IER |= interrupt.value;
 }
 
 void
-xpcc::stm32::Adc{{ id }}::disableInterrupt(const Interrupt interrupt)
+xpcc::stm32::Adc{{ id }}::disableInterrupt(const Interrupt_t interrupt)
 {
-	ADC{{ id }}->IER &= ~static_cast<uint32_t>(interrupt);
+	ADC{{ id }}->IER &= ~interrupt.value;
 }
 
-xpcc::stm32::Adc{{ id }}::InterruptFlag
+xpcc::stm32::Adc{{ id }}::InterruptFlag_t
 xpcc::stm32::Adc{{ id }}::getInterruptFlags()
 {
-	return static_cast<InterruptFlag>(ADC{{ id }}->ISR);
+	return InterruptFlag_t(ADC{{ id }}->ISR);
 }
 
 void
-xpcc::stm32::Adc{{ id }}::acknowledgeInterruptFlag(const InterruptFlag flags)
+xpcc::stm32::Adc{{ id }}::acknowledgeInterruptFlag(const InterruptFlag_t flags)
 {
 	// Flags are cleared by writing a one to the flag position.
 	// Writing a zero is ignored.
-	ADC{{ id }}->ISR = static_cast<uint32_t>(flags);
+	ADC{{ id }}->ISR = flags.value;
 }

--- a/src/xpcc/architecture/platform/driver/can/lpc/c_can_filter.hpp
+++ b/src/xpcc/architecture/platform/driver/can/lpc/c_can_filter.hpp
@@ -57,7 +57,7 @@ namespace xpcc
 			struct Identifier
 			{
 			protected:
-				ALWAYS_INLINE
+				xpcc_always_inline
 				Identifier(uint32_t identifier) :
 					value(identifier)
 				{
@@ -66,7 +66,7 @@ namespace xpcc
 				uint32_t value;
 
 			public:
-				ALWAYS_INLINE
+				xpcc_always_inline
 				operator uint32_t () const
 				{
 					return value;
@@ -82,7 +82,7 @@ namespace xpcc
 			 */
 			struct ExtendedIdentifier : public Identifier
 			{
-				ALWAYS_INLINE
+				xpcc_always_inline
 				ExtendedIdentifier(uint32_t identifier, RemoteRequestStatus rtr = NO_RTR) :
 					Identifier(identifier | (CAN_IFn_ARB2_MSGVAL << 16) | (CAN_IFn_ARB2_XTD << 16) | ((rtr) ? (CAN_IFn_ARB2_DIR << 16) : 0))
 				{
@@ -91,13 +91,13 @@ namespace xpcc
 
 			struct ExtendedFilterMask
 			{
-				ALWAYS_INLINE
+				xpcc_always_inline
 				ExtendedFilterMask(uint32_t identifier, RemoteRequestFilter rtr = RTR_MATCH) :
 					value(identifier | (CAN_IFn_MSK2_MXTD << 16) | ((rtr) ? (CAN_IFn_MSK2_MDIR << 16) : 0))
 				{
 				}
 
-				ALWAYS_INLINE
+				xpcc_always_inline
 				operator uint32_t () const
 				{
 					return value;

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
@@ -168,7 +168,7 @@ sendMailbox(const xpcc::can::Message& message, uint32_t mailboxId)
 	mailbox->TDTR = message.getLength();
 	
 	// Set up the data field (copy the 8x8-bits into two 32-bit registers)
-	const uint8_t * ATTRIBUTE_MAY_ALIAS data = message.data;
+	const uint8_t * xpcc_may_alias data = message.data;
 	mailbox->TDLR = reinterpret_cast<const uint32_t *>(data)[0];
 	mailbox->TDHR = reinterpret_cast<const uint32_t *>(data)[1];
 	
@@ -197,7 +197,7 @@ readMailbox(xpcc::can::Message& message, uint32_t mailboxId)
 	
 	message.length = mailbox->RDTR & CAN_TDT1R_DLC;
 	
-	uint8_t * ATTRIBUTE_MAY_ALIAS data = message.data;
+	uint8_t * xpcc_may_alias data = message.data;
 	reinterpret_cast<uint32_t *>(data)[0] = mailbox->RDLR;
 	reinterpret_cast<uint32_t *>(data)[1] = mailbox->RDHR;
 }

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
@@ -46,7 +46,7 @@ static xpcc::atomic::Queue<xpcc::can::Message, {{ parameters.rx_buffer }}> rxQue
 // Re-implemented here to save some code space. As all arguments in the calls
 // below are constant the compiler is able to calculate everything at
 // compile time.
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicEnableInterrupt(IRQn_Type IRQn)
 {
 	NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1UL << ((uint32_t)(IRQn) & 0x1F));

--- a/src/xpcc/architecture/platform/driver/can/stm32/can_filter.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can_filter.hpp.in
@@ -59,7 +59,7 @@ private:
 	struct Identifier
 	{
 	protected:
-		ALWAYS_INLINE
+		xpcc_always_inline
 		Identifier(uint32_t identifier) :
 			value(identifier)
 		{
@@ -68,7 +68,7 @@ private:
 		uint32_t value;
 
 	public:
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint32_t () const
 		{
 			return value;
@@ -81,7 +81,7 @@ public:
 	 */
 	struct ExtendedIdentifier : public Identifier
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		ExtendedIdentifier(uint32_t identifier, RemoteRequestStatus rtr = NO_RTR) :
 			Identifier((identifier << 3) | 0x4 | ((rtr) ? 0x2 : 0))
 		{
@@ -93,13 +93,13 @@ public:
 	 */
 	struct ExtendedFilterMask
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		ExtendedFilterMask(uint32_t identifier, RemoteRequestFilter rtr = RTR_MATCH) :
 			value((identifier << 3) | 0x4 | ((rtr) ? 0x2 : 0))
 		{
 		}
 
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint32_t () const
 		{
 			return value;
@@ -114,7 +114,7 @@ public:
 	 */
 	struct StandardIdentifier : public Identifier
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		StandardIdentifier(uint16_t identifier, RemoteRequestStatus rtr = NO_RTR) :
 			Identifier((identifier << 21) | ((rtr) ? 0x2 : 0))
 		{
@@ -126,13 +126,13 @@ public:
 	 */
 	struct StandardFilterMask
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		StandardFilterMask(uint16_t identifier, RemoteRequestFilter rtr = RTR_MATCH) :
 			value((identifier << 21) | ((rtr) ? 0x2 : 0))
 		{
 		}
 
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint32_t () const
 		{
 			return value;
@@ -147,7 +147,7 @@ private:
 	struct IdentifierShort
 	{
 	protected:
-		ALWAYS_INLINE
+		xpcc_always_inline
 		IdentifierShort(uint16_t identifier) :
 			value(identifier)
 		{
@@ -156,7 +156,7 @@ private:
 		uint16_t value;
 
 	public:
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint16_t () const
 		{
 			return value;
@@ -173,7 +173,7 @@ public:
 	 */
 	struct ExtendedIdentifierShort : public IdentifierShort
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		ExtendedIdentifierShort(uint32_t identifier, RemoteRequestStatus rtr = NO_RTR) :
 			IdentifierShort(((identifier >> 13) & 0xffe0) |
 					((identifier >> 15) & 0x007f) |
@@ -191,7 +191,7 @@ public:
 	 */
 	struct ExtendedFilterMaskShort
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		ExtendedFilterMaskShort(uint32_t identifier, RemoteRequestFilter rtr = RTR_MATCH) :
 			value(((identifier >> 13) & 0xffe0) |
 					((identifier >> 15) & 0x007f) |
@@ -200,7 +200,7 @@ public:
 		{
 		}
 
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint16_t () const
 		{
 			return value;
@@ -216,7 +216,7 @@ public:
 	 */
 	struct StandardIdentifierShort : public IdentifierShort
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		StandardIdentifierShort(uint16_t identifier, RemoteRequestStatus rtr = NO_RTR) :
 			IdentifierShort(((identifier << 5) & 0xffe0) | ((rtr) ? 0x10 : 0))
 		{
@@ -225,13 +225,13 @@ public:
 
 	struct StandardFilterMaskShort
 	{
-		ALWAYS_INLINE
+		xpcc_always_inline
 		StandardFilterMaskShort(uint16_t identifier, RemoteRequestFilter rtr = RTR_MATCH) :
 			value(((identifier << 5) & 0xffe0) | ((rtr) ? 0x10 : 0))
 		{
 		}
 
-		ALWAYS_INLINE
+		xpcc_always_inline
 		operator uint16_t () const
 		{
 			return value;
@@ -251,7 +251,7 @@ public:
 	 * @param	id		29-bit identifier
 	 * @param	mask	29-bit mask
 	 */
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilter(uint8_t bank, Fifo fifo, ExtendedIdentifier id, ExtendedFilterMask mask)
 	{
 		setFilterBase(bank, fifo | MASK_MODE | SINGLE_MODE, id, mask);
@@ -266,7 +266,7 @@ public:
 	 * @param	id		11-bit identifier
 	 * @param	mask	11-bit mask
 	 */
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilter(uint8_t bank, Fifo fifo, StandardIdentifier id, StandardFilterMask mask)
 	{
 		setFilterBase(bank, fifo | MASK_MODE | SINGLE_MODE, id, mask);
@@ -283,14 +283,14 @@ public:
 	 * @param	id		11 or 29-bit identifier
 	 * @param	id2		11 or 29-bit identifier
 	 */
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setIdentifierFilter(uint8_t bank, Fifo fifo, Identifier id, Identifier id2)
 	{
 		setFilterBase(bank, fifo | LIST_MODE | SINGLE_MODE, id, id2);
 	}
 
 	// ----------------------------------------------------------------
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilterShort(uint8_t bank, Fifo fifo,
 			StandardIdentifierShort id1, StandardFilterMaskShort mask1,
 			StandardIdentifierShort id2, StandardFilterMaskShort mask2)
@@ -300,7 +300,7 @@ public:
 				id2 | ((uint32_t) mask2 << 16));
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilterShort(uint8_t bank, Fifo fifo,
 			StandardIdentifierShort id1, StandardFilterMaskShort mask1,
 			ExtendedIdentifierShort id2, ExtendedFilterMaskShort mask2)
@@ -310,7 +310,7 @@ public:
 				id2 | ((uint32_t) mask2 << 16));
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilterShort(uint8_t bank, Fifo fifo,
 			ExtendedIdentifierShort id1, ExtendedFilterMaskShort mask1,
 			StandardIdentifierShort id2, StandardFilterMaskShort mask2)
@@ -320,7 +320,7 @@ public:
 				id2 | ((uint32_t) mask2 << 16));
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setFilterShort(uint8_t bank, Fifo fifo,
 			ExtendedIdentifierShort id1, ExtendedFilterMaskShort mask1,
 			ExtendedIdentifierShort id2, ExtendedFilterMaskShort mask2)
@@ -345,7 +345,7 @@ public:
 	 * @param	id3		11 or 29-bit identifier
 	 * @param	id4		11 or 29-bit identifier
 	 */
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setIdentifierFilterShort(uint8_t bank, Fifo fifo,
 			IdentifierShort id1, IdentifierShort id2,
 			IdentifierShort id3, IdentifierShort id4)

--- a/src/xpcc/architecture/platform/driver/clock/generic/common_clock.hpp
+++ b/src/xpcc/architecture/platform/driver/clock/generic/common_clock.hpp
@@ -101,10 +101,10 @@ StartupError : uint8_t
 	WatchdogClock
 };
 
-extern uint32_t ATTRIBUTE_FASTDATA fcpu;
-extern uint32_t ATTRIBUTE_FASTDATA fcpu_kHz;
-extern uint16_t ATTRIBUTE_FASTDATA fcpu_MHz;
-extern uint16_t ATTRIBUTE_FASTDATA ns_per_loop;
+extern uint32_t xpcc_fastdata fcpu;
+extern uint32_t xpcc_fastdata fcpu_kHz;
+extern uint16_t xpcc_fastdata fcpu_MHz;
+extern uint16_t xpcc_fastdata ns_per_loop;
 
 }	// namespace clock
 

--- a/src/xpcc/architecture/platform/driver/clock/generic/static.macros
+++ b/src/xpcc/architecture/platform/driver/clock/generic/static.macros
@@ -218,7 +218,7 @@ public:
 %%	endfor
 	};
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setDivision(Division)
 	{
 		//ClockControl::enable{{ o.name }}(static_cast<int>(d));
@@ -226,7 +226,7 @@ public:
 %% endif
 	// Connect Functions
 %% for src in o.sources
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 %% if target is stm32f2 or target is stm32f4
 	connect(::{{type_id_namespace}}::TypeId::{{ src.name }} /* t */, uint8_t div = 1)
 	{

--- a/src/xpcc/architecture/platform/driver/clock/lpc/common_clock.cpp
+++ b/src/xpcc/architecture/platform/driver/clock/lpc/common_clock.cpp
@@ -17,10 +17,10 @@ namespace xpcc
 namespace clock
 {
 
-uint32_t ATTRIBUTE_FASTDATA fcpu(MHz12);
-uint32_t ATTRIBUTE_FASTDATA fcpu_kHz(12000);
-uint16_t ATTRIBUTE_FASTDATA fcpu_MHz(12);
-uint16_t ATTRIBUTE_FASTDATA ns_per_loop(4000/12);
+uint32_t xpcc_fastdata fcpu(MHz12);
+uint32_t xpcc_fastdata fcpu_kHz(12000);
+uint16_t xpcc_fastdata fcpu_MHz(12);
+uint16_t xpcc_fastdata ns_per_loop(4000/12);
 
 }
 

--- a/src/xpcc/architecture/platform/driver/clock/stm32/clock.cpp.in
+++ b/src/xpcc/architecture/platform/driver/clock/stm32/clock.cpp.in
@@ -14,9 +14,9 @@ namespace xpcc
 namespace clock
 {
 
-uint32_t ATTRIBUTE_FASTDATA fcpu({{ hsi_frequency|int * 1000000 }});
-uint32_t ATTRIBUTE_FASTDATA fcpu_kHz({{ hsi_frequency|int * 1000 }});
-uint16_t ATTRIBUTE_FASTDATA fcpu_MHz({{ hsi_frequency }});
+uint32_t xpcc_fastdata fcpu({{ hsi_frequency|int * 1000000 }});
+uint32_t xpcc_fastdata fcpu_kHz({{ hsi_frequency|int * 1000 }});
+uint16_t xpcc_fastdata fcpu_MHz({{ hsi_frequency }});
 %% if target is cortex_m0
 	%% set loops = 4000.0
 %% elif target is cortex_m7
@@ -24,7 +24,7 @@ uint16_t ATTRIBUTE_FASTDATA fcpu_MHz({{ hsi_frequency }});
 %% else
 	%% set loops = 3000.0
 %% endif
-uint16_t ATTRIBUTE_FASTDATA ns_per_loop({{ loops / hsi_frequency|int}});
+uint16_t xpcc_fastdata ns_per_loop({{ loops / hsi_frequency|int}});
 
 }
 }

--- a/src/xpcc/architecture/platform/driver/core/avr/interrupts.hpp.in
+++ b/src/xpcc/architecture/platform/driver/core/avr/interrupts.hpp.in
@@ -26,14 +26,14 @@ namespace {{ target.family }}
 {
 
 /// enables global interrupts
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 enableInterrupts()
 {
 	sei();
 }
 
 /// disables global interrupts
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 disableInterrupts()
 {
 	cli();

--- a/src/xpcc/architecture/platform/driver/core/avr/utils.hpp
+++ b/src/xpcc/architecture/platform/driver/core/avr/utils.hpp
@@ -33,7 +33,7 @@ namespace xmega
  *
  * @ingroup	xmega
  */
-ALWAYS_INLINE static void
+xpcc_always_inline static void
 changeProtectedRegister(volatile uint8_t *address, uint8_t value)
 {
 #ifdef RAMPZ
@@ -69,7 +69,7 @@ readCalibrationByte(uint8_t index);
  *
  * @ingroup	xmega
  */
-ALWAYS_INLINE static void
+xpcc_always_inline static void
 softwareReset()
 {
 	changeProtectedRegister(&RST_CTRL, RST_SWRST_bm);

--- a/src/xpcc/architecture/platform/driver/core/cortex/delay.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/delay.cpp.in
@@ -36,7 +36,7 @@ extern "C"
 {
 
 
-void ATTRIBUTE_FASTCODE
+void xpcc_fastcode
 _delay_ns(uint16_t ns)
 {
 	// ns_per_loop = nanoseconds per cycle times cycles per loop ({{loop}} cycles)
@@ -51,7 +51,7 @@ _delay_ns(uint16_t ns)
 }
 
 
-void ATTRIBUTE_FASTCODE
+void xpcc_fastcode
 _delay_us(uint16_t us)
 {
 	if (!us) return;    // 1 cycle, or 2 when taken
@@ -74,7 +74,7 @@ _delay_us(uint16_t us)
 }
 
 
-void ATTRIBUTE_FASTCODE
+void xpcc_fastcode
 _delay_ms(uint16_t ms)
 {
 	if (!ms) return;    // 1 cycle, or 2 when taken

--- a/src/xpcc/architecture/platform/driver/gpio/at90_tiny_mega/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/at90_tiny_mega/gpio.hpp.in
@@ -92,43 +92,43 @@ public:
 	static constexpr xpcc::Gpio::Direction direction = xpcc::Gpio::Direction::Out;
 
 public:
-	ALWAYS_INLINE static void configure(Gpio::InputType /*type*/) {}
-	ALWAYS_INLINE static void setInput() {}
-	ALWAYS_INLINE static void setInput(Gpio::InputType /*type*/) {}
-	ALWAYS_INLINE static void setOutput() {}
-	ALWAYS_INLINE static void setOutput(bool status) {
+	xpcc_always_inline static void configure(Gpio::InputType /*type*/) {}
+	xpcc_always_inline static void setInput() {}
+	xpcc_always_inline static void setInput(Gpio::InputType /*type*/) {}
+	xpcc_always_inline static void setOutput() {}
+	xpcc_always_inline static void setOutput(bool status) {
 		set(status);
 	}
 	%% if name == 'GpioOpenDrain'
 	/// maps to `setInput(InputType::Floating)`
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		Pin::setInput(Gpio::InputType::Floating);
 	}
 	%% else
 	/// maps to `setInput(InputType::PullUp)`
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		Pin::setInput(Gpio::InputType::PullUp);
 	}
 	%% endif
 	/// maps to `setOutput(::xpcc::Gpio::Low)`
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		Pin::setOutput(::xpcc::Gpio::Low);
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) { set(); }
 		else { reset(); }
 	}
-	ALWAYS_INLINE static bool isSet() {
+	xpcc_always_inline static bool isSet() {
 		return (Pin::getDirection() == xpcc::Gpio::Direction::In);
 	}
-	ALWAYS_INLINE static xpcc::Gpio::Direction getDirection() {
+	xpcc_always_inline static xpcc::Gpio::Direction getDirection() {
 		return xpcc::Gpio::Direction::Out;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::SoftwareI2cMasterSda) {
 		set();
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::SoftwareI2cMasterScl) {
 		set();
 		xpcc::I2c::resetDevices< Pin >();
@@ -156,39 +156,39 @@ public:
 	static constexpr uint8_t mask = (1 << pin);	///< the mask of this GPIO
 
 		%% if type in ["IO", "Output"]
-	ALWAYS_INLINE static void setOutput(bool status) {
+	xpcc_always_inline static void setOutput(bool status) {
 		setOutput();
 		set(status);
 	}
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 			%% if pue is defined
 		PUE{{port}} &= ~mask;
 			%% endif
 		DDR{{port}} |= mask;
 	}
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		PORT{{port}} |= mask;
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) { set(); }
 		else { reset(); }
 	}
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		PORT{{port}} &= ~mask;
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 			%% if notoggle is defined
 		PORT{{port}} ^= mask;
 			%% else
 		PIN{{port}} = mask;
 			%% endif
 	}
-	ALWAYS_INLINE static bool isSet() {
+	xpcc_always_inline static bool isSet() {
 		return (PORT{{port}} & mask);
 	}
 		%% endif
 		%% if type in ["IO", "Input"]
-	ALWAYS_INLINE static void configure(InputType type) {
+	xpcc_always_inline static void configure(InputType type) {
 		if (type == InputType::PullUp) {
 			%% if pue is defined
 			PUE{{port}} |= mask;
@@ -204,15 +204,15 @@ public:
 			%% endif
 		}
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput(InputType type) {
 		setInput();
 		configure(type);
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		DDR{{port}} &= ~mask;
 	}
-	ALWAYS_INLINE static bool read() {
+	xpcc_always_inline static bool read() {
 		return (PIN{{port}} & mask);
 	}
 			%% if 'extint' in gpio
@@ -220,7 +220,7 @@ public:
 				%% if eicra is not defined
 					%% set eicra = 'EICRA'
 				%% endif
-	ALWAYS_INLINE static void setInputTrigger(InputTrigger trigger) {
+	xpcc_always_inline static void setInputTrigger(InputTrigger trigger) {
 				%% if af_id < 4
 					%% if isc2 is defined and af_id == 2
 		{{isc2}} = ({{isc2}} & ~(1 << ISC2)) | ((i(trigger) & 0b01) << ISC2);
@@ -231,16 +231,16 @@ public:
 		EICRB = (EICRB & ~(0b11 << 2*{{af_id - 4}})) | (i(trigger) << 2*{{af_id - 4}});
 				%% endif
 	}
-	ALWAYS_INLINE static void enableExternalInterrupt() {
+	xpcc_always_inline static void enableExternalInterrupt() {
 		EIMSK |= (1 << INT{{af_id}});
 	}
-	ALWAYS_INLINE static void disableExternalInterrupt() {
+	xpcc_always_inline static void disableExternalInterrupt() {
 		EIMSK &= ~(1 << INT{{af_id}});
 	}
-	ALWAYS_INLINE static bool getExternalInterruptFlag() {
+	xpcc_always_inline static bool getExternalInterruptFlag() {
 		return (EIFR & (1 << INTF{{af_id}}));
 	}
-	ALWAYS_INLINE static void acknowledgeExternalInterruptFlag() {
+	xpcc_always_inline static void acknowledgeExternalInterruptFlag() {
 		EIFR |= (1 << INTF{{af_id}});
 	}
 			%% endif
@@ -257,30 +257,30 @@ public:
 						%% set af_reg = ""
 					%% endif
 				%% endif
-	ALWAYS_INLINE static void enablePCInterrupt() {
+	xpcc_always_inline static void enablePCInterrupt() {
 		PCMSK{{af_reg}} |= (1 << PCINT{{af_id}});
 		PCICR |= (1 << PCIE{{af_reg}});
 	}
-	ALWAYS_INLINE static void disablePCInterrupt() {
+	xpcc_always_inline static void disablePCInterrupt() {
 		PCMSK{{af_reg}} &= ~(1 << PCINT{{af_id}});
 		if (!PCMSK{{af_reg}}) {
 			PCICR &= ~(1 << PCIE{{af_reg}});
 		}
 	}
-	ALWAYS_INLINE static bool readPCInterruptFlag() {
+	xpcc_always_inline static bool readPCInterruptFlag() {
 		return (PCIFR & (1 << PCIF{{af_reg}}));
 	}
-	ALWAYS_INLINE static void acknowledgePCInterruptFlag() {
+	xpcc_always_inline static void acknowledgePCInterruptFlag() {
 		PCIFR |= (1 << PCIF{{af_reg}});
 	}
 			%% endif
 		%% endif
 		%% if type in ["IO"]
-	ALWAYS_INLINE static Direction getDirection() {
+	xpcc_always_inline static Direction getDirection() {
 		return (DDR{{port}} & mask) ? Direction::Out : Direction::In;
 	}
 		%% endif
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disconnect() {
 		%% if type == "Output"
 		DDR{{port}} &= ~mask;   // manual call to setInput()
@@ -318,7 +318,7 @@ public:
 			%% for peripheral in   ['SoftwareSpiMasterMosi',
 									'SoftwareSpiMasterSck']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		setOutput();
 	}
@@ -327,7 +327,7 @@ public:
 		%% if type in ['IO', 'Input']
 			%% for peripheral in ['SoftwareSpiMasterMiso']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		setInput();
 	}
@@ -400,10 +400,10 @@ class GpioPortBase<Gpio::Port::{{port.name}}, StartPin, Width, PortOrder> : publ
 	static constexpr uint8_t portMask = dataMask << StartPin;
 
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		DDR{{port.name}} |= portMask;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		DDR{{port.name}} &= ~portMask;
 	}
 	inline static uint8_t read() {
@@ -414,7 +414,7 @@ public:
 		data <<= StartPin;
 		PORT{{port.name}} = (PORT{{port.name}} & ~portMask) | (data & portMask);
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 	%% if notoggle is defined
 		PORT{{port.name}} ^= portMask;
 	%% else
@@ -440,10 +440,10 @@ class GpioPortBase<Gpio::Port::{{port.name}}, StartPin, Width, ::xpcc::GpioPort:
 	static constexpr uint8_t portMask = dataMask << StartPin;
 
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		DDR{{port.name}} |= portMask;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		DDR{{port.name}} &= ~portMask;
 	}
 	inline static uint8_t read() {
@@ -454,7 +454,7 @@ public:
 		data = xpcc::bitReverse(uint8_t(data << StartPinReversed));
 		PORT{{port.name}} = (PORT{{port.name}} & ~portMask) | (data & portMask);
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 	%% if notoggle is defined
 		PORT{{port.name}} ^= portMask;
 	%% else
@@ -470,19 +470,19 @@ public:
 	static constexpr uint8_t width = 8;
 
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		DDR{{port.name}} = 0xff;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		DDR{{port.name}} = 0;
 	}
-	ALWAYS_INLINE static uint8_t read() {
+	xpcc_always_inline static uint8_t read() {
 		return PIN{{port.name}};
 	}
-	ALWAYS_INLINE static void write(uint8_t data) {
+	xpcc_always_inline static void write(uint8_t data) {
 		PORT{{port.name}} = data;
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 		%% if notoggle is defined
 		PORT{{port.name}} ^= 0xff;
 		%% else
@@ -498,19 +498,19 @@ public:
 	static constexpr uint8_t width = 8;
 
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		DDR{{port.name}} = 0xff;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		DDR{{port.name}} = 0;
 	}
-	ALWAYS_INLINE static uint8_t read() {
+	xpcc_always_inline static uint8_t read() {
 		return xpcc::bitReverse(uint8_t(PIN{{port.name}}));
 	}
-	ALWAYS_INLINE static void write(uint8_t data) {
+	xpcc_always_inline static void write(uint8_t data) {
 		PORT{{port.name}} = xpcc::bitReverse(data);
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 		%% if notoggle is defined
 		PORT{{port.name}} ^= 0xff;
 		%% else

--- a/src/xpcc/architecture/platform/driver/gpio/generic/gpio.hpp
+++ b/src/xpcc/architecture/platform/driver/gpio/generic/gpio.hpp
@@ -51,43 +51,43 @@ namespace xpcc
 class GpioUnused : GpioIO
 {
 public:
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput()
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(bool)
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput()
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set()
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set(bool)
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	reset()
 	{
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	toggle()
 	{
 	}
 
 	/// Always returns `false`
-	ALWAYS_INLINE static bool
+	xpcc_always_inline static bool
 	read()
 	{
 		return false;
@@ -118,37 +118,37 @@ template < class Pin >
 class GpioInverted : public Pin
 {
 public:
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput()
 	{
 		Pin::setOutput();
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(bool value)
 	{
 		Pin::setOutput(!value);
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set()
 	{
 		Pin::reset();
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set(bool value)
 	{
 		Pin::set(!value);
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	reset()
 	{
 		Pin::set();
 	}
 
-	ALWAYS_INLINE static bool
+	xpcc_always_inline static bool
 	read()
 	{
 		return !Pin::read();

--- a/src/xpcc/architecture/platform/driver/gpio/lpc/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/lpc/gpio.hpp.in
@@ -70,30 +70,30 @@ class GpioOpenDrain : Gpio
 {
 public:
 	/// calls set
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		IO::set();
 	}
 	/// calls reset
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		IO::reset();
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) { set(); }
 		else { reset(); }
 	}
-	ALWAYS_INLINE static bool read() {
+	xpcc_always_inline static bool read() {
 		bool lastOutput = IO::read();
 		IO::setInput();
 		bool read = IO::read();
 		IO::setOutput(lastOutput);
 		return read;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::SoftwareI2cMasterSda) {
 		IO::setOutput();
 		IO::set();
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::SoftwareI2cMasterScl) {
 		IO::setOutput();
 		IO::set();
@@ -136,7 +136,7 @@ public:
 	};
 
 	/// change the function of the pin
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	selectFunction(Function f){
 		uint32_t temp;
 		temp = {{ conf_reg }} & ~(7<<0);	// FUNC REG is 3 bits wide
@@ -146,7 +146,7 @@ public:
 
 public:
 		%% if "i2c_mode" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(I2cMode mode) {
 		uint32_t temp;
 		temp = {{ conf_reg }} & ~(3<<8);
@@ -158,7 +158,7 @@ public:
 		%% if type == "" or type == "Output"
 
 			%% if "od" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(OutputType type) {
 		if(type == OutputType::PushPull) {
 			{{ conf_reg }} &= ~static_cast<uint32_t>(OutputType::OpenDrain);
@@ -168,7 +168,7 @@ public:
 	}
 			%% endif
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput() {
 			%% if "admode" in bits
 		{{ conf_reg }} |= IOCON_ADMODE_DIGITAL;	// configure as digital pin
@@ -177,14 +177,14 @@ public:
 		{{ gpio_reg }}->DIR |= (1 << {{ pin}});
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(bool status) {
 		setOutput();
 		set(status);
 	}
 
 			%% if "od" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(OutputType type) {
 		configure(type);
 		setOutput();
@@ -192,30 +192,30 @@ public:
 			%% endif
 
 			%% if "i2c_mode" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(I2cMode type) {
 		configure(type);
 		setOutput();
 	}
 			%% endif
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set() {
 		{{ gpio_reg }}->MASKED_ACCESS[1 << {{ pin }}] = (1 << {{pin}});
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	set(bool status) {
 		if (status) { set(); }
 		else { reset(); }
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	reset() {
 		{{ gpio_reg }}->MASKED_ACCESS[1 << {{ pin }}] = 0;
 	}
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	toggle() {
 		if (({{ gpio_reg }}->MASKED_ACCESS[1 << {{ pin }}]) >> {{ pin }})
 		{ reset(); } else { set(); }
@@ -224,7 +224,7 @@ public:
 		%% if type == "" or type == "Input"
 
 			%% if "mode" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(InputType type) {
 		uint32_t temp;
 		temp = {{ conf_reg }} & ~static_cast<uint32_t>(InputType::Repeater);
@@ -234,7 +234,7 @@ public:
 			%% endif
 
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput() {
 			%% if "admode" in bits
 		{{ conf_reg }} |= IOCON_ADMODE_DIGITAL;	// configure as digital pin
@@ -243,13 +243,13 @@ public:
 		{{ gpio_reg }}->DIR &= ~(1 << {{ pin}});
 	}
 
-	ALWAYS_INLINE static bool
+	xpcc_always_inline static bool
 	read() {
 		return ({{ gpio_reg }}->MASKED_ACCESS[1 << {{ pin }}]) >> {{ pin }};
 	}
 
 			%% if "mode" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput(InputType type) {
 		configure(type);
 		setInput();
@@ -257,7 +257,7 @@ public:
 			%% endif
 
 			%% if "i2c_mode" in bits
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput(I2cMode type) {
 		configure(type);
 		setInput();
@@ -271,7 +271,7 @@ public:
 			%% for peripheral in   ['SoftwareSpiMasterMosi',
 									'SoftwareSpiMasterSck']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 				%% if "mode" in bits
 		configure(OutputType::PushPull);
@@ -286,7 +286,7 @@ public:
 		%% if type in ['', 'Input']
 			%% for peripheral in ['SoftwareSpiMasterMiso']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 				%% if "mode" in bits
 		configure(InputType::Floating);

--- a/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
@@ -208,7 +208,7 @@ private:
 	%% endif
 %% endif
 
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setAlternateFunction(AlternateFunction alt) {
 		{{reg}}->AFR[af_id] = ({{reg}}->AFR[af_id] & ~af_mask)
 								| (i(alt) << af_offset);
@@ -217,19 +217,19 @@ private:
 	}
 
 	/// Enable Analog Mode which is needed to use this pin as an ADC input.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setAnalogInput() {
 		{{reg}}->MODER |= i(Mode::Analog) << (pin * 2);
 	}
 
 public:
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(OutputType type,
 			  OutputSpeed speed = OutputSpeed::MHz50) {
 		{{reg}}->OTYPER  = ({{reg}}->OTYPER  & ~mask)  | (i(type) << pin);
 		{{reg}}->OSPEEDR = ({{reg}}->OSPEEDR & ~mask2) | (i(speed) << (pin * 2));
 	}
-	ALWAYS_INLINE static void configure(InputType type) {
+	xpcc_always_inline static void configure(InputType type) {
 		{{reg}}->PUPDR   = ({{reg}}->PUPDR   & ~mask2) | (i(type)  << (pin * 2));
 	}
 		%% for af in gpio.afs
@@ -242,38 +242,38 @@ public:
 		%% if type in ["" , "Output"]
 	// GpioOutput
 	// start documentation inherited
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		{{reg}}->MODER   = ({{reg}}->MODER   & ~mask2) | (i(Mode::Output)<< pin * 2);
 	}
-	ALWAYS_INLINE static void setOutput(bool status) {
+	xpcc_always_inline static void setOutput(bool status) {
 		set(status);
 		setOutput();
 	}
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		{{reg}}->BSRR = mask;
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) {
 			set();
 		} else {
 			reset();
 		}
 	}
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		{{reg}}->BSRR = (uint32_t(mask) << 16);
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 		if (isSet()) {
 			reset();
 		} else {
 			set();
 		}
 	}
-	ALWAYS_INLINE static bool isSet() {
+	xpcc_always_inline static bool isSet() {
 		return ({{reg}}->ODR & mask);
 	}
 	// stop documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(OutputType type,
 			  OutputSpeed speed = OutputSpeed::MHz50) {
 		configure(type, speed);
@@ -290,16 +290,16 @@ public:
 		{{reg}}->OTYPER  &= ~mask;
 		{{reg}}->OSPEEDR &= ~mask2;
 	}
-	ALWAYS_INLINE static bool read() {
+	xpcc_always_inline static bool read() {
 		return ({{reg}}->IDR & mask);
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void setInput(InputType type) {
+	xpcc_always_inline static void setInput(InputType type) {
 		configure(type);
 		setInput();
 	}
 	// External Interrupts
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	enableExternalInterrupt()
 	{
 		// PA[x], x =  0 ..  3 maps to EXTICR[0]
@@ -317,18 +317,18 @@ public:
 		SYSCFG->EXTICR[index] = (SYSCFG->EXTICR[index] & ~syscfg_mask) | syscfg_value;
 		EXTI->IMR |= mask;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disableExternalInterrupt()
 	{
 		EXTI->IMR &= ~mask;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	enableExternalInterruptVector(const uint32_t priority)
 	{
 		NVIC_SetPriority(ExternalInterruptIRQ, priority);
 		NVIC_EnableIRQ(ExternalInterruptIRQ);
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disableExternalInterruptVector()
 	{
 		NVIC_DisableIRQ(ExternalInterruptIRQ);
@@ -352,13 +352,13 @@ public:
 			break;
 		}
 	}
-	ALWAYS_INLINE static bool
+	xpcc_always_inline static bool
 	getExternalInterruptFlag()
 	{
 		return (EXTI->PR & mask);
 	}
 	/**	\brief	Reset the interrupt flag in the interrupt routine. */
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	acknowledgeExternalInterruptFlag()
 	{
 		// Flags are cleared by writing a one to the flag position.
@@ -376,7 +376,7 @@ public:
 		return Direction::Special;
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disconnect() {
 		%% if type == "Output"
 		{{reg}}->MODER &= ~mask2;
@@ -396,7 +396,7 @@ public:
 			%% if use
 				%% if af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */) {
 					%% if af.type == "analog"
 		setAnalogInput();
@@ -407,7 +407,7 @@ public:
 				%% endif
 				%% if af.type|string in ['', 'out'] and type != "Input" and af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */,
 		OutputType type, OutputSpeed speed = OutputSpeed::MHz50) {
 		configure(type, speed);
@@ -428,7 +428,7 @@ public:
 				%% endif
 				%% if af.type|string in ['', 'in'] and type != "Output" and af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */, InputType type) {
 		configure(type);
 		setAlternateFunction(AlternateFunction::AF_{{ af.id }});
@@ -467,7 +467,7 @@ public:
 		%% if type in ['', 'Input']
 			%% for peripheral in ['SoftwareSpiMasterMiso']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		configure(InputType::Floating);
 		setInput();
@@ -546,10 +546,10 @@ class GpioPortBase<Gpio::Port::{{port.name}}, StartPin, Width, PortOrder> : publ
 	static constexpr uint32_t port10 = 0xAAAAAAAA & portMask2;
 
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		GPIO{{port.name}}->MODER = (GPIO{{port.name}}->MODER & ~portMask2) | port01;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		GPIO{{port.name}}->MODER &= ~portMask2;
 	}
 	inline static void

--- a/src/xpcc/architecture/platform/driver/gpio/stm32f1/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32f1/gpio.hpp.in
@@ -138,18 +138,18 @@ private:
 %% endif
 
 	/// Enable Analog Mode which is needed to use this pin as an ADC input.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setAnalogInput() {
 		{{reg}}->{{cr}} &= ~mask4;
 	}
 
 public:
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(OutputType type,
 			  OutputSpeed speed = OutputSpeed::MHz50) {
 		{{reg}}->{{cr}}  = ({{reg}}->{{cr}}  & ~mask4)  | ((i(type) | i(speed)) << (cr_pin * 4));
 	}
-	ALWAYS_INLINE static void configure(InputType type) {
+	xpcc_always_inline static void configure(InputType type) {
 		{{reg}}->{{cr}}  = ({{reg}}->{{cr}}  & ~mask4)  | ((i(type) & 0xc) << (cr_pin * 4));
 		if (type == InputType::PullUp) {{reg}}->BSRR = mask;
 		else {{reg}}->BRR = mask;
@@ -164,38 +164,38 @@ public:
 		%% if type in ["" , "Output"]
 	// GpioOutput
 	// start documentation inherited
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		configure(OutputType::PushPull);
 	}
-	ALWAYS_INLINE static void setOutput(bool status) {
+	xpcc_always_inline static void setOutput(bool status) {
 		set(status);
 		setOutput();
 	}
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		{{reg}}->BSRR = mask;
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) {
 			set();
 		} else {
 			reset();
 		}
 	}
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		{{reg}}->BRR = mask;
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 		if (isSet()) {
 			reset();
 		} else {
 			set();
 		}
 	}
-	ALWAYS_INLINE static bool isSet() {
+	xpcc_always_inline static bool isSet() {
 		return ({{reg}}->ODR & mask);
 	}
 	// stop documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setOutput(OutputType type,
 			  OutputSpeed speed = OutputSpeed::MHz50) {
 		configure(type, speed);
@@ -205,19 +205,19 @@ public:
 		%% if type in ["", "Input"]
 	// GpioInput
 	// start documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput() {
 		configure(InputType::Floating);
 	}
-	ALWAYS_INLINE static bool read() {
+	xpcc_always_inline static bool read() {
 		return ({{reg}}->IDR & mask);
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void setInput(InputType type) {
+	xpcc_always_inline static void setInput(InputType type) {
 		configure(type);
 	}
 	// External Interrupts
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	enableExternalInterrupt()
 	{
 		// PA[x], x =  0 ..  3 maps to EXTICR[0]
@@ -235,18 +235,18 @@ public:
 		AFIO->EXTICR[index] = (AFIO->EXTICR[index] & ~syscfg_mask) | syscfg_value;
 		EXTI->IMR |= mask;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disableExternalInterrupt()
 	{
 		EXTI->IMR &= ~mask;
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	enableExternalInterruptVector(const uint32_t priority)
 	{
 		NVIC_SetPriority(ExternalInterruptIRQ, priority);
 		NVIC_EnableIRQ(ExternalInterruptIRQ);
 	}
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disableExternalInterruptVector()
 	{
 		NVIC_DisableIRQ(ExternalInterruptIRQ);
@@ -270,12 +270,12 @@ public:
 			break;
 		}
 	}
-	ALWAYS_INLINE static bool
+	xpcc_always_inline static bool
 	getExternalInterruptFlag() {
 		return (EXTI->PR & mask);
 	}
 	/**	\brief	Reset the interrupt flag in the interrupt routine. */
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	acknowledgeExternalInterruptFlag()
 	{
 		// Flags are cleared by writing a one to the flag position.
@@ -293,7 +293,7 @@ public:
 		return Direction::In;
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	disconnect() {
 		{{reg}}->{{cr}} = ({{reg}}->{{cr}}  & ~mask4)  | ((i(InputType::Floating)) << (cr_pin * 4));
 		{{reg}}->BRR = mask;
@@ -316,7 +316,7 @@ public:
 			%% if use
 				%% if af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */) {
 					%% if af.type == "analog"
 		setAnalogInput();
@@ -332,7 +332,7 @@ public:
 				%% endif
 				%% if af.type|string in ['', 'out'] and type != "Input" and af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */,
 		OutputType type, OutputSpeed speed = OutputSpeed::MHz50) {
 		configure(OutputType(i(type) | 0x8), speed);
@@ -352,7 +352,7 @@ public:
 				%% endif
 				%% if af.type|string in ['', 'in'] and type != "Output" and af.name not in ['Scl', 'Sda']
 	/// Connect {{name}} as {{af.name}} to {{af.peripheral}}.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }} /* t */, InputType type) {
 		configure(type);
 		{{ enableAlternateFunction }}
@@ -365,7 +365,7 @@ public:
 			%% for peripheral in   ['SoftwareSpiMasterMosi',
 									'SoftwareSpiMasterSck']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		set();
 		configure(OutputType::PushPull);
@@ -389,7 +389,7 @@ public:
 		%% if type in ['', 'Input']
 			%% for peripheral in ['SoftwareSpiMasterMiso']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		configure(InputType::Floating);
 	}

--- a/src/xpcc/architecture/platform/driver/gpio/xmega/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/xmega/gpio.hpp.in
@@ -118,45 +118,45 @@ public:
 		Mult4X = PORTCFG_CLKOUTSEL_CLK4X_gc,
 	};
 
-	ALWAYS_INLINE static void setVirtualPort0(Port port) {
+	xpcc_always_inline static void setVirtualPort0(Port port) {
 		PORTCFG_VPCTRLA = (PORTCFG_VPCTRLA & ~PORTCFG_VP0MAP_gm) | (static_cast<uint8_t>(port) & PORTCFG_VP0MAP_gm);
 	}
-	ALWAYS_INLINE static void setVirtualPort1(Port port) {
+	xpcc_always_inline static void setVirtualPort1(Port port) {
 		PORTCFG_VPCTRLA = (PORTCFG_VPCTRLA & ~PORTCFG_VP1MAP_gm) | (static_cast<uint8_t>(port) & PORTCFG_VP1MAP_gm);
 	}
-	ALWAYS_INLINE static void setVirtualPort2(Port port) {
+	xpcc_always_inline static void setVirtualPort2(Port port) {
 		PORTCFG_VPCTRLB = (PORTCFG_VPCTRLB & ~PORTCFG_VP2MAP_gm) | (static_cast<uint8_t>(port) & PORTCFG_VP2MAP_gm);
 	}
-	ALWAYS_INLINE static void setVirtualPort3(Port port) {
+	xpcc_always_inline static void setVirtualPort3(Port port) {
 		PORTCFG_VPCTRLB = (PORTCFG_VPCTRLB & ~PORTCFG_VP3MAP_gm) | (static_cast<uint8_t>(port) & PORTCFG_VP3MAP_gm);
 	}
 	
 	/// enables RTC output on `GpioC6`
-	ALWAYS_INLINE static void enableRTC_Output() {
+	xpcc_always_inline static void enableRTC_Output() {
 		PORTCFG_CLKEVOUT |= PORTCFG_RTCOUT_bm;
 	}
 	/// disables RTC output on `GpioC6`
-	ALWAYS_INLINE static void disableRTC_Output() {
+	xpcc_always_inline static void disableRTC_Output() {
 		PORTCFG_CLKEVOUT &= ~PORTCFG_RTCOUT_bm;
 	}
 	
 	/// @warning some Xmegas output only channel 7 regardless of selection
-	ALWAYS_INLINE static void enableEventChannelOutput(Output output, uint8_t channel) {
+	xpcc_always_inline static void enableEventChannelOutput(Output output, uint8_t channel) {
 		PORTCFG_CLKEVOUT = (PORTCFG_CLKEVOUT & ~(PORTCFG_CLKEVPIN_bm | PORTCFG_EVOUT_gm)) |
 				(i(output) & (PORTCFG_CLKEVPIN_bm | PORTCFG_EVOUT_gm));
 		PORTCFG_EVOUTSEL = (PORTCFG_EVOUTSEL & ~PORTCFG_EVOUTSEL_gm) | (channel & PORTCFG_EVOUTSEL_gm);
 	}
-	ALWAYS_INLINE static void disableEventChannelOutput() {
+	xpcc_always_inline static void disableEventChannelOutput() {
 		PORTCFG_CLKEVOUT &= ~PORTCFG_EVOUT_gm;
 	}
 	
 	/// @warning this overrides the output of `enableEventChannelOutput()`!
-	ALWAYS_INLINE static void enablePeripheralClockOutput(Output output,
+	xpcc_always_inline static void enablePeripheralClockOutput(Output output,
 			ClockMultiplier multiplier = ClockMultiplier::Mult1X) {
 		PORTCFG_CLKEVOUT = (PORTCFG_CLKEVOUT & ~(PORTCFG_CLKEVPIN_bm | PORTCFG_CLKOUT_gm | PORTCFG_CLKOUTSEL_gm)) |
 				(i(output) & (PORTCFG_CLKEVPIN_bm | PORTCFG_CLKOUT_gm)) | i(multiplier);
 	}
-	ALWAYS_INLINE static void enablePeripheralClockOutput() {
+	xpcc_always_inline static void enablePeripheralClockOutput() {
 		PORTCFG_CLKEVOUT &= ~PORTCFG_CLKOUT_gm;
 	}
 	
@@ -191,7 +191,7 @@ private:
 	static constexpr uint16_t interrupt1VectorNumber = PORT{{port}}_INT1_vect_num;
 
 public:
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	configure(Configuration config,
 			  Inverted invert = Inverted::No) {
 		PORT{{port}}_PIN{{pin}}CTRL = (PORT{{port}}_PIN{{pin}}CTRL & ~(PORT_OPC_gm | PORT_INVEN_bm)) |
@@ -200,91 +200,91 @@ public:
 		%% if type in ["", "Output"]
 	// GpioOutput
 	// start documentation inherited
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		PORT{{port}}_DIRSET = mask;
 	}
-	ALWAYS_INLINE static void setOutput(bool value) {
+	xpcc_always_inline static void setOutput(bool value) {
 		set(value);
 		setOutput();
 	}
-	ALWAYS_INLINE static void set() {
+	xpcc_always_inline static void set() {
 		PORT{{port}}_OUTSET = mask;
 	}
-	ALWAYS_INLINE static void set(bool status) {
+	xpcc_always_inline static void set(bool status) {
 		if (status) { set(); }
 		else { reset(); }
 	}
-	ALWAYS_INLINE static void reset() {
+	xpcc_always_inline static void reset() {
 		PORT{{port}}_OUTCLR = mask;
 	}
-	ALWAYS_INLINE static void toggle() {
+	xpcc_always_inline static void toggle() {
 		PORT{{port}}_OUTTGL = mask;
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void setOutput(Configuration config,
+	xpcc_always_inline static void setOutput(Configuration config,
 										Inverted invert = Inverted::No) {
 		configure(config, invert);
 		setOutput();
 	}
-	ALWAYS_INLINE static void enableSlewRateLimit() {
+	xpcc_always_inline static void enableSlewRateLimit() {
 		PORT{{port}}_PIN{{pin}}CTRL |= PORT_SRLEN_bm;
 	}
-	ALWAYS_INLINE static void disableSlewRateLimit() {
+	xpcc_always_inline static void disableSlewRateLimit() {
 		PORT{{port}}_PIN{{pin}}CTRL &= ~PORT_SRLEN_bm;
 	}
 		%% endif
 		%% if type in ["", "Input"]
 	// GpioInput
 	// start documentation inherited
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	setInput() {
 		 PORT{{port}}_DIRCLR = mask; 
 	}
-	ALWAYS_INLINE static bool read() {
+	xpcc_always_inline static bool read() {
 		(void) {{pin}};
 		return (PORT{{port}}_IN & mask);
 	}
 	// end documentation inherited
-	ALWAYS_INLINE static void setInput(Configuration config,
+	xpcc_always_inline static void setInput(Configuration config,
 										Inverted invert = Inverted::No) {
 		setInput();
 		configure(config, invert);
 	}
-	ALWAYS_INLINE static void setInputTrigger(InputTrigger trigger) {
+	xpcc_always_inline static void setInputTrigger(InputTrigger trigger) {
 		PORT{{port}}_PIN{{pin}}CTRL = (PORT{{port}}_PIN{{pin}}CTRL & ~PORT_ISC_gm) | i(trigger);
 	}
-	ALWAYS_INLINE static void enableExternalInterrupt0(InterruptLevel level) {
+	xpcc_always_inline static void enableExternalInterrupt0(InterruptLevel level) {
 		PORT{{port}}_INT0MASK |= mask;
 		PORT{{port}}_INTCTRL = (PORT{{port}}_INTCTRL & ~PORT_INT0LVL_gm) | (::xpcc::xmega::i(level) & PORT_INT0LVL_gm);
 	}
-	ALWAYS_INLINE static void enableExternalInterrupt1(InterruptLevel level) {
+	xpcc_always_inline static void enableExternalInterrupt1(InterruptLevel level) {
 		PORT{{port}}_INT1MASK |= mask;
 		PORT{{port}}_INTCTRL = (PORT{{port}}_INTCTRL & ~PORT_INT1LVL_gm) | ((::xpcc::xmega::i(level) << 2) & PORT_INT1LVL_gm);
 	}
-	ALWAYS_INLINE static void disableExternalInterrupt0() {
+	xpcc_always_inline static void disableExternalInterrupt0() {
 		PORT{{port}}_INT0MASK &= ~mask;
 	}
-	ALWAYS_INLINE static void disableExternalInterrupt1() {
+	xpcc_always_inline static void disableExternalInterrupt1() {
 		PORT{{port}}_INT1MASK &= ~mask;
 	}
-	ALWAYS_INLINE static bool getExternalInterruptFlag0() {
+	xpcc_always_inline static bool getExternalInterruptFlag0() {
 		return (PORT{{port}}_INTFLAGS & PORT_INT0IF_bm);
 	}
-	ALWAYS_INLINE static bool getExternalInterruptFlag1() {
+	xpcc_always_inline static bool getExternalInterruptFlag1() {
 		return (PORT{{port}}_INTFLAGS & PORT_INT1IF_bm);
 	}
-	ALWAYS_INLINE static void acknowledgeExternalInterruptFlag0() {
+	xpcc_always_inline static void acknowledgeExternalInterruptFlag0() {
 		PORT{{port}}_INTFLAGS |= PORT_INT0IF_bm;
 	}
-	ALWAYS_INLINE static void acknowledgeExternalInterruptFlag1() {
+	xpcc_always_inline static void acknowledgeExternalInterruptFlag1() {
 		PORT{{port}}_INTFLAGS |= PORT_INT1IF_bm;
 	}
 			%% if port in ['A', 'B', 'C', 'D', 'E', 'F']
-	ALWAYS_INLINE static void enableInputBuffer() {
+	xpcc_always_inline static void enableInputBuffer() {
 		PORT{{port}}_PIN{{pin}}CTRL &= ~PORT_ISC_gm;
 	}
 	/// disables the input buffer, when using this pin as analog input
-	ALWAYS_INLINE static void disableInputBuffer() {
+	xpcc_always_inline static void disableInputBuffer() {
 		PORT{{port}}_PIN{{pin}}CTRL = (PORT{{port}}_PIN{{pin}}CTRL & ~PORT_ISC_gm) | PORT_ISC_INPUT_DISABLE_gc;
 	}
 			%% endif
@@ -319,7 +319,7 @@ public:
 						%% endif
 					%% endif
 				%% endif
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(TypeId::{{ af.peripheral }}{{ af.name }}) {
 				%% if 'remap' in af
 					%% if af.peripheral.startswith('Spi')
@@ -351,7 +351,7 @@ public:
 			%% for peripheral in   ['SoftwareSpiMasterMosi',
 									'SoftwareSpiMasterSck']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		configure(Configuration::Floating);
 		setOutput();
@@ -361,7 +361,7 @@ public:
 			%% for peripheral in   ['SoftwareI2cMasterSda',
 									'SoftwareI2cMasterScl']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		configure(Configuration::OpenDrain);
 		setOutput();
@@ -372,7 +372,7 @@ public:
 		%% if type in ['', 'Input']
 			%% for peripheral in ['SoftwareSpiMasterMiso']
 	/// Connect to `{{peripheral}}`.
-	ALWAYS_INLINE static void
+	xpcc_always_inline static void
 	connect(::xpcc::TypeId::{{ peripheral }}) {
 		configure(Configuration::Floating);
 		setInput();
@@ -403,22 +403,22 @@ public:
 	static constexpr uint8_t width = WIDTH;
 	
 public:
-	ALWAYS_INLINE static void setOutput() {
+	xpcc_always_inline static void setOutput() {
 		PORT{{port.name}}_DIRSET |= portMask;
 	}
-	ALWAYS_INLINE static void setInput() {
+	xpcc_always_inline static void setInput() {
 		PORT{{port.name}}_DIRCLR |= portMask;
 	}
-	ALWAYS_INLINE static void configure(Configuration config,
+	xpcc_always_inline static void configure(Configuration config,
 										Inverted invert = Inverted::No) {
 		PORTCFG_MPCMASK = portMask;
 		*(&PORT{{port.name}}_PIN0CTRL + START_PIN) = i(config) | ((invert == Inverted::Yes) ? PORT_INVEN_bm : 0);
 	}
-	ALWAYS_INLINE static uint8_t read() {
+	xpcc_always_inline static uint8_t read() {
 		uint8_t data = PORT{{port.name}}_IN & portMask;
 		return (data >> START_PIN);
 	}
-	ALWAYS_INLINE static void write(uint8_t data) {
+	xpcc_always_inline static void write(uint8_t data) {
 		data <<= START_PIN;
 		PORT{{port.name}}_OUTCLR |= portMask;
 		PORT{{port.name}}_OUTSET |= (data & portMask);

--- a/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.hpp.in
@@ -38,7 +38,7 @@ public:
 
 	template< class SystemClock, uint32_t baudrate=Baudrate::Standard,
 			uint16_t tolerance = xpcc::Tolerance::FivePercent >
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		// Prescalers: 1, 4, 16, 64

--- a/src/xpcc/architecture/platform/driver/i2c/generic/i2c_master.hpp
+++ b/src/xpcc/architecture/platform/driver/i2c/generic/i2c_master.hpp
@@ -55,7 +55,7 @@ public:
 	static bool
 	start(I2cTransaction *transaction, ConfigurationHandler handler = nullptr);
 
-	static Error ALWAYS_INLINE
+	static Error xpcc_always_inline
 	getErrorState()
 	{ return errorState; }
 
@@ -110,13 +110,13 @@ private:
 
 	// timings
 	/// busy waits a **half** clock cycle
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	delay2()
 	{ xpcc::delayNanoseconds(delayTime*2); }
 
 	// timings
 	/// busy waits **quarter** clock cycle
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	delay4()
 	{ xpcc::delayNanoseconds(delayTime); }
 

--- a/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.hpp.in
@@ -50,7 +50,7 @@ public:
 	 */
 	template<class SystemClock, uint32_t baudrate=Baudrate::Standard,
 			uint16_t tolerance = xpcc::Tolerance::FivePercent >
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		// calculate the expected clock ratio

--- a/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.cpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.cpp.in
@@ -36,28 +36,28 @@ namespace
 	static xpcc::I2cMaster::Error errorState(xpcc::I2cMaster::Error::NoError);
 	
 	// helper functions
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initializeWrite(xpcc::I2cDelegate::Writing w) {
 		writePointer = w.buffer;
 		writeBytesLeft = w.size;
 		nextOperation = static_cast<xpcc::I2c::Operation>(w.next);
 	}
 	
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initializeRead(xpcc::I2cDelegate::Reading r) {
 		readPointer = r.buffer;
 		readBytesLeft = r.size;
 		nextOperation = static_cast<xpcc::I2c::Operation>(r.next);
 	}
 	
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initializeStopAfterAddress() {
 		//writePointer = ..;
 		writeBytesLeft = 0;
 		nextOperation = xpcc::I2c::Operation::Stop;
 	}
 	
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initializeRestartAfterAddress() {
 		//writePointer = ..;
 		writeBytesLeft = 0;

--- a/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.hpp.in
@@ -44,7 +44,7 @@ public:
 	 */
 	template<class SystemClock, uint32_t baudrate=DataRate::Standard
 			uint16_t tolerance = xpcc::Tolerance::FivePercent >
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		static_assert(baudrate <= 400000, "The Xmega does not support I2C baudrates above 400kHz.");

--- a/src/xpcc/architecture/platform/driver/spi/generic/spi_master_impl.hpp
+++ b/src/xpcc/architecture/platform/driver/spi/generic/spi_master_impl.hpp
@@ -186,7 +186,7 @@ xpcc::SoftwareSpiMaster<SCK, MOSI, MISO>::transfer(
 // ----------------------------------------------------------------------------
 
 template <typename SCK, typename MOSI, typename MISO>
-void ALWAYS_INLINE
+void xpcc_always_inline
 xpcc::SoftwareSpiMaster<SCK, MOSI, MISO>::delay()
 {
 	xpcc::delayNanoseconds(delayTime);

--- a/src/xpcc/architecture/platform/driver/spi/lpc/spi.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/lpc/spi.hpp.in
@@ -251,7 +251,7 @@ namespace xpcc
 			static bool
 			transfer(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			transferSync(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
 			static bool

--- a/src/xpcc/architecture/platform/driver/spi/lpc/spi_0.hpp
+++ b/src/xpcc/architecture/platform/driver/spi/lpc/spi_0.hpp
@@ -247,7 +247,7 @@ namespace xpcc
 			static bool
 			transfer(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			transferSync(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
 			static bool

--- a/src/xpcc/architecture/platform/driver/spi/lpc/spi_1.hpp
+++ b/src/xpcc/architecture/platform/driver/spi/lpc/spi_1.hpp
@@ -245,7 +245,7 @@ namespace xpcc
 			static bool
 			transfer(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			transferSync(TransferOptions options=TRANSFER_SEND_BUFFER_SAVE_RECEIVE);
 			
 			static bool

--- a/src/xpcc/architecture/platform/driver/spi/stm32/spi_base.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/stm32/spi_base.hpp.in
@@ -43,6 +43,7 @@ public:
 		TxBufferEmpty		= SPI_CR2_TXEIE,
 		Error				= SPI_CR2_ERRIE,
 	};
+	XPCC_FLAGS32(Interrupt);
 
 	enum class
 	InterruptFlag : uint32_t
@@ -61,6 +62,7 @@ public:
 		FifoTxLevel			= SPI_SR_FTLVL,
 %% endif
 	};
+	XPCC_FLAGS32(InterruptFlag);
 
 	enum class
 	MasterSelection : uint32_t
@@ -128,11 +130,6 @@ public:
 	};
 
 };
-
-/// @cond
-ENUM_CLASS_FLAG(SpiBase::Interrupt)
-ENUM_CLASS_FLAG(SpiBase::InterruptFlag)
-/// @endcond
 
 } // namespace stm32
 

--- a/src/xpcc/architecture/platform/driver/spi/stm32/spi_hal.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/stm32/spi_hal.hpp.in
@@ -116,12 +116,12 @@ public:
 	enableInterruptVector(bool enable, uint32_t priority);
 
 	static void
-	enableInterrupt(Interrupt interrupt);
+	enableInterrupt(Interrupt_t interrupt);
 
 	static void
-	disableInterrupt(Interrupt interrupt);
+	disableInterrupt(Interrupt_t interrupt);
 
-	static InterruptFlag
+	static InterruptFlag_t
 	getInterruptFlags();
 
 	/**
@@ -130,7 +130,7 @@ public:
 	 * @warning 	Not all InterruptFlags can be cleared this way.
 	 */
 	static void
-	acknowledgeInterruptFlag(InterruptFlag flags);
+	acknowledgeInterruptFlag(InterruptFlag_t flags);
 };
 
 } // namespace stm32

--- a/src/xpcc/architecture/platform/driver/spi/stm32/spi_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/stm32/spi_hal_impl.hpp.in
@@ -164,26 +164,26 @@ xpcc::stm32::SpiHal{{ id }}::enableInterruptVector(bool enable, uint32_t priorit
 }
 
 void inline
-xpcc::stm32::SpiHal{{ id }}::enableInterrupt(Interrupt interrupt)
+xpcc::stm32::SpiHal{{ id }}::enableInterrupt(Interrupt_t interrupt)
 {
-	SPI{{ id }}->CR2 |= static_cast<uint32_t>(interrupt);
+	SPI{{ id }}->CR2 |= interrupt.value;
 }
 
 void inline
-xpcc::stm32::SpiHal{{ id }}::disableInterrupt(Interrupt interrupt)
+xpcc::stm32::SpiHal{{ id }}::disableInterrupt(Interrupt_t interrupt)
 {
-	SPI{{ id }}->CR2 &= ~static_cast<uint32_t>(interrupt);
+	SPI{{ id }}->CR2 &= ~interrupt.value;
 }
 
-xpcc::stm32::SpiHal{{ id }}::InterruptFlag inline
+xpcc::stm32::SpiHal{{ id }}::InterruptFlag_t inline
 xpcc::stm32::SpiHal{{ id }}::getInterruptFlags()
 {
-	return static_cast<InterruptFlag>(SPI{{ id }}->SR );
+	return InterruptFlag_t(SPI{{ id }}->SR);
 }
 
 void inline
-xpcc::stm32::SpiHal{{ id }}::acknowledgeInterruptFlag(InterruptFlag /*flags*/)
+xpcc::stm32::SpiHal{{ id }}::acknowledgeInterruptFlag(InterruptFlag_t /*flags*/)
 {
 	// TODO: implement; see STM32F3 reference manual p. 736
-	// SPI{{ id }}->SR =  static_cast<InterruptFlag>(flags);
+	// SPI{{ id }}->SR = flags.value;
 }

--- a/src/xpcc/architecture/platform/driver/spi/stm32/spi_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/spi/stm32/spi_master.hpp.in
@@ -103,13 +103,13 @@ public:
 	}
 
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setDataMode(DataMode mode)
 	{
 		SpiHal{{ id }}::setDataMode(static_cast<SpiHal{{ id }}::DataMode>(mode));
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	setDataOrder(DataOrder order)
 	{
 		SpiHal{{ id }}::setDataOrder(static_cast<SpiHal{{ id }}::DataOrder>(order));

--- a/src/xpcc/architecture/platform/driver/timer/lpc/timer.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/lpc/timer.hpp.in
@@ -97,12 +97,12 @@ namespace xpcc
 				{{reg}}->TCR = TCR_CRst;
 			}
 
-			static ALWAYS_INLINE Value
+			static xpcc_always_inline Value
 			getValue() {
 				return {{reg}}->TC;
 			}
 
-			static ALWAYS_INLINE void
+			static xpcc_always_inline void
 			setValue(uint16_t value) {
 				{{reg}}->TC = value;
 			}

--- a/src/xpcc/architecture/platform/driver/timer/stm32/advanced.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/advanced.cpp.in
@@ -232,13 +232,13 @@ uint32_t modeOutputPorts)
 // Re-implemented here to save some code space. As all arguments in the calls
 // below are constant the compiler is able to calculate everything at
 // compile time.
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicEnableInterrupt(IRQn_Type IRQn)
 {
 	NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
 }
 
-static ALWAYS_INLINE void
+static xpcc_always_inline void
 nvicDisableInterrupt(IRQn_Type IRQn)
 {
 	NVIC_DisableIRQ(IRQn);

--- a/src/xpcc/architecture/platform/driver/timer/stm32/basic.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/basic.hpp.in
@@ -142,29 +142,29 @@ public:
 	enableInterruptVector(bool enable, uint32_t priority);
 
 	static inline void
-	enableInterrupt(Interrupt interrupt)
+	enableInterrupt(Interrupt_t interrupt)
 	{
-		TIM{{ id }}->DIER |= static_cast<uint32_t>(interrupt);
+		TIM{{ id }}->DIER |= interrupt.value;
 	}
 
 	static inline void
-	disableInterrupt(Interrupt interrupt)
+	disableInterrupt(Interrupt_t interrupt)
 	{
-		TIM{{ id }}->DIER &= ~static_cast<uint32_t>(interrupt);
+		TIM{{ id }}->DIER &= ~interrupt.value;
 	}
 
-	static inline InterruptFlag
+	static inline InterruptFlag_t
 	getInterruptFlags()
 	{
-		return static_cast<InterruptFlag>(TIM{{ id }}->SR);
+		return InterruptFlag_t(TIM{{ id }}->SR);
 	}
 
 	static void
-	acknowledgeInterruptFlags(InterruptFlag interrupt)
+	acknowledgeInterruptFlags(InterruptFlag_t interrupt)
 	{
 		// Flags are cleared by writing a zero to the flag position.
 		// Writing a one is ignored.
-		TIM{{ id }}->SR = ~static_cast<uint32_t>(interrupt);
+		TIM{{ id }}->SR = ~interrupt.value;
 	}
 };
 

--- a/src/xpcc/architecture/platform/driver/timer/stm32/basic_base.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/basic_base.hpp.in
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include "../../../device.hpp"
+#include <xpcc/architecture/interface/register.hpp>
 
 /**
  * @ingroup 	{{target.string}}
@@ -37,11 +38,13 @@ public:
 	{
 		Update = TIM_DIER_UIE,
 	};
+	XPCC_FLAGS32(Interrupt);
 
 	enum class InterruptFlag : uint32_t
 	{
 		Update = TIM_SR_UIF,
 	};
+	XPCC_FLAGS32(InterruptFlag);
 
 public:
 	/**
@@ -183,7 +186,7 @@ public:
 	 * \see		enableInterruptVector()
 	 */
 	static void
-	enableInterrupt(Interrupt interrupt);
+	enableInterrupt(Interrupt_t interrupt);
 
 	/**
 	 * Disables interrupts.
@@ -192,7 +195,7 @@ public:
 	 * 				Interrupts to disable
 	 */
 	static void
-	disableInterrupt(Interrupt interrupt);
+	disableInterrupt(Interrupt_t interrupt);
 
 	/**
 	 * Returns a bitmap of the enum StateFlag. Use this method while
@@ -215,7 +218,7 @@ public:
 	 * }
 	 * \endcode
 	 */
-	static InterruptFlag
+	static InterruptFlag_t
 	getInterruptFlags();
 
 	/**
@@ -224,13 +227,8 @@ public:
 	 * \param flags		Bitmap of StateFlag
 	 */
 	static void
-	acknowledgeInterruptFlags(InterruptFlag flags);
+	acknowledgeInterruptFlags(InterruptFlag_t flags);
 };
-
-/// @cond
-ENUM_CLASS_FLAG(BasicTimer::Interrupt)
-ENUM_CLASS_FLAG(BasicTimer::InterruptFlag)
-/// @endcond
 
 } // namespace stm32
 

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.cpp.in
@@ -153,7 +153,7 @@ xpcc::stm32::Timer{{ id }}::configureInputChannel(uint32_t channel,
 // ----------------------------------------------------------------------------
 void
 xpcc::stm32::Timer{{ id }}::configureOutputChannel(uint32_t channel,
-		OutputCompareMode mode, Value compareValue, PinState out)
+		OutputCompareMode_t mode, Value compareValue, PinState out)
 {
 	channel -= 1;	// 1..4 -> 0..3
 	
@@ -163,7 +163,7 @@ xpcc::stm32::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 	setCompareValue(channel + 1, compareValue);
 	
 	// enable preload (the compare value is loaded at each update event)
-	uint32_t flags = static_cast<uint32_t>(mode) | TIM_CCMR1_OC1PE;
+	uint32_t flags = mode.value | TIM_CCMR1_OC1PE;
 	
 	if (channel <= 1)
 	{

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
@@ -213,7 +213,7 @@ public:
 			bool xor_ch1_3=false);
 
 	static void
-	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
+	configureOutputChannel(uint32_t channel, OutputCompareMode_t mode,
 			Value compareValue, PinState out = PinState::Enable);
 
 	/// Switch to Pwm Mode 2
@@ -368,15 +368,15 @@ public:
 	enableInterruptVector(bool enable, uint32_t priority);
 
 	static inline void
-	enableInterrupt(Interrupt interrupt)
+	enableInterrupt(Interrupt_t interrupt)
 	{
-		TIM{{ id }}->DIER |= static_cast<uint32_t>(interrupt);
+		TIM{{ id }}->DIER |= interrupt.value;
 	}
 
 	static inline void
-	disableInterrupt(Interrupt interrupt)
+	disableInterrupt(Interrupt_t interrupt)
 	{
-		TIM{{ id }}->DIER &= ~static_cast<uint32_t>(interrupt);
+		TIM{{ id }}->DIER &= ~interrupt.value;
 	}
 
 	static inline void
@@ -391,18 +391,18 @@ public:
 		TIM{{ id }}->DIER &= ~static_cast<uint32_t>(dmaRequests);
 	}
 
-	static inline InterruptFlag
+	static inline InterruptFlag_t
 	getInterruptFlags()
 	{
-		return (InterruptFlag) TIM{{ id }}->SR;
+		return InterruptFlag_t(TIM{{ id }}->SR);
 	}
 
 	static inline void
-	acknowledgeInterruptFlags(InterruptFlag flags)
+	acknowledgeInterruptFlags(InterruptFlag_t flags)
 	{
 		// Flags are cleared by writing a zero to the flag position.
 		// Writing a one is ignored.
-		TIM{{ id }}->SR = ~static_cast<uint32_t>(flags);
+		TIM{{ id }}->SR = ~flags.value;
 	}
 };
 

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose_base.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose_base.hpp.in
@@ -44,6 +44,7 @@ public:
 		Trigger = TIM_DIER_TIE,
 		Break = TIM_DIER_BIE,
 	};
+	XPCC_FLAGS32(Interrupt);
 
 	enum class InterruptFlag : uint32_t
 	{
@@ -60,6 +61,7 @@ public:
 		Overcapture3 = TIM_SR_CC3OF,
 		Overcapture4 = TIM_SR_CC4OF,
 	};
+	XPCC_FLAGS32(InterruptFlag);
 
 	enum class SlaveModeTrigger : uint32_t
 	{
@@ -124,6 +126,7 @@ public:
 		 */
 		Pwm2 = TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0,
 	};
+	XPCC_FLAGS32(OutputCompareMode);
 
 	enum class OutputComparePreload : uint32_t
 	{
@@ -212,7 +215,7 @@ public:
 	 * 							changed later via setCompareValue())
 	 */
 	static void
-	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
+	configureOutputChannel(uint32_t channel, OutputCompareMode_t mode,
 			uint16_t compareValue);
 
 	/**
@@ -233,10 +236,6 @@ public:
 	static inline uint16_t
 	getCompareValue(uint32_t channel);
 };
-
-ENUM_CLASS_FLAG(GeneralPurposeTimer::Interrupt)
-ENUM_CLASS_FLAG(GeneralPurposeTimer::InterruptFlag)
-ENUM_CLASS_FLAG(GeneralPurposeTimer::OutputCompareMode)
 
 } // namespace stm32
 

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart.hpp.in
@@ -57,7 +57,7 @@ public:
 	// start documentation inherited
 	template< class SystemClock, uint32_t baudrate,
 			uint16_t tolerance = xpcc::Tolerance::TwoPercent >
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		// use double speed when necessary

--- a/src/xpcc/architecture/platform/driver/uart/lpc/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/lpc/uart.hpp.in
@@ -59,7 +59,7 @@ public:
 public:
 	template< class SystemClock, uint32_t baudrate,
 			uint16_t tolerance = xpcc::Tolerance::OnePercent >
-	static void ALWAYS_INLINE
+	static void xpcc_always_inline
 	initialize()
 	{
 		initialize(baudrate);

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
@@ -54,7 +54,7 @@ private:
 public:
 template< 	class SystemClock, uint32_t baudrate,
 		uint16_t tolerance = xpcc::Tolerance::OnePercent >
-	static void ALWAYS_INLINE
+	static void xpcc_always_inline
 %% if parameters.buffered
 	initialize(uint32_t interruptPriority, Parity parity = Parity::Disabled)
 %% else

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_base.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_base.hpp.in
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include "../../../device.hpp"
+#include <xpcc/architecture/interface/register.hpp>
 
 %% if target is stm32f1 or target is stm32f2 or target is stm32f4
 // STM has some weird ideas about continuity
@@ -58,6 +59,7 @@ public:
 		/// Call interrupt when char received (RXNE) or overrun occurred (ORE)
 		RxNotEmpty	= USART_CR1_RXNEIE,
 	};
+	XPCC_FLAGS32(Interrupt);
 
 	enum class InterruptFlag : uint32_t
 	{
@@ -81,6 +83,7 @@ public:
 		/// Set if a parity error was detected.
 		ParityError		= USART_{{reg}}_PE,
 	};
+	XPCC_FLAGS32(InterruptFlag);
 
 	enum class Parity : uint32_t
 	{
@@ -123,11 +126,6 @@ public:
 	};
 
 };
-
-/// @cond
-ENUM_CLASS_FLAG(UartBase::Interrupt)
-ENUM_CLASS_FLAG(UartBase::InterruptFlag)
-/// @endcond
 
 }	// namespace stm32
 

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_baudrate.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_baudrate.hpp.in
@@ -59,7 +59,7 @@ public:
 	 * 		the allowed absolute tolerance for the resulting baudrate
 	 */
 	template< uint32_t clockrate, uint32_t baudrate, uint16_t tolerance = 1000 >
-	static uint16_t ALWAYS_INLINE
+	static uint16_t xpcc_always_inline
 	getBrr()
 	{
 %% if target is stm32f1

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal.hpp.in
@@ -159,12 +159,12 @@ public:
 	enableInterruptVector(bool enable, uint32_t priority);
 
 	static inline void
-	enableInterrupt(Interrupt interrupt);
+	enableInterrupt(Interrupt_t interrupt);
 
 	static inline void
-	disableInterrupt(Interrupt interrupt);
+	disableInterrupt(Interrupt_t interrupt);
 
-	static inline InterruptFlag
+	static inline InterruptFlag_t
 	getInterruptFlags();
 
 	/**
@@ -173,7 +173,7 @@ public:
 	 * @warning 	Not all InterruptFlags can be cleared this way.
 	 */
 	static inline void
-	acknowledgeInterruptFlags(InterruptFlag flags);
+	acknowledgeInterruptFlags(InterruptFlag_t flags);
 };
 
 }	// namespace stm32

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
@@ -241,29 +241,29 @@ xpcc::stm32::{{ name }}::enableInterruptVector(bool enable, uint32_t priority)
 }
 
 void
-xpcc::stm32::{{ name }}::enableInterrupt(Interrupt interrupt)
+xpcc::stm32::{{ name }}::enableInterrupt(Interrupt_t interrupt)
 {
-	{{ peripheral }}->CR1 |= static_cast<uint32_t>(interrupt);
+	{{ peripheral }}->CR1 |= interrupt.value;
 }
 
 void
-xpcc::stm32::{{ name }}::disableInterrupt(Interrupt interrupt)
+xpcc::stm32::{{ name }}::disableInterrupt(Interrupt_t interrupt)
 {
-	{{ peripheral }}->CR1 &= ~static_cast<uint32_t>(interrupt);
+	{{ peripheral }}->CR1 &= ~interrupt.value;
 }
 
-xpcc::stm32::{{ name }}::InterruptFlag
+xpcc::stm32::{{ name }}::InterruptFlag_t
 xpcc::stm32::{{ name }}::getInterruptFlags()
 {
 %% if target is stm32f0 or target is stm32f3 or target is stm32f7
-	return static_cast<InterruptFlag>( {{ peripheral }}->ISR );
+	return InterruptFlag_t( {{ peripheral }}->ISR );
 %% else
-	return static_cast<InterruptFlag>( {{ peripheral }}->SR );
+	return InterruptFlag_t( {{ peripheral }}->SR );
 %% endif
 }
 
 void
-xpcc::stm32::{{ name }}::acknowledgeInterruptFlags(InterruptFlag flags)
+xpcc::stm32::{{ name }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
 {
 %% if target is stm32f0 or target is stm32f3 or target is stm32f7
 	// Not all flags can be cleared by writing to this reg
@@ -274,7 +274,7 @@ xpcc::stm32::{{ name }}::acknowledgeInterruptFlags(InterruptFlag flags)
 		USART_ICR_WUCF;
 	// Flags are cleared by writing a one to the flag position.
 	// Writing a zero is (hopefully) ignored.
-	{{ peripheral }}->ICR = (flags & mask);
+	{{ peripheral }}->ICR = (flags.value & mask);
 %% else
 	/* Interrupts must be cleared manually by accessing SR and DR.
 	 * Overrun Interrupt, Noise flag detected, Framing Error, Parity Error

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
@@ -76,7 +76,7 @@ xpcc::stm32::{{ name }}::disable()
 %% if target is not stm32f1
 template<class SystemClock, uint32_t baudrate,
 		xpcc::stm32::{{ name }}::OversamplingMode oversample>
-void ALWAYS_INLINE
+void xpcc_always_inline
 xpcc::stm32::{{ name }}::initialize(Parity parity)
 {
 	initializeWithBrr(UartBaudrate::getBrr<SystemClock::{{ uart ~ id }}, baudrate>(),
@@ -86,7 +86,7 @@ xpcc::stm32::{{ name }}::initialize(Parity parity)
 %% endif
 
 template<class SystemClock, uint32_t baudrate>
-void ALWAYS_INLINE
+void xpcc_always_inline
 xpcc::stm32::{{ name }}::initialize(Parity parity)
 {
 %% if target is stm32f1

--- a/src/xpcc/architecture/platform/driver/uart/xmega/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/xmega/uart.hpp.in
@@ -61,7 +61,7 @@ public:
 	 *		desired baud rate
 	 */
 	template< uint32_t baudrate >
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		static_assert(F_CPU/16l >= baudrate, "The CPU frequency must be at least 16x higher than UART baudrate.");

--- a/src/xpcc/architecture/utils.hpp
+++ b/src/xpcc/architecture/utils.hpp
@@ -32,108 +32,121 @@
 #define XPCC__UTILS_HPP
 
 #include "detect.hpp"
+#include "legacy_macros.hpp"
 
 #ifdef __DOXYGEN__
-	/**
-	 * \brief	Force inlining
-	 *
-	 * Macro to force inlining on functions if needed. Compiling with -Os  does not
-	 * always inline them when declared only \c inline.
-	 *
-	 * \ingroup	platform
-	 */
-	#define	ALWAYS_INLINE
+	/// @ingroup	platform
+	/// @{
+
+	/// Convert the argument into a C-String
+	#define	XPCC_STRINGIFY(s)		#s
+
+	/// Concatenate two arguments
+	#define	XPCC_CONCAT(a,b)		a ## b
+
+	/// Concatenate three arguments
+	#define	XPCC_CONCAT3(a,b,c)		a ## b ## c
+
+	/// Concatenate three arguments
+	#define	XPCC_CONCAT4(a,b,c,d)		a ## b ## c ## d
+
+	/// Concatenate three arguments
+	#define	XPCC_CONCAT5(a,b,c,d,e)		a ## b ## c ## d ## e
+
+	/// Compute the size of a static (!) array.
+	#define XPCC_ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
 
 	/**
-	 * \brief	Convert the argument into a C-String
-	 * \ingroup	platform
+	 * Force inlining on functions if needed. Compiling with -Os  does not
+	 * always inline them when declared only `inline`
 	 */
-	#define	STRINGIFY(s)	#s
+	#define xpcc_always_inline
 
-	/**
-	 * \brief	Concatenate the two arguments
-	 * \ingroup	platform
-	 */
-	#define	CONCAT(a,b)		a ## b
+	/// Attached to a variable or a function this means that it is meant to be possibly unused.
+	#define xpcc_unused
+
+	/// Causes the declaration to be emitted as a weak symbol rather than a global.
+	#define xpcc_weak
+
+	/// Specifies a minimum alignment for the function, measured in bytes.
+	#define xpcc_aligned(n)
+
+	/// Specifies that a variable or structure field should have the smallest possible alignment.
+	#define xpcc_packed
+
+	/// Specifies that a variable (or function) lives in a particular section.
+	#define xpcc_section(s)
+
+	/// Specifies that a function is placed in fastest executable memory.
+	/// @note This is not always SRAM, since Flash accelerators can be faster.
+	#define xpcc_fastcode
+
+	/// Specifies that a variable is placed in fastest accessible memory.
+	#define xpcc_fastdata
+
+	/// This branch is more likely to execute.
+	#define xpcc_likely(x) (x)
+
+	/// This branch is less likely to execute.
+	#define xpcc_unlikely(x) (x)
+
+	/// @}
 
 #else // !__DOXYGEN__
 
-	#define	STRINGIFY(s)	STRINGIFY_(s)
-	#define	STRINGIFY_(s)	STRINGIFY__(s)
-	#define	STRINGIFY__(s)	#s
+	#define	XPCC_STRINGIFY(s)	XPCC_STRINGIFY_(s)
+	#define	XPCC_STRINGIFY_(s)	XPCC_STRINGIFY__(s)
+	#define	XPCC_STRINGIFY__(s)	#s
 
-	#define	CONCAT(a,b)		CONCAT_(a,b)
-	#define	CONCAT_(a,b)	CONCAT__(a,b)
-	#define	CONCAT__(a,b)	a ## b
+	#define	XPCC_CONCAT(a,b)	XPCC_CONCAT_(a,b)
+	#define	XPCC_CONCAT_(a,b)	XPCC_CONCAT__(a,b)
+	#define	XPCC_CONCAT__(a,b)	a ## b
 
-	#define	CONCAT3(a,b,c)		CONCAT3_(a,b,c)
-	#define	CONCAT3_(a,b,c)		CONCAT3__(a,b,c)
-	#define	CONCAT3__(a,b,c)	a ## b ## c
+	#define	XPCC_CONCAT3(a,b,c)		XPCC_CONCAT3_(a,b,c)
+	#define	XPCC_CONCAT3_(a,b,c)	XPCC_CONCAT3__(a,b,c)
+	#define	XPCC_CONCAT3__(a,b,c)	a ## b ## c
 
-	#define	CONCAT4(a,b,c,d)	CONCAT4_(a,b,c,d)
-	#define	CONCAT4_(a,b,c,d)	CONCAT4__(a,b,c,d)
-	#define	CONCAT4__(a,b,c,d)	a ## b ## c ## d
+	#define	XPCC_CONCAT4(a,b,c,d)	XPCC_CONCAT4_(a,b,c,d)
+	#define	XPCC_CONCAT4_(a,b,c,d)	XPCC_CONCAT4__(a,b,c,d)
+	#define	XPCC_CONCAT4__(a,b,c,d)	a ## b ## c ## d
 
-	#define	CONCAT5(a,b,c,d,e)		CONCAT5_(a,b,c,d,e)
-	#define	CONCAT5_(a,b,c,d,e)		CONCAT5__(a,b,c,d,e)
-	#define	CONCAT5__(a,b,c,d,e)	a ## b ## c ## d ## e
+	#define	XPCC_CONCAT5(a,b,c,d,e)		XPCC_CONCAT5_(a,b,c,d,e)
+	#define	XPCC_CONCAT5_(a,b,c,d,e)	XPCC_CONCAT5__(a,b,c,d,e)
+	#define	XPCC_CONCAT5__(a,b,c,d,e)	a ## b ## c ## d ## e
 
-	#ifdef XPCC__COMPILER_GCC
-	#	define ALWAYS_INLINE  		inline __attribute__((always_inline))
-	#	define ATTRIBUTE_UNUSED		__attribute__((unused))
-	#	define ATTRIBUTE_WEAK		__attribute__ ((weak))
-	#	define ATTRIBUTE_ALIGNED(n)	__attribute__((aligned(n)))
-	#	define ATTRIBUTE_PACKED		__attribute__((packed))
-	#	define ATTRIBUTE_FASTCODE	__attribute__((section(".fastcode")))
-	#	define ATTRIBUTE_FASTDATA	__attribute__((section(".fastdata")))
-	#	define ATTRIBUTE_MAY_ALIAS	__attribute__((__may_alias__))	// see http://dbp-consulting.com/tutorials/StrictAliasing.html
-	#	define likely(x)			__builtin_expect(!!(x), 1)
-	#	define unlikely(x)			__builtin_expect(!!(x), 0)
+
+	#if defined(XPCC__COMPILER_GCC) || defined(XPCC__COMPILER_CLANG)
+	#	define xpcc_always_inline	inline __attribute__((always_inline))
+	#	define xpcc_unused			__attribute__((unused))
+	#	define xpcc_weak			__attribute__((weak))
+	#	define xpcc_aligned(n)		__attribute__((aligned(n)))
+	#	define xpcc_packed			__attribute__((packed))
+	#	define xpcc_may_alias		__attribute__((__may_alias__))	// see http://dbp-consulting.com/tutorials/StrictAliasing.html
+	#	define xpcc_deprecated(msg)	__attribute__((deprecated(msg)))
+	#	define xpcc_likely(x)		__builtin_expect(!!(x), 1)
+	#	define xpcc_unlikely(x)		__builtin_expect(!!(x), 0)
+	#	define xpcc_section_(s)		__attribute__((section(s)))
 	#else
-	#	define ALWAYS_INLINE  		inline
-	#	define ATTRIBUTE_UNUSED
-	#	define ATTRIBUTE_WEAK
-	#	define ATTRIBUTE_ALIGNED(n)
-	#	define ATTRIBUTE_PACKED
-	#	define ATTRIBUTE_FASTCODE
-	#	define ATTRIBUTE_FASTDATA
-	#	define ATTRIBUTE_MAY_ALIAS
-	#	define likely(x)			(x)
-	#	define unlikely(x)			(x)
+	#	define xpcc_always_inline	inline
+	#	define xpcc_unused
+	#	define xpcc_weak
+	#	define xpcc_aligned(n)
+	#	define xpcc_packed
+	#	define xpcc_may_alias
+	#	define xpcc_deprecated(msg)
+	#	define xpcc_likely(x)		(x)
+	#	define xpcc_unlikely(x)		(x)
+	#	define xpcc_section_(s)
 	#endif
-
-	#ifdef XPCC__CPU_AVR
-	#	define	MAIN_FUNCTION	int main(void) __attribute__((OS_main)); \
-								int main(void)
-	#	define	MAIN_FUNCTION_NAKED MAIN_FUNCTION
-	#elif defined XPCC__OS_HOSTED
-	#	define 	MAIN_FUNCTION		int main( int argc, char* argv[] )
-	#	define	MAIN_FUNCTION_NAKED	int main( int,      char**       )
+	#ifdef XPCC__OS_HOSTED
+	#	define xpcc_section(s)
 	#else
-	#	define	MAIN_FUNCTION	int main(void)
-	#	define	MAIN_FUNCTION_NAKED MAIN_FUNCTION
+	#	define xpcc_section(s)		xpcc_section_(s)
 	#endif
+	#define xpcc_fastcode		xpcc_section(".fastcode")
+	#define xpcc_fastdata		xpcc_section(".fastdata")
 
-	#define XPCC__ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
-
-	/**
-	 * Makes it possible to use enum classes as bit flags.
-	 * This disables some typesafety introduced by the enum class feature
-	 * but it should still be more typesafe than using the traditional
-	 * enum type.
-	 * Use (for public enum classes after class definition) like this:
-	 * ENUM_CLASS_FLAG(Adc{{ id }}::InterruptFlag)
-	 */
-	#define ENUM_CLASS_FLAG(name) \
-	inline name operator|(name a, name b) \
-	{return static_cast<name>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));} \
-	inline uint32_t operator&(name a, name b) \
-	{return (static_cast<uint32_t>(a) & static_cast<uint32_t>(b));} \
-	inline uint32_t operator&(uint32_t a, name b) \
-	{return ((a) & static_cast<uint32_t>(b));} \
-	inline uint32_t operator&(name a, uint32_t b) \
-	{return (static_cast<uint32_t>(a) & (b));}
-
+	#define XPCC_ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
 
 #endif	// !__DOXYGEN__
 

--- a/src/xpcc/communication/amnb/interface.hpp
+++ b/src/xpcc/communication/amnb/interface.hpp
@@ -119,14 +119,14 @@ namespace xpcc
 			 * \brief	Send a message
 			 */
 			template <typename T>
-			static bool ALWAYS_INLINE
+			static bool xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command,
 					const T& payload);
 			
 			/**
 			 * \brief	Send a empty message
 			 */
-			static bool ALWAYS_INLINE
+			static bool xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command);
 			
 			/**
@@ -134,38 +134,38 @@ namespace xpcc
 			 * 
 			 * Reset the status with a call of dropMessage().
 			 */
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			isMessageAvailable();
 			
-			static ALWAYS_INLINE uint8_t
+			static xpcc_always_inline uint8_t
 			getTransmittedAddress();
 			
-			static ALWAYS_INLINE uint8_t
+			static xpcc_always_inline uint8_t
 			getTransmittedCommand();
 			
-			static ALWAYS_INLINE Flags
+			static xpcc_always_inline Flags
 			getTransmittedFlags();
 			
-			static ALWAYS_INLINE uint8_t
+			static xpcc_always_inline uint8_t
 			getAddress();
 			
-			static ALWAYS_INLINE uint8_t
+			static xpcc_always_inline uint8_t
 			getCommand();
 			
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			isResponse();
 			
 			/**
 			 * \brief	Check if the message is an ACK or NACK
 			 * \return	\c true if the message is an ACK, \c false on NACK.
 			 */
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			isAcknowledge();
 			
 			/**
 			 * \return	\c true you are allowed to send right now
 			 */
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			isBusAvailable();
 			
 			/**
@@ -173,7 +173,7 @@ namespace xpcc
 			 * \return	\c true if the message has been transmitted without
 			 *			collision.
 			 */
-			static ALWAYS_INLINE bool
+			static xpcc_always_inline bool
 			messageTransmitted();
 			
 			/**
@@ -182,14 +182,14 @@ namespace xpcc
 			 * Data access is only valid after isMessageAvailable() returns
 			 * \c true and before any call of dropMessage() or update()
 			 */
-			static ALWAYS_INLINE const uint8_t *
+			static xpcc_always_inline const uint8_t *
 			getPayload();
 			
 			/**
 			 * \return	Size of the received message. Zero if no message
 			 * 			is available at the moment.
 			 */
-			static ALWAYS_INLINE uint8_t
+			static xpcc_always_inline uint8_t
 			getPayloadLength();
 			
 			/**

--- a/src/xpcc/communication/amnb/node.hpp
+++ b/src/xpcc/communication/amnb/node.hpp
@@ -96,7 +96,7 @@ namespace xpcc
 			 * \brief	Send a response with an attached payload
 			 */
 			template <typename T>
-			ALWAYS_INLINE void
+			xpcc_always_inline void
 			send(const T& payload);
 			
 		protected:

--- a/src/xpcc/communication/sab/interface.hpp
+++ b/src/xpcc/communication/sab/interface.hpp
@@ -90,14 +90,14 @@ namespace xpcc
 			 * \brief	Send a message
 			 */
 			template <typename T>
-			static void ALWAYS_INLINE
+			static void xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command,
 					const T& payload);
 			
 			/**
 			 * \brief	Send a empty message
 			 */
-			static void ALWAYS_INLINE
+			static void xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command);
 			
 			/**

--- a/src/xpcc/communication/sab/slave.hpp
+++ b/src/xpcc/communication/sab/slave.hpp
@@ -95,7 +95,7 @@ namespace xpcc
 			 * \brief	Send a response with an attached payload
 			 */
 			template <typename T>
-			ALWAYS_INLINE void
+			xpcc_always_inline void
 			send(const T& payload);
 			
 		protected:

--- a/src/xpcc/communication/sab2/interface.hpp
+++ b/src/xpcc/communication/sab2/interface.hpp
@@ -96,14 +96,14 @@ namespace xpcc
 			 * \brief	Send a message
 			 */
 			template <typename T>
-			static void ALWAYS_INLINE
+			static void xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command,
 					const T& payload);
 			
 			/**
 			 * \brief	Send a empty message
 			 */
-			static void ALWAYS_INLINE
+			static void xpcc_always_inline
 			sendMessage(uint8_t address, Flags flags, uint8_t command);
 			
 			/**

--- a/src/xpcc/container/smart_pointer.hpp
+++ b/src/xpcc/container/smart_pointer.hpp
@@ -145,7 +145,7 @@ namespace xpcc
 	protected:
 		friend IOStream&
 		operator <<( IOStream&, const SmartPointer&);
-	} ATTRIBUTE_PACKED;
+	} xpcc_packed;
 
 	/**
 	 * \ingroup container

--- a/src/xpcc/debug/logger/hosted/default_style.cpp
+++ b/src/xpcc/debug/logger/hosted/default_style.cpp
@@ -56,15 +56,15 @@ namespace xpcc
 		};
 
 		static Wrapper< char[10], TURQUOISE, NONE > debugWrapper("Debug:   ", device);
-		Logger ATTRIBUTE_WEAK debug(debugWrapper);
+		Logger xpcc_weak debug(debugWrapper);
 
 		static Wrapper< char[10], GREEN, NONE > debugInfo("Info:    ", device);
-		Logger ATTRIBUTE_WEAK info(debugInfo);
+		Logger xpcc_weak info(debugInfo);
 
 		static Wrapper< char[10], YELLOW, NONE > warningInfo("Warning: ", device);
-		Logger ATTRIBUTE_WEAK warning(warningInfo);
+		Logger xpcc_weak warning(warningInfo);
 
 		static Wrapper< char[10], RED, NONE > errorInfo("Error:   ", device);
-		Logger ATTRIBUTE_WEAK error(errorInfo);
+		Logger xpcc_weak error(errorInfo);
 	}
 }

--- a/src/xpcc/debug/logger/logger.hpp
+++ b/src/xpcc/debug/logger/logger.hpp
@@ -68,11 +68,11 @@ namespace xpcc
 				/**
 				 * @brief	Output forwarding
 				 * 
-				 * We must use ALWAYS_INLINE here to prevent the generation of
+				 * We must use xpcc_always_inline here to prevent the generation of
 				 * specialized functions for every type. Especially for strings
 				 * this might cause a lot of code size bloat.
 				 * 
-				 * Example without ALWAYS_INLINE or only \c inline:
+				 * Example without xpcc_always_inline or only \c inline:
 				 * \code
 				 * $ scons symbols | grep "Logger"
 				 * ...
@@ -86,10 +86,10 @@ namespace xpcc
 				 * ...
 				 * \endcode
 				 * 
-				 * With ALWAYS_INLINE all these functions are gone.
+				 * With xpcc_always_inline all these functions are gone.
 				 */
 				template<typename T>
-				ALWAYS_INLINE Logger&
+				xpcc_always_inline Logger&
 				operator << (const T& msg)
 				{
 					*(xpcc::IOStream *) this << msg;

--- a/src/xpcc/debug/logger/logger.hpp
+++ b/src/xpcc/debug/logger/logger.hpp
@@ -212,10 +212,10 @@ namespace xpcc
 #		define FILENAME __BASE_FILE__
 #	endif
 #else
-#	define	FILENAME	STRINGIFY(BASENAME)
+#	define	FILENAME	XPCC_STRINGIFY(BASENAME)
 #endif
 
-#define	XPCC_FILE_INFO		"[" FILENAME "(" STRINGIFY(__LINE__) ")] "
+#define	XPCC_FILE_INFO		"[" FILENAME "(" XPCC_STRINGIFY(__LINE__) ")] "
 
 #endif	// __DOXYGEN__
 #endif // XPCC__LOGGER_HPP

--- a/src/xpcc/driver/adc/test/ad7280a_test.cpp
+++ b/src/xpcc/driver/adc/test/ad7280a_test.cpp
@@ -119,10 +119,10 @@ Ad7280aTest::testChainSetup()
 	uint8_t arg4Tx[] = {0x11, 0xC2, 0x65, 0xDC};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);
@@ -149,12 +149,12 @@ Ad7280aTest::testSelftest()
 	uint8_t arg4Tx[] = {0x00, 0x1E, 0xA5, 0x90};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
 
 		// Read the self-test conversion result (value = 980)
-		test::Transmission(XPCC__ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);
@@ -175,8 +175,8 @@ Ad7280aTest::testSoftwareReset()
 	uint8_t arg2Tx[] = {0x00, 0x00, 0x00, 0x00};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);
@@ -203,11 +203,11 @@ Ad7280aTest::testChannelRead()
 	uint8_t arg4Tx[] = {0x01, 0x91, 0x2D, 0x88};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
 
-		test::Transmission(XPCC__ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);
@@ -249,15 +249,15 @@ Ad7280aTest::testAllChannelRead()
 	uint8_t arg8Tx[] = {0x02, 0x92, 0xC6, 0x74};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
 
-		test::Transmission(XPCC__ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg5Rx), arg5Rx, arg5Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg6Rx), arg6Rx, arg6Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg7Rx), arg7Rx, arg7Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg8Rx), arg8Rx, arg8Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg3Rx), arg3Rx, arg3Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg4Rx), arg4Rx, arg4Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg5Rx), arg5Rx, arg5Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg6Rx), arg6Rx, arg6Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg7Rx), arg7Rx, arg7Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg8Rx), arg8Rx, arg8Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);
@@ -283,7 +283,7 @@ Ad7280aTest::testBalancer()
 	uint8_t arg1Tx[] = {0x00, 0x00, 0x00, 0x00};
 
 	test::Transmission transmissionsInitialize[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
 	};
 
 	device.start(transmissionsInitialize, ARRAY_SIZE(transmissionsInitialize), __LINE__);

--- a/src/xpcc/driver/adc/test/spi_device_test.cpp
+++ b/src/xpcc/driver/adc/test/spi_device_test.cpp
@@ -60,7 +60,7 @@ SpiDeviceTest::testSingleTransmission()
 	uint8_t arg1Tx[] = {4, 3, 2, 1};
 
 	test::Transmission transmissions[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
 	};
 	
 	test::SpiDevice device;
@@ -105,8 +105,8 @@ SpiDeviceTest::testMultipleTransmissions()
 	uint8_t arg2Tx[] = {100, 101};
 
 	test::Transmission transmissions[] = {
-		test::Transmission(XPCC__ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
-		test::Transmission(XPCC__ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg1Rx), arg1Rx, arg1Tx),
+		test::Transmission(XPCC_ARRAY_SIZE(arg2Rx), arg2Rx, arg2Tx),
 	};
 	
 	test::SpiDevice device;

--- a/src/xpcc/driver/bus/bitbang_memory_interface.hpp
+++ b/src/xpcc/driver/bus/bitbang_memory_interface.hpp
@@ -33,13 +33,13 @@ namespace xpcc
 	class BitbangMemoryInterface
 	{
 	public:
-		ALWAYS_INLINE static void
+		xpcc_always_inline static void
 		initialize();
 
-		ALWAYS_INLINE static void
+		xpcc_always_inline static void
 		writeRegister(const uint8_t reg);
 
-		ALWAYS_INLINE static void
+		xpcc_always_inline static void
 		writeCommand(const uint8_t command, const uint16_t data);
 
 		static void
@@ -49,7 +49,7 @@ namespace xpcc
 		writeRam(uint8_t * addr, const uint16_t size);
 
 	protected:
-		ALWAYS_INLINE static void
+		xpcc_always_inline static void
 		writeData(const uint16_t data);
 
 	protected:

--- a/src/xpcc/driver/bus/tft_memory_bus.hpp
+++ b/src/xpcc/driver/bus/tft_memory_bus.hpp
@@ -26,32 +26,32 @@ public:
 	{
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeIndex(uint16_t index)
 	{
 		*ptrIndex = index;
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeData(uint16_t data)
 	{
 		*ptrData = data;
 	}
 
-	ALWAYS_INLINE uint16_t
+	xpcc_always_inline uint16_t
 	readData()
 	{
 		return *ptrData;
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeRegister(uint16_t reg, uint16_t value)
 	{
 		writeIndex(reg);
 		writeData(value);
 	}
 
-	ALWAYS_INLINE uint16_t
+	xpcc_always_inline uint16_t
 	readRegister(uint16_t reg)
 	{
 		writeIndex(reg);
@@ -74,34 +74,34 @@ public:
 	{
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeIndex(uint8_t index)
 	{
 		*ptrIndex = 0;
 		*ptrIndex = index;
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeData(uint16_t data)
 	{
 		*ptrData = data >> 8;
 		*ptrData = data & 0xff;
 	}
 
-//	ALWAYS_INLINE uint16_t
+//	xpcc_always_inline uint16_t
 //	readData()
 //	{
 //		return *ptrData;
 //	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	writeRegister(uint8_t reg, uint16_t value)
 	{
 		writeIndex(reg);
 		writeData(value);
 	}
 
-//	ALWAYS_INLINE uint16_t
+//	xpcc_always_inline uint16_t
 //	readRegister(uint16_t reg)
 //	{
 //		writeIndex(reg);
@@ -128,7 +128,7 @@ template <
 class MemoryBus
 {
 public:
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		CS::set();
@@ -137,7 +137,7 @@ public:
 		PORT::setInput();
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	write(const uint8_t data)
 	{
 		CS::reset();
@@ -159,7 +159,7 @@ public:
 		CS::set();
 	}
 
-	static ALWAYS_INLINE uint8_t
+	static xpcc_always_inline uint8_t
 	read()
 	{
 		uint8_t ret;
@@ -193,13 +193,13 @@ class TftMemoryBus8BitGpio
 public:
 	typedef MemoryBus<PORT, CS, RD, WR> BUS;
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	initialize()
 	{
 		BUS::initialize();
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	writeIndex(uint8_t index)
 	{
 		// *ptrIndex = 0;
@@ -210,7 +210,7 @@ public:
 		BUS::write(index);
 	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	writeData(uint16_t data)
 	{
 		// *ptrData = data >> 8;
@@ -221,20 +221,20 @@ public:
 		BUS::write(data & 0xff);
 	}
 
-//	static ALWAYS_INLINE uint16_t
+//	static xpcc_always_inline uint16_t
 //	readData()
 //	{
 //		return *ptrData;
 //	}
 
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	writeRegister(uint8_t reg, uint16_t value)
 	{
 		writeIndex(reg);
 		writeData(value);
 	}
 
-//	static ALWAYS_INLINE uint16_t
+//	static xpcc_always_inline uint16_t
 //	readRegister(uint16_t reg)
 //	{
 //		writeIndex(reg);

--- a/src/xpcc/driver/color/tcs3414.hpp
+++ b/src/xpcc/driver/color/tcs3414.hpp
@@ -301,7 +301,7 @@ private:
 		}
 		inline uint8_t getLSB()	const { return low; }
 		inline uint8_t getMSB()	const { return high; }
-	} ATTRIBUTE_PACKED;
+	} xpcc_packed;
 
 	static union Data
 	{
@@ -312,7 +312,7 @@ private:
 			uint16_t_LOW_HIGH red;
 			uint16_t_LOW_HIGH blue;
 			uint16_t_LOW_HIGH clear;
-		} ATTRIBUTE_PACKED;
+		} xpcc_packed;
 	} data;
 
 	static Rgb	color;

--- a/src/xpcc/driver/display/hd44780_base.hpp
+++ b/src/xpcc/driver/display/hd44780_base.hpp
@@ -82,12 +82,12 @@ public:
 
 	/// Clear the display of all Data
 	/// @return	`true` if operation successful, `false` if controller is busy
-	static ALWAYS_INLINE bool
+	static xpcc_always_inline bool
 	clear();
 
 	/// Reset the cursor to (0,0) home position
 	/// @return	`true` if operation successful, `false` if controller is busy
-	static ALWAYS_INLINE bool
+	static xpcc_always_inline bool
 	resetCursor();
 
 	// write
@@ -109,7 +109,7 @@ public:
 	// read
 	/// Read the cursor position
 	/// @return	`true` if operation successful, `false` if controller is busy
-	static ALWAYS_INLINE bool
+	static xpcc_always_inline bool
 	readAddress(uint8_t &address);
 
 	/// Read the character at the current cursor position
@@ -127,11 +127,11 @@ public:
 
 protected:
 	/// unconditionally write data to the controller
-	static ALWAYS_INLINE void
+	static xpcc_always_inline void
 	write(uint8_t data);
 
 	/// unconditionally read data from the controller
-	static ALWAYS_INLINE uint8_t
+	static xpcc_always_inline uint8_t
 	read();
 
 private:
@@ -174,7 +174,7 @@ private:
 
 		/// only writes the high nibble of data
 		/// Use this in the initialization, when bus width is not determined yet
-		static ALWAYS_INLINE void
+		static xpcc_always_inline void
 		writeHighNibble(uint8_t data);
 
 		/// toggles the Enable line and reads the port
@@ -195,7 +195,7 @@ private:
 
 		/// only writes the high nibble of data
 		/// Use this in the initialization, when bus width is not determined yet
-		static ALWAYS_INLINE void
+		static xpcc_always_inline void
 		writeHighNibble(uint8_t data);
 
 		/// toggles the Enable line and reads the port

--- a/src/xpcc/driver/display/nokia6610.hpp
+++ b/src/xpcc/driver/display/nokia6610.hpp
@@ -70,19 +70,19 @@ namespace xpcc
 		setContrast(uint8_t contrast);
 
 	private:
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdSettings(void);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeSpiCommand(uint16_t data);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeSpiData(uint16_t data);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeSpi9Bit(uint16_t data);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeSpi9BitFlush();
 
 		void

--- a/src/xpcc/driver/display/siemens_m55.hpp
+++ b/src/xpcc/driver/display/siemens_m55.hpp
@@ -58,10 +58,10 @@ namespace xpcc
 		update();
 
 	private:
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdSettings(void);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdCls(uint16_t colour);
 	};
 }

--- a/src/xpcc/driver/display/siemens_s65.hpp
+++ b/src/xpcc/driver/display/siemens_s65.hpp
@@ -64,19 +64,19 @@ namespace xpcc
 	class SiemensS65Common
 	{
 	protected:
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeCmd(uint8_t reg, uint16_t param);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeReg(uint8_t reg);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		writeData(uint16_t param);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdCls(uint16_t colour);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdSettings(bool landscape);
 
 	};

--- a/src/xpcc/driver/display/siemens_s75.hpp
+++ b/src/xpcc/driver/display/siemens_s75.hpp
@@ -113,10 +113,10 @@ namespace xpcc
 		initialize(void);
 
 	protected:
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdCls(const uint16_t colour);
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		lcdSettings();
 
 	private:

--- a/src/xpcc/driver/display/ssd1306.hpp
+++ b/src/xpcc/driver/display/ssd1306.hpp
@@ -118,7 +118,7 @@ public:
 	public:
 		DataTransmissionAdapter(uint8_t address);
 
-		void ALWAYS_INLINE
+		void xpcc_always_inline
 		setCommandBuffer(uint8_t *buffer)
 		{ commands = buffer; }
 
@@ -179,7 +179,7 @@ public:
 	/// Use this method to synchronize writing to the displays buffer
 	/// to avoid tearing.
 	/// @return	`true` if the frame buffer is not being copied to the display
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	isWritable()
 	{
 		return this->transaction.writeable;
@@ -195,11 +195,11 @@ public:
 	writeDisplay();
 
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setDisplayMode(DisplayMode mode = DisplayMode::Normal)
 	{ return writeCommand(static_cast<Command>(mode)); }
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setContrast(uint8_t contrast = 0xCE)
 	{ return writeCommand(Command::SetContrastControl, contrast); }
 
@@ -211,11 +211,11 @@ public:
 	configureScroll(uint8_t origin, uint8_t size,
 			ScrollDirection direction, ScrollStep steps);
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	enableScroll()
 	{ return writeCommand(Command::SetEnableScroll); }
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	disableScroll()
 	{ return writeCommand(Command::SetDisableScroll); }
 

--- a/src/xpcc/driver/display/st7565.hpp
+++ b/src/xpcc/driver/display/st7565.hpp
@@ -64,7 +64,7 @@ namespace xpcc
 		setInvert(bool invert);
 
 	protected:
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		initialize(xpcc::accessor::Flash<uint8_t> configuration, uint8_t size);
 
 		SPI spi;

--- a/src/xpcc/driver/fpga/xilinx_spartan6_impl.hpp
+++ b/src/xpcc/driver/fpga/xilinx_spartan6_impl.hpp
@@ -145,7 +145,7 @@ template <	typename Cclk,
 			typename DataSource,
 			typename Led0,
 			typename Led1>
-ALWAYS_INLINE void
+xpcc_always_inline void
 xpcc::XilinxSpartan6Parallel<Cclk, DataLow, DataHigh, ProgB, InitB, Done, DataSource, Led0, Led1>::writeWord(uint8_t first, uint8_t second) {
 	DataLow::write(first);
 	Cclk::set();
@@ -164,7 +164,7 @@ template <	typename Cclk,
 			typename DataSource,
 			typename Led0,
 			typename Led1 >
-ALWAYS_INLINE void
+xpcc_always_inline void
 xpcc::XilinxSpartan6Parallel<Cclk, DataLow, DataHigh, ProgB, InitB, Done, DataSource, Led0, Led1>::writePage(uint8_t *buffer, WritePageState& writePageState, uint32_t pageSize) {
 	for (uint32_t offset = 0; offset < pageSize; offset+=2) {
 		uint8_t first = buffer[offset];

--- a/src/xpcc/driver/gpio/mcp23_transport.hpp
+++ b/src/xpcc/driver/gpio/mcp23_transport.hpp
@@ -47,7 +47,7 @@ protected:
 	write16(uint8_t reg, uint16_t value);
 
 	/// read a 8bit value
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(uint8_t reg, uint8_t &value)
 	{
 		return read(reg, &value, 1);
@@ -96,7 +96,7 @@ protected:
 	write16(uint8_t reg, uint16_t value);
 
 	/// read a 8bit value
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(uint8_t reg, uint8_t &value)
 	{
 		return read(reg, &value, 1);

--- a/src/xpcc/driver/gpio/mcp23x17.hpp
+++ b/src/xpcc/driver/gpio/mcp23x17.hpp
@@ -254,7 +254,7 @@ public:
 	using Port = GpioExpanderPort< Mcp23x17<Transport>, object, StartPin, Width, DataOrder >;
 
 private:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Memory
 	{
 		Memory() :

--- a/src/xpcc/driver/gpio/pca9535.hpp
+++ b/src/xpcc/driver/gpio/pca9535.hpp
@@ -250,7 +250,7 @@ private:
 	readMemory(Index index);
 
 	/// @cond
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Memory
 	{
 		Memory() :

--- a/src/xpcc/driver/inertial/bma180.hpp
+++ b/src/xpcc/driver/inertial/bma180.hpp
@@ -432,7 +432,7 @@ namespace xpcc
 		 * only read the X-ZDATA0-1 registers and buffer the results
 		 * sets isNewDataAvailable() to \c true
 		 */
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		readAccelerometer();
 
 		/* \return pointer to 8bit array containing xyzt temperature and accelerations
@@ -445,7 +445,7 @@ namespace xpcc
 		 * \c false, when the data has been accessed, or data is being
 		 * copied into the buffer.
 		 */
-		ALWAYS_INLINE bool
+		xpcc_always_inline bool
 		isNewDataAvailable();
 
 		void

--- a/src/xpcc/driver/inertial/hmc58x3.hpp
+++ b/src/xpcc/driver/inertial/hmc58x3.hpp
@@ -110,7 +110,7 @@ public:
 	};
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class I2cMaster >

--- a/src/xpcc/driver/inertial/hmc58x3.hpp
+++ b/src/xpcc/driver/inertial/hmc58x3.hpp
@@ -257,7 +257,7 @@ public:
 protected:
 	/// @cond
 	/// write a 8bit value a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	write(Register reg, uint8_t &value)
 	{ return write(reg, &value, 1); }
 
@@ -266,7 +266,7 @@ protected:
 	write(Register reg, uint8_t *buffer, uint8_t length);
 
 	/// read a 8bit value from a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(Register reg, uint8_t &value)
 	{ return read(reg, &value, 1); }
 

--- a/src/xpcc/driver/inertial/hmc6343.hpp
+++ b/src/xpcc/driver/inertial/hmc6343.hpp
@@ -117,7 +117,7 @@ public:
 		Hz10 = 0x02,
 	};
 
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class I2cMaster >

--- a/src/xpcc/driver/inertial/hmc6343.hpp
+++ b/src/xpcc/driver/inertial/hmc6343.hpp
@@ -126,46 +126,46 @@ public:
 		// DATA ACCESS
 		/// returns the acceleration in unknown units
 		///@{
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getAccelerationX() { return swapData(0); }
 
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getAccelerationY() { return swapData(1); }
 
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getAccelerationZ() { return swapData(2); }
 		///@}
 
 		/// returns the magnetic field in unknown units
 		///@{
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getMagneticFieldX() { return swapData(3); }
 
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getMagneticFieldY() { return swapData(4); }
 
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getMagneticFieldZ() { return swapData(5); }
 		///@}
 
 		/// returns the heading in tenth of degrees (0 -> 3600)
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getHeading() { return swapData(6); }
 
 		/// returns the Pitch in tenth of degrees (-900 -> 0 -> 900)
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getPitch() { return swapData(7); }
 
 		/// returns the Roll in tenth of degrees (-900 -> 0 -> 900)
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getRoll() { return swapData(8); }
 
 		/// returns the temperature in unknown format (was not specified in datasheet)
-		int16_t ALWAYS_INLINE
+		int16_t xpcc_always_inline
 		getTemperature() { return swapData(9); }
 
 		/// returns the value of the operation mode register
-		OperationMode_t ALWAYS_INLINE
+		OperationMode_t xpcc_always_inline
 		getOperationMode() { return OperationMode_t(data[20]); }
 
 
@@ -222,7 +222,7 @@ public:
 
 	// READING RAM
 	/// read operation mode register 2
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	readOperationMode()
 	{ return readPostData(Command::PostOperationMode, 20, 1); }
 
@@ -230,7 +230,7 @@ public:
 
 	// WRITING EEPROM
 	/// Configures the sensor to normal orientation mode with 10Hz data rate.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setMeasurementRate(MeasurementRate measurementRate=MeasurementRate::Hz10)
 	{ return writeRegister(Register::OperationMode2, i(measurementRate)); }
 
@@ -245,7 +245,7 @@ public:
 	{ return writeRegister(Register16::VariationAngle, static_cast<uint16_t>(angle)); }
 
 	/// sets a new IIR filter in eeprom
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setIIR_Filter(uint8_t filter)
 	{ return writeRegister(Register::Filter, filter & 0x0f); }
 
@@ -253,12 +253,12 @@ public:
 
 	// READING EEPROM
 	/// reads the device id from eeprom
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	getDeviceId(uint16_t &value)
 	{ return readRegister(Register16::DeviceSerial, value); }
 
 	/// sets a new IIR filter in eeprom
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	getIIR_Filter(uint8_t &value)
 	{ return readRegister(Register::Filter, value); }
 
@@ -266,42 +266,42 @@ public:
 
 	// COMMANDS
 	/// Sets the specified orientation
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setOrientation(Orientation orientation)
 	{ return writeCommand(static_cast<Command>(orientation)); }
 
 	/// enters run mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	enterRunMode()
 	{ return writeCommand(Command::EnterRunMode); }
 
 	/// enters standby mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	enterStandbyMode()
 	{ return writeCommand(Command::EnterStandbyMode); }
 
 	/// enters sleep mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	enterSleepMode()
 	{ return writeCommand(Command::EnterSleepMode); }
 
 	/// exit sleep mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	exitSleepMode()
 	{ return writeCommand(Command::ExitSleepMode, 20); }
 
 	/// enters user calibration mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	enterUserCalibrationMode()
 	{ return writeCommand(Command::EnterUserCalibrationMode); }
 
 	/// exit user calibration mode
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	exitUserCalibrationMode()
 	{ return writeCommand(Command::ExitUserCalibrationMode, 50); }
 
 	/// resets the processor, any new command is delayed by 500ms
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	resetProcessor()
 	{ return writeCommand(Command::ResetProcessor, 500); }
 
@@ -309,22 +309,22 @@ public:
 
 	// DATA REQUESTS
 	/// reads the Acceleration registers and buffer the results
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	readAcceleration()
 	{ return readPostData(Command::PostAccelData, 0, 6); }
 
 	/// reads the Magnetometer registers and buffer the results
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	readMagneticField()
 	{ return readPostData(Command::PostMagData, 6, 6); }
 
 	/// reads the Heading registers and buffer the results
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	readHeading()
 	{ return readPostData(Command::PostHeadingData, 12, 6); }
 
 	/// reads the Tilt registers and buffer the results
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	readTilt()
 	{ return readPostData(Command::PostTiltData, 14, 6); }
 

--- a/src/xpcc/driver/inertial/itg3200.hpp
+++ b/src/xpcc/driver/inertial/itg3200.hpp
@@ -262,7 +262,7 @@ public:
 protected:
 	/// @cond
 	/// write a 8bit value a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	write(Register reg, uint8_t &value)
 	{ return write(reg, &value, 1); }
 
@@ -271,7 +271,7 @@ protected:
 	write(Register reg, uint8_t *buffer, uint8_t length, bool copyBuffer=true);
 
 	/// read a 8bit value from a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(Register reg, uint8_t &value)
 	{ return read(reg, &value, 1); }
 

--- a/src/xpcc/driver/inertial/itg3200.hpp
+++ b/src/xpcc/driver/inertial/itg3200.hpp
@@ -137,7 +137,7 @@ public:
 	typedef Configuration< Power_t, ClockSource, (Bit2 | Bit1 | Bit0) > ClockSource_t;
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template< class I2cMaster >

--- a/src/xpcc/driver/inertial/l3gd20.hpp
+++ b/src/xpcc/driver/inertial/l3gd20.hpp
@@ -249,7 +249,7 @@ public:
 	};
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class Transport >

--- a/src/xpcc/driver/inertial/lis302dl.hpp
+++ b/src/xpcc/driver/inertial/lis302dl.hpp
@@ -240,7 +240,7 @@ public:
 	};
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class Transport >

--- a/src/xpcc/driver/inertial/lis3_transport.hpp
+++ b/src/xpcc/driver/inertial/lis3_transport.hpp
@@ -46,7 +46,7 @@ protected:
 	write(uint8_t reg, uint8_t value);
 
 	/// read a 8bit value
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(uint8_t reg, uint8_t &value)
 	{
 		return read(reg, &value, 1);
@@ -97,7 +97,7 @@ protected:
 	write(uint8_t reg, uint8_t value);
 
 	/// read a 8bit value
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(uint8_t reg, uint8_t &value)
 	{
 		return read(reg, &value, 1);

--- a/src/xpcc/driver/inertial/lis3dsh.hpp
+++ b/src/xpcc/driver/inertial/lis3dsh.hpp
@@ -435,7 +435,7 @@ public:
 	};
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class Transport >

--- a/src/xpcc/driver/inertial/lsm303a.hpp
+++ b/src/xpcc/driver/inertial/lsm303a.hpp
@@ -307,7 +307,7 @@ public:
 	};
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class Transport >

--- a/src/xpcc/driver/position/vl6180.hpp
+++ b/src/xpcc/driver/position/vl6180.hpp
@@ -403,14 +403,14 @@ public:
 
 public:
 	/// write a 8bit value a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	write(Register reg, uint8_t value)
 	{ return write(reg, value, 1); }
 
 protected:
 	/// @cond
 	/// read a 8bit value from a register
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	read(Register reg, uint8_t &value)
 	{ return read(reg, &value, 1); }
 	/// @endcond

--- a/src/xpcc/driver/position/vl6180.hpp
+++ b/src/xpcc/driver/position/vl6180.hpp
@@ -303,7 +303,7 @@ public:
 			InterruptStatus_t>;
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template< class I2cMaster >

--- a/src/xpcc/driver/pressure/bmp085_data.hpp
+++ b/src/xpcc/driver/pressure/bmp085_data.hpp
@@ -35,7 +35,7 @@ namespace bmp085data
  * Values are used for calculation of calibrated
  * sensor values from raw sensor data
  */
-struct ATTRIBUTE_PACKED
+struct xpcc_packed
 Calibration
 {
 	int16_t  ac1;
@@ -53,7 +53,7 @@ Calibration
 	int16_t  md;
 };
 
-class ATTRIBUTE_PACKED
+class xpcc_packed
 DataBase
 {
 	template < typename I2cMaster >
@@ -105,7 +105,7 @@ protected:
 	};
 };
 
-class ATTRIBUTE_PACKED
+class xpcc_packed
 Data : public DataBase
 {
 public:
@@ -165,7 +165,7 @@ private:
 	int32_t b5; // calculated in calculateCalibratedTemperature, needed for calculateCalibratedPressure
 };
 
-class ATTRIBUTE_PACKED
+class xpcc_packed
 DataDouble : public DataBase
 {
 public:

--- a/src/xpcc/driver/pressure/hclax.hpp
+++ b/src/xpcc/driver/pressure/hclax.hpp
@@ -22,7 +22,7 @@ class HclaX;
 
 struct hclax
 {
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < typename I2cMaster >

--- a/src/xpcc/driver/pressure/test/bmp085_test.cpp
+++ b/src/xpcc/driver/pressure/test/bmp085_test.cpp
@@ -68,7 +68,7 @@ Bmp085Test::testConversion()
 	adc_press_min[2] = 0x4000;
 	adc_press_max[2] = 0xE000;
 
-	for (size_t jj = 0; jj < XPCC__ARRAY_SIZE(dataTable); ++jj)
+	for (size_t jj = 0; jj < XPCC_ARRAY_SIZE(dataTable); ++jj)
 	{
 		xpcc::bmp085::DataDouble* dataDouble;
 

--- a/src/xpcc/driver/pwm/tlc594x.hpp
+++ b/src/xpcc/driver/pwm/tlc594x.hpp
@@ -120,26 +120,26 @@ public:
 	latch();
 
 	/// @return true if LOD or TEF is detected
-	ALWAYS_INLINE
+	xpcc_always_inline
 	static bool
 	isError()
 	{
 		return !Xerr::read();
 	}
 
-	ALWAYS_INLINE
+	xpcc_always_inline
 	static uint8_t*
 	getGrayscaleData()
 	{
 		return gs;
 	}
-	ALWAYS_INLINE
+	xpcc_always_inline
 	static uint8_t*
 	getDotCorrectionData()
 	{
 		return dc;
 	}
-	ALWAYS_INLINE
+	xpcc_always_inline
 	static uint8_t*
 	getStatusData()
 	{

--- a/src/xpcc/driver/radio/nrf24/nrf24_data.hpp
+++ b/src/xpcc/driver/radio/nrf24/nrf24_data.hpp
@@ -62,7 +62,7 @@ public:
 	/// @{
 	/// @ingroup	nrf24
 	/// Data structure that user uses to pass data to the data layer
-	struct ATTRIBUTE_PACKED Packet
+	struct xpcc_packed Packet
 	{
 		Packet() :
 			dest(0), src(0)
@@ -70,7 +70,7 @@ public:
 			payload.length = Nrf24Phy::getMaxPayload();
 		}
 
-		struct ATTRIBUTE_PACKED Payload
+		struct xpcc_packed Payload
 		{
 			uint8_t data[Nrf24Phy::getMaxPayload()];
 			uint8_t length;      // max. 30!
@@ -83,14 +83,14 @@ public:
 
 
 	/// Header of Frame
-	struct ATTRIBUTE_PACKED Header
+	struct xpcc_packed Header
 	{
 		uint8_t     src;
 		uint8_t     dest;
 	};
 
 	/// Data that will be sent over the air
-	struct ATTRIBUTE_PACKED Frame
+	struct xpcc_packed Frame
 	{
 		Header      header;
 		uint8_t     data[30];   // max. possible payload size (32 byte) - 2 byte (src + dest)

--- a/src/xpcc/driver/temperature/ds1631.hpp
+++ b/src/xpcc/driver/temperature/ds1631.hpp
@@ -110,7 +110,7 @@ public:
 	///
 	Ds1631(Data &data, uint8_t address=0x90);
 
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	update()
 	{ run(); }
 
@@ -131,12 +131,12 @@ public:
 	setConversionMode(ConversionMode mode);
 
 	/// Writes the upper limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setUpperLimit(float temperature)
 	{ return setLimitRegister(Command::TemperatureUpperLimit, temperature); }
 
 	/// Writes the lower limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setLowerLimit(float temperature)
 	{ return setLimitRegister(Command::TemperatureLowerLimit, temperature); }
 
@@ -146,15 +146,15 @@ public:
 	readTemperature();
 
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	startConversion()
 	{ return writeCommand(Command::StartConvert); }
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	stopConversion()
 	{ return writeCommand(Command::StopConvert); }
 
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	reset()
 	{ return writeCommand(Command::SoftwareReset); }
 

--- a/src/xpcc/driver/temperature/lm75.hpp
+++ b/src/xpcc/driver/temperature/lm75.hpp
@@ -81,7 +81,7 @@ protected:
 	/// @endcond
 
 public:
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class I2cMaster >

--- a/src/xpcc/driver/temperature/lm75.hpp
+++ b/src/xpcc/driver/temperature/lm75.hpp
@@ -142,12 +142,12 @@ public:
 	configureAlertMode(ThermostatMode mode, AlertPolarity polarity, FaultQueue faults);
 
 	/// Writes the upper limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setUpperLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureUpperLimit, temperature); }
 
 	/// Writes the lower limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setLowerLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureLowerLimit, temperature); }
 

--- a/src/xpcc/driver/temperature/tmp102.hpp
+++ b/src/xpcc/driver/temperature/tmp102.hpp
@@ -62,7 +62,7 @@ protected:
 	/// @endcond
 public:
 
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template < class I2cMaster >

--- a/src/xpcc/driver/temperature/tmp102.hpp
+++ b/src/xpcc/driver/temperature/tmp102.hpp
@@ -128,7 +128,7 @@ public:
 	/// sets address to default of 0x48 (alternatives are 0x49, 0x4A and 0x4B).
 	Tmp102(Data &data, uint8_t address=0x48);
 
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	update()
 	{ run(); }
 
@@ -146,12 +146,12 @@ public:
 	readComparatorMode(bool &result);
 
 	/// Writes the upper limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setUpperLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureUpperLimit, temperature); }
 
 	/// Writes the lower limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setLowerLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureLowerLimit, temperature); }
 

--- a/src/xpcc/driver/temperature/tmp175.hpp
+++ b/src/xpcc/driver/temperature/tmp175.hpp
@@ -79,7 +79,7 @@ public:
 	/// sets address to default of 0x48 (alternatives are 0x49, 0x4A and 0x4B).
 	Tmp175(Data &data, uint8_t address=0x48);
 
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	update()
 	{ run(); }
 
@@ -91,12 +91,12 @@ public:
 	setResolution(Resolution resolution);
 
 	/// Writes the upper limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setUpperLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureUpperLimit, temperature); }
 
 	/// Writes the lower limit of the alarm.
-	xpcc::ResumableResult<bool> ALWAYS_INLINE
+	xpcc::ResumableResult<bool> xpcc_always_inline
 	setLowerLimit(float temperature)
 	{ return setLimitRegister(Register::TemperatureLowerLimit, temperature); }
 

--- a/src/xpcc/driver/touch/ft6x06.hpp
+++ b/src/xpcc/driver/touch/ft6x06.hpp
@@ -117,7 +117,7 @@ public:
 		// uint8_t area;
 	};
 
-	struct ATTRIBUTE_PACKED
+	struct xpcc_packed
 	Data
 	{
 		template< class I2cMaster >

--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -103,7 +103,7 @@ public:
 	}
 
 	/// set the output mode to binary style for `char` and `char*`
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	bin()
 	{
 		this->mode = Mode::Binary;
@@ -111,7 +111,7 @@ public:
 	}
 
 	/// set the output mode to hexadecimal style for `char` and `char*`
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	hex()
 	{
 		this->mode = Mode::Hexadecimal;
@@ -119,7 +119,7 @@ public:
 	}
 
 	/// set the output mode to ASCII style for `char` and `char*`
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	ascii()
 	{
 		this->mode = Mode::Ascii;
@@ -184,7 +184,7 @@ public:
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const uint16_t& v)
 	{
 		if (this->mode == Mode::Ascii) {
@@ -201,7 +201,7 @@ public:
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const int16_t& v)
 	{
 		if (this->mode == Mode::Ascii) {
@@ -218,7 +218,7 @@ public:
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const uint32_t& v)
 	{
 		if (this->mode == Mode::Ascii) {
@@ -239,7 +239,7 @@ public:
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const int32_t& v)
 	{
 		if (this->mode == Mode::Ascii) {
@@ -264,14 +264,14 @@ public:
 	// For OSX 'int64_t' is of type 'int'. Therefore there is no
 	// function here for the default type 'long int'. As 'long int' has the same
 	// width as 'int64_t' we just use a typedef here.
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const long int& v)
 	{
 		this->writeInteger(static_cast<int64_t>(v));
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const long unsigned int& v)
 	{
 		this->writeInteger(static_cast<uint64_t>(v));
@@ -283,14 +283,14 @@ public:
 	// For ARM 'int32_t' is of type 'long'. Therefore there is no
 	// function here for the default type 'int'. As 'int' has the same
 	// width as 'int32_t' we just use a typedef here.
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const int& v)
 	{
 		this->writeInteger(static_cast<int32_t>(v));
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const unsigned int& v)
 	{
 		this->writeInteger(static_cast<uint32_t>(v));
@@ -301,14 +301,14 @@ public:
 // The 64-bit types on the AVR are extremely slow and are
 // therefore excluded here
 #if !defined(XPCC__CPU_AVR)
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const uint64_t& v)
 	{
 		this->writeInteger(v);
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const int64_t& v)
 	{
 		this->writeInteger(v);
@@ -316,14 +316,14 @@ public:
 	}
 #endif
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const float& v)
 	{
 		this->writeFloat(v);
 		return *this;
 	}
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (const double& v)
 	{
 #if defined(XPCC__CPU_AVR)
@@ -353,7 +353,7 @@ public:
 	IOStream&
 	operator << (const void* p);
 
-	ALWAYS_INLINE IOStream&
+	xpcc_always_inline IOStream&
 	operator << (IOStream& (*function)(IOStream&))
 	{
 		return function(*this);

--- a/src/xpcc/io/test/io_stream_test.cpp
+++ b/src/xpcc/io/test/io_stream_test.cpp
@@ -9,7 +9,7 @@
 
 #include "io_stream_test.hpp"
 
-#include <xpcc/architecture/utils.hpp> // XPCC__ARRAY_SIZE
+#include <xpcc/architecture/utils.hpp> // XPCC_ARRAY_SIZE
 #include <stdio.h>	// snprintf
 #include <string.h>	// memset
 
@@ -492,7 +492,7 @@ IoStreamTest::testPrintf2()
 		+0.0067890
 	};
 
-	for (std::size_t ii = 0; ii < XPCC__ARRAY_SIZE(ff_testvector); ++ii)
+	for (std::size_t ii = 0; ii < XPCC_ARRAY_SIZE(ff_testvector); ++ii)
 	{
 		float ff = ff_testvector[ii];
 

--- a/src/xpcc/math/filter/fir_impl.hpp
+++ b/src/xpcc/math/filter/fir_impl.hpp
@@ -94,7 +94,7 @@ xpcc::filter::Fir<T, N, BLOCK_SIZE, ScaleFactor>::append(const T& input)
 		else printf("(%.3f)    ", taps[i]);
 	printf("\n");
 #endif // FIR_DEBUG_APPEND
-	if(likely(taps_index > 0)){
+	if(xpcc_likely(taps_index > 0)){
 		taps_index--;
 	}
 	else{

--- a/src/xpcc/math/utils/bit_operation.hpp
+++ b/src/xpcc/math/utils/bit_operation.hpp
@@ -49,7 +49,7 @@ namespace xpcc
 	 *
 	 * \ingroup	math
 	 */
-	ALWAYS_INLINE uint8_t
+	xpcc_always_inline uint8_t
 	swap(uint8_t n)
 	{
 #ifdef XPCC__CPU_AVR
@@ -71,7 +71,7 @@ namespace xpcc
 	 *
 	 * \ingroup	math
 	 */
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	swap(uint8_t& a, uint8_t& b)
 	{
 		uint8_t temp = a;
@@ -88,7 +88,7 @@ namespace xpcc
 	 *
 	 * \ingroup	math
 	 */
-	ALWAYS_INLINE uint16_t
+	xpcc_always_inline uint16_t
 	swap(uint16_t n)
 	{
 #ifdef XPCC__CPU_ARM
@@ -127,7 +127,7 @@ namespace xpcc
 	 *
 	 * \ingroup	math
 	 */
-	ALWAYS_INLINE uint32_t
+	xpcc_always_inline uint32_t
 	swap(uint32_t n)
 	{
 #ifdef XPCC__CPU_ARM
@@ -143,7 +143,7 @@ namespace xpcc
 #endif
 	}
 
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	swap(int16_t& a, int16_t& b)
 	{
 		int16_t temp = a;

--- a/src/xpcc/processing/resumable/resumable.hpp
+++ b/src/xpcc/processing/resumable/resumable.hpp
@@ -235,7 +235,7 @@ protected:
 
 	/// increases nesting level, call this in the switch statement!
 	/// @return current state before increasing nesting level
-	rf::State ALWAYS_INLINE
+	rf::State xpcc_always_inline
 	pushRf(uint_fast8_t index) const
 	{
 		return rfStateArray[index];
@@ -243,13 +243,13 @@ protected:
 
 	/// always call this before returning from the run function!
 	/// decreases nesting level
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	popRf() const
 	{}
 
 	// invalidates the parent nesting level
 	// @warning	be aware in which nesting level you call this! (before popRf()!)
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	stopRf(uint_fast8_t index)
 	{
 		rfStateArray[index] = rf::Stopped;
@@ -257,20 +257,20 @@ protected:
 
 	/// sets the state of the parent nesting level
 	/// @warning	be aware in which nesting level you call this! (before popRf()!)
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	setRf(rf::State state, uint_fast8_t index)
 	{
 		rfStateArray[index] = state;
 	}
 
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	nestingOkRf() const
 	{
 		return true;
 	}
 
 	/// @return	`true` if `stopRf()` has been called before
-	bool ALWAYS_INLINE
+	bool xpcc_always_inline
 	isStoppedRf(uint_fast8_t index) const
 	{
 		return (rfStateArray[index] == rf::Stopped);

--- a/src/xpcc/processing/scheduler/scheduler.hpp
+++ b/src/xpcc/processing/scheduler/scheduler.hpp
@@ -85,7 +85,7 @@ namespace xpcc
 		void
 		schedule();
 
-		ALWAYS_INLINE void
+		xpcc_always_inline void
 		scheduleInterupt();
 
 	private:

--- a/src/xpcc/ui/animation/interpolation.hpp
+++ b/src/xpcc/ui/animation/interpolation.hpp
@@ -236,28 +236,28 @@ public:
 	 * @param	end		the end of the ramp
 	 * @param	steps	the number of steps for the ramp.
 	 */
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	initialize(T begin, T end, StepType steps)
 	{
 		computations.initialize(begin, end, steps);
 	}
 
 	/// update the intermediate value for one step
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	step()
 	{
 		computations.step();
 	}
 
 	/// @return the intermediate value.
-	T ALWAYS_INLINE
+	T xpcc_always_inline
 	getValue()
 	{
 		return computations.get();
 	}
 
 	/// stops the interpolation.
-	void ALWAYS_INLINE
+	void xpcc_always_inline
 	stop()
 	{
 		computations.deltaValue = 0;

--- a/src/xpcc/ui/animation/key_frame.hpp
+++ b/src/xpcc/ui/animation/key_frame.hpp
@@ -39,7 +39,7 @@ struct KeyFrameBase
 	:	length(length), value{values...}
 	{
 	}
-} ATTRIBUTE_PACKED;
+} xpcc_packed;
 
 template<typename T, int remaining, typename... Args>
 struct KeyFrameHelper

--- a/src/xpcc/ui/button_group.hpp
+++ b/src/xpcc/ui/button_group.hpp
@@ -199,7 +199,7 @@ public:
 	 * @param	input
 	 * 		input signals
 	 */
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	update(T input);
 
 protected:

--- a/src/xpcc/ui/display/graphic_display.hpp
+++ b/src/xpcc/ui/display/graphic_display.hpp
@@ -50,21 +50,21 @@ namespace xpcc
 		class Color
 		{
 		public:
-			static ALWAYS_INLINE Color white()   { return Color(0xffff); };
-			static ALWAYS_INLINE Color yellow()  { return Color(0xFFE0); };
-			static ALWAYS_INLINE Color magenta() { return Color(0xF81F); };
-			static ALWAYS_INLINE Color red()     { return Color(0xF800); };
-			static ALWAYS_INLINE Color orange()  { return Color(0xFD20); };
-			static ALWAYS_INLINE Color sliver()  { return Color(0xC618); };
-			static ALWAYS_INLINE Color gray()    { return Color(0x8410); };
-			static ALWAYS_INLINE Color maroon()  { return Color(0x8000); };
-			static ALWAYS_INLINE Color lime()    { return Color(0x07E0); };
-			static ALWAYS_INLINE Color green()   { return Color(0x0400); };
-			static ALWAYS_INLINE Color blue()    { return Color(0x001F); };
-			static ALWAYS_INLINE Color navy()    { return Color(0x0010); };
-			static ALWAYS_INLINE Color black()   { return Color(0x0000); };
-			static ALWAYS_INLINE Color signalViolet()   { return Color(0x8010); }; //0x84D0
-			static ALWAYS_INLINE Color emeraldGreen()   { return Color(0x5DCC); };
+			static xpcc_always_inline Color white()   { return Color(0xffff); };
+			static xpcc_always_inline Color yellow()  { return Color(0xFFE0); };
+			static xpcc_always_inline Color magenta() { return Color(0xF81F); };
+			static xpcc_always_inline Color red()     { return Color(0xF800); };
+			static xpcc_always_inline Color orange()  { return Color(0xFD20); };
+			static xpcc_always_inline Color sliver()  { return Color(0xC618); };
+			static xpcc_always_inline Color gray()    { return Color(0x8410); };
+			static xpcc_always_inline Color maroon()  { return Color(0x8000); };
+			static xpcc_always_inline Color lime()    { return Color(0x07E0); };
+			static xpcc_always_inline Color green()   { return Color(0x0400); };
+			static xpcc_always_inline Color blue()    { return Color(0x001F); };
+			static xpcc_always_inline Color navy()    { return Color(0x0010); };
+			static xpcc_always_inline Color black()   { return Color(0x0000); };
+			static xpcc_always_inline Color signalViolet()   { return Color(0x8010); }; //0x84D0
+			static xpcc_always_inline Color emeraldGreen()   { return Color(0x5DCC); };
 
 			/**
 			 * @param	red

--- a/src/xpcc/ui/led/led.hpp
+++ b/src/xpcc/ui/led/led.hpp
@@ -48,33 +48,33 @@ namespace ui
 class Led
 {
 public:
-	ALWAYS_INLINE Led(): Led(nullptr) {}
+	xpcc_always_inline Led(): Led(nullptr) {}
 
 	/// Requires a handler function pointer for value updates.
-	ALWAYS_INLINE Led(Animation<uint8_t>::Handler handler):
+	xpcc_always_inline Led(Animation<uint8_t>::Handler handler):
 		animation(brightness, handler), brightness(0) {}
 
 	/// @param	brightness
 	///		between 0 and length of lookup-table (usually 255)
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	setBrightness(uint8_t brightness)
 	{ animation.setValue(brightness); }
 
 	/// @return brightness of the LED
-	ALWAYS_INLINE uint8_t
+	xpcc_always_inline uint8_t
 	getBrightness() const
 	{ return animation.getValue(); }
 
 	/// @return `true` if LED is currently fading to another brightness,
 	///			`false` if otherwise
-	ALWAYS_INLINE bool
+	xpcc_always_inline bool
 	isFading() const
 	{ return animation.isAnimating(); }
 
 	/// Fade from the current brightness to a new brightness in the specified ms.
 	/// Fading times of more than ~32s are not possible. You must control
 	/// fading externally in that case.
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	fadeTo(uint8_t brightness, uint16_t time)
 	{ animation.animateTo(brightness, time); }
 
@@ -84,7 +84,7 @@ public:
 	 * @param	time
 	 * 		specify the fade up time in ms, `0` to turn the LED on instantly
 	 */
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	on(uint16_t time=75)
 	{ fadeTo(255, time); }
 
@@ -94,14 +94,14 @@ public:
 	 * @param	time
 	 * 		specify the fade up time in ms, `0` to turn the LED off instantly
 	 */
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	off(uint16_t time=120)
 	{ fadeTo(0, time); }
 
 	/// Can be called at a interval of 1ms or less.
 	/// If you do not need 1ms response time (e.g. for on(), off()),
 	/// you may call this at intervals < 255ms.
-	ALWAYS_INLINE void
+	xpcc_always_inline void
 	update()
 	{ animation.update(); }
 

--- a/src/xpcc/utils/template_metaprogramming.hpp
+++ b/src/xpcc/utils/template_metaprogramming.hpp
@@ -310,7 +310,7 @@ namespace xpcc
 		#define	XPCC__STATIC_ASSERT(condition, msg) 					\
 			typedef ::xpcc::tmp::static_assert_test<					\
 				sizeof(::xpcc::tmp::STATIC_ASSERTION_FAILURE< (bool) (condition) >) >\
-					CONCAT(static_assert_typedef_, __LINE__)
+					XPCC_CONCAT(static_assert_typedef_, __LINE__)
 #	else
 		#define	XPCC__STATIC_ASSERT(condition, msg) 					\
 			static_assert(condition, msg)


### PR DESCRIPTION
As initially [discussed here](https://github.com/roboterclubaachen/xpcc/pull/104#issuecomment-193026455), the `xpcc/architecture/util.hpp` macros have been namespaced in a backwards compatible way and documented:

| Legacy | Future |
| :-- | :-- |
| `ALWAYS_INLINE` | `xpcc_always_inline` |
| `ATTRIBUTE_UNUSED` | `xpcc_unused` |
| `ATTRIBUTE_WEAK` | `xpcc_weak` |
| `ATTRIBUTE_ALIGNED(n)` | `xpcc_aligned(n)` |
| `ATTRIBUTE_PACKED` | `xpcc_packed` |
| `ATTRIBUTE_FASTCODE` | `xpcc_fastcode` |
| `ATTRIBUTE_FASTDATA` | `xpcc_fastdata` |
| `ATTRIBUTE_MAY_ALIAS` | `xpcc_may_alias` |
| `CONCAT(a,b)` | `XPCC_CONCAT(a,b)` |
| `STRINGIFY(a)` | `XPCC_STRINGIFY(a)` |
| `XPCC__ARRAY_SIZE(x)` | `XPCC_ARRAY_SIZE(x)` |
| `likely(x)` | `xpcc_likely(x)` |
| `unlikely(x)` | `xpcc_unlikely(x)` |
| `ENUM_CLASS_FLAG` | :fire: :fire: :fire: |

A new header `xpcc/architecture/legacy_macros.hpp` contains backwards compatible mappings for application code. All occuranced of the non-namespaced macros in xpcc have been replaced.
The backwards-compatible mapping can be disabled by declaring the `XPCC_DISABLE_LEGACY_MACROS` macro to the compiler.

Note that the `ENUM_CLASS_FLAG` was replace with `xpcc::Flags32` and is not completely backwards compatible (`Interrupt` vs `Interrupt_t`), but considering how phenomenally terrible it is to use, I believe no application to actually use it. (It deserves to :fire: otherwise).

cc @ekiwi @dergraaf @strongly-typed 
