### PR TITLE
[wip] xpcc error model using assertions

### DIFF
--- a/examples/avr/assert/SConstruct
+++ b/examples/avr/assert/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/avr/assert/main.cpp
+++ b/examples/avr/assert/main.cpp
@@ -1,0 +1,92 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <xpcc/architecture/platform.hpp>
+#include <avr/pgmspace.h>
+
+using xpcc::accessor::asFlash;
+
+// Flash support on avr-gcc is so horribly broken.
+#define IFS(s) asFlash(PSTR(s))
+
+#define XPCC_CAN_MODULE_NAME 		"can"
+#define XPCC_IOBUFFER_MODULE_NAME 	"iobuffer"
+#define XPCC_UART_MODULE_NAME 		"uart"
+
+extern "C" void
+xpcc_abandon(const char * module,
+			 const char * location,
+			 const char * failure)
+{
+	serialStream << IFS("Assertion '")
+			<< asFlash(module) << '.'
+			<< asFlash(location) << '.'
+			<< asFlash(failure)
+			<< IFS("' failed! Abandoning.") << xpcc::endl;
+
+	Leds::setOutput();
+	while(1) {
+		Leds::write(1);
+		xpcc::delayMilliseconds(20);
+		Leds::write(0);
+		xpcc::delayMilliseconds(180);
+	}
+}
+
+static xpcc::Abandonment
+test_assertion_handler(const char * module,
+					   const char * /* location */,
+					   const char * /* failure */)
+{
+	serialStream << IFS("#1: '") << asFlash(module) << IFS("'!") << xpcc::endl;
+	// The strings are located in FLASH!!!
+	if (strcmp_P(module, PSTR(XPCC_IOBUFFER_MODULE_NAME)) == 0)
+		return xpcc::Abandonment::Ignore;
+	return xpcc::Abandonment::DontCare;
+}
+XPCC_ASSERTION_HANDLER(test_assertion_handler);
+
+static xpcc::Abandonment
+test_assertion_handler2(const char * /* module */,
+						const char * location,
+						const char * /* failure */)
+{
+	serialStream << IFS("#2: '") << asFlash(location) << IFS("'!") << xpcc::endl;
+	return xpcc::Abandonment::DontCare;
+}
+XPCC_ASSERTION_HANDLER(test_assertion_handler2);
+
+static xpcc::Abandonment
+test_assertion_handler3(const char * /* module */,
+						const char * /* location */,
+						const char * failure)
+{
+	serialStream << IFS("#3: '") << asFlash(failure) << IFS("'!") << xpcc::endl;
+	return xpcc::Abandonment::DontCare;
+}
+XPCC_ASSERTION_HANDLER(test_assertion_handler3);
+
+// ----------------------------------------------------------------------------
+int main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	xpcc_assert(true, XPCC_CAN_MODULE_NAME, "init", "timeout");
+
+	xpcc_assert_debug(false, XPCC_IOBUFFER_MODULE_NAME, "tx", "full");
+
+	xpcc_assert(false, XPCC_UART_MODULE_NAME, "init", "mode");
+
+	while (1)
+	{
+		Led3::toggle();
+		xpcc::delayMilliseconds(500);
+	}
+}

--- a/examples/avr/assert/project.cfg
+++ b/examples/avr/assert/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = al_avreb_can
+buildpath = ${xpccpath}/build/avr/${name}

--- a/examples/linux/assert/SConstruct
+++ b/examples/linux/assert/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/linux/assert/main.cpp
+++ b/examples/linux/assert/main.cpp
@@ -1,0 +1,29 @@
+#include <xpcc/architecture/platform.hpp>
+
+#define XPCC_CAN_MODULE_NAME "can"
+#define XPCC_IOBUFFER_MODULE_NAME "iobuffer"
+#define XPCC_UART_MODULE_NAME "uart"
+
+static xpcc::Abandonment
+test_assertion_handler(const char * module,
+					   const char * location,
+					   const char * failure)
+{
+	if (strcmp(module, XPCC_IOBUFFER_MODULE_NAME) == 0)
+		return xpcc::Abandonment::Ignore;
+	return xpcc::Abandonment::DontCare;
+}
+XPCC_ASSERTION_HANDLER(test_assertion_handler);
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	xpcc_assert(true, XPCC_CAN_MODULE_NAME, "init", "timeout");
+
+	xpcc_assert_debug(false, XPCC_IOBUFFER_MODULE_NAME, "tx", "full");
+
+	xpcc_assert(false, XPCC_UART_MODULE_NAME, "init", "mode");
+
+	return 0;
+}

--- a/examples/linux/assert/project.cfg
+++ b/examples/linux/assert/project.cfg
@@ -1,0 +1,3 @@
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/linux/${name}

--- a/examples/stm32f469_discovery/assert/SConstruct
+++ b/examples/stm32f469_discovery/assert/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f469_discovery/assert/main.cpp
+++ b/examples/stm32f469_discovery/assert/main.cpp
@@ -1,0 +1,56 @@
+#include <xpcc/architecture/platform.hpp>
+
+#define XPCC_CAN_MODULE_NAME "can"
+#define XPCC_IOBUFFER_MODULE_NAME "iobuffer"
+#define XPCC_UART_MODULE_NAME "uart"
+
+using namespace Board;
+
+extern "C" void xpcc_abandon(const char * module,
+							 const char * location,
+							 const char * failure)
+{
+	XPCC_LOG_ERROR << "Assertion '"
+			<< module << "." << location << "." << failure
+			<< "' failed! Abandoning." << xpcc::endl;
+
+	LedGreen::setOutput();
+	while(1) {
+		LedBlue::set();
+		xpcc::delayMilliseconds(20);
+		LedBlue::reset();
+		xpcc::delayMilliseconds(180);
+	}
+}
+
+static xpcc::Abandonment
+test_assertion_handler(const char * module,
+					   const char * /* location */,
+					   const char * /* failure */)
+{
+	if (strcmp(module, XPCC_IOBUFFER_MODULE_NAME) == 0)
+		return xpcc::Abandonment::Ignore;
+	return xpcc::Abandonment::DontCare;
+}
+XPCC_ASSERTION_HANDLER(test_assertion_handler);
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	xpcc_assert(true, XPCC_CAN_MODULE_NAME, "init", "timeout");
+
+	xpcc_assert_debug(false, XPCC_IOBUFFER_MODULE_NAME, "tx", "full");
+
+	xpcc_assert(false, XPCC_UART_MODULE_NAME, "init", "mode");
+
+	while(1)
+	{
+		LedRed::toggle();
+		xpcc::delayMilliseconds(500);
+	}
+
+	return 0;
+}

--- a/examples/stm32f469_discovery/assert/project.cfg
+++ b/examples/stm32f469_discovery/assert/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f469_discovery
+buildpath = ${xpccpath}/build/stm32f469_discovery/${name}

--- a/scons/site_tools/avr.py
+++ b/scons/site_tools/avr.py
@@ -167,6 +167,7 @@ def generate(env, **kw):
 		"-mmcu=$AVR_DEVICE", 
 		"-Wl,--relax", 
 		"-Wl,--gc-sections",
+		"-Wl,-T,${XPCC_ROOTPATH}/src/xpcc/architecture/platform/driver/core/avr/linkerscript.ld",
 #		"-Wl,-Map=${TARGET.base}.map,--cref", 
 #		"-Wl,-u,vfprintf -lprintf_flt"		# enable float support for vfprinft
 	]

--- a/src/xpcc/architecture/interface.hpp
+++ b/src/xpcc/architecture/interface.hpp
@@ -106,5 +106,6 @@ public:
 #include "interface/i2c.hpp"
 #include "interface/register.hpp"
 #include "interface/memory.hpp"
+#include "interface/assert.hpp"
 
 #endif	// XPCC_INTERFACE_HPP

--- a/src/xpcc/architecture/interface/assert.hpp
+++ b/src/xpcc/architecture/interface/assert.hpp
@@ -1,0 +1,180 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_ASSERT_HPP
+#define XPCC_ASSERT_HPP
+
+#include <stdint.h>
+#include <xpcc/architecture/utils.hpp>
+#include <xpcc/utils/bit_constants.hpp>
+#include <xpcc/architecture/driver/accessor/flash.hpp>
+
+/**
+ * @ingroup		interface
+ * @defgroup	assert	Assertions
+ *
+ * These functions allow you to assert a condition at runtime and define
+ * failure handlers in your application that can decide what to do with this
+ * assertion and provide custom functionality.
+ *
+ * Each assertion has the form `xpcc_assert(condition, module, location, failure)`,
+ * where the condition is a boolean and rest are strings, so that a simple
+ * string compare can be used to match for module, location or failure.
+ * For example, the identifier `"can", "init", "timeout"` describes a timeout
+ * failure in the CAN initializer function.
+ * The assert `xpcc_assert_debug(condition, module, location, failure)` is only
+ * available on debug builds and is removed from the code for a release build.
+ *
+ * The user can define one or multiple assertion handlers in any part of the
+ * application using the `XPCC_ASSERTION_HANDLER(function)` macro.
+ * All assertion handlers will be executed when an assertion fails anywhere in
+ * the code and get passed the identifier string.
+ *
+ * @note The order of assertion handler execution is undefined and must not be
+ *       relied upon for any functionality!
+ * @warning Assertion handlers may be executed in interrupt context!
+ *
+ * Depending on the information in the failure identifier, the assertion handler
+ * returns `Abandonment::DontCare` if the failure is not of interest, or
+ * `Abandonment::Ignore` for recoverable failures, or `Abandonment::Fail` for
+ * failures that do not allow normal program continuation.
+ * The program is aborted, if any assertion handler returns `Abandonment::Fail`,
+ * all assertion handlers return `Abandonment::DontCare` or no assertion
+ * handlers have been defined in the application.
+ * Only if one or many assertion handlers return `Abandonment::Ignore` and the
+ * remainder returns `Abandonment::DontCare`, only then is the assertion ignored.
+ *
+ * @note It is intended that the assertion handlers do not block (forever), so
+ *       that all assertion handlers can get called.
+ *
+ * On program abandonment `xpcc_abandon(module, location, failure)` is called,
+ * which exits the program silently by default.
+ * Only on hosted an formatted error string is output by default.
+ * It is therefore recommended to overwrite this function on embedded targets
+ * for custom behavior like blinking an LED and printing to a serial connection.
+ *
+ * @warning The abandonment handler may also be executed in interrupt context!
+ *
+ * @see		driver
+ * @author	Niklas Hauser
+ */
+
+namespace xpcc
+{
+
+/// Describes abandonment type of assertions.
+/// @ingroup assert
+enum class
+Abandonment : uint8_t
+{
+	DontCare = Bit0,	///< Do not care about failure.
+	Ignore = Bit1,		///< Safe to ignore this failure.
+	Fail = Bit2			///< This failure is reason for abandonment.
+};
+
+/// Signature of the assertion handlers
+/// @ingroup assert
+using AssertionHandler = Abandonment (*)(const char * module,
+										 const char * location,
+					 					 const char * failure);
+
+} // namespace xpcc
+
+#ifdef __DOXYGEN__
+
+/**
+ * This adds a function to the list of assertion handlers to execute on
+ * assertion failure. Note that this macro does not give you any influence
+ * over the order of handler execution on assertion failure.
+ * Do not write assertion handlers that depend on any ordered execution!
+ *
+ * @warning On AVR targets the failure identifier resides in Flash memory!
+ *
+ * @param handler A function of signature `AssertionHandler`.
+ *
+ * @ingroup assert
+ */
+#define XPCC_ASSERTION_HANDLER(handler)
+
+/**
+ * Assert a condition to be true with failure identifier.
+ * This assert is always included in the source code.
+ *
+ * @note On AVR targets the failure identifier string is placed in Flash memory!
+ *
+ * @ingroup assert
+ */
+#define xpcc_assert(condition, module, location, failure)
+
+/**
+ * Assert a condition to be true with failure identifier.
+ * This assert is only included in the source code on debug builds!
+ *
+ * @note On AVR targets the strings are placed in Flash memory!
+ *
+ * @ingroup assert
+ */
+#define xpcc_assert_debug(condition, module, location, failure)
+
+/**
+ * Overwriteable abandonment handler for all targets.
+ *
+ * You should overwrite this handler for custom failure behaviour like blinking
+ * LEDs and outputting the failure string via a serial connection.
+ *
+ * @ingroup assert
+ */
+extern "C" void
+xpcc_abandon(const char * module,
+			 const char * location,
+			 const char * failure) xpcc_weak;
+
+#else
+
+#if defined XPCC__CPU_ARM || defined XPCC__CPU_AVR
+#	define XPCC_ASSERTION_LINKER_SECTION ".assertion"
+#elif defined XPCC__OS_OSX
+#	define XPCC_ASSERTION_LINKER_SECTION "__DATA,xpcc_assertion"
+#elif defined XPCC__OS_LINUX
+#	define XPCC_ASSERTION_LINKER_SECTION "xpcc_assertion"
+#endif
+
+#ifdef XPCC_ASSERTION_LINKER_SECTION
+#	define XPCC_ASSERTION_HANDLER(handler) \
+		__attribute__((section(XPCC_ASSERTION_LINKER_SECTION), used)) \
+		const xpcc::AssertionHandler \
+		handler ## _assertion_handler_ptr = handler
+#else
+#	define XPCC_ASSERTION_HANDLER(handler)
+#endif
+
+#define xpcc_assert(condition, module, location, failure) \
+	xpcc_assert_evaluate((condition), INLINE_FLASH_STORAGE_STRING(module "\0" location "\0" failure));
+
+#ifndef NDEBUG
+#	define xpcc_assert_debug(condition, module, location, failure) \
+		xpcc_assert(condition, module, location, failure)
+#	define XPCC_ASSERTION_HANDLER_DEBUG(handler) \
+		XPCC_ASSERTION_HANDLER(handler)
+#else
+#	define xpcc_assert_debug(condition, module, location, failure)
+#	define XPCC_ASSERTION_HANDLER_DEBUG(handler)
+#endif
+
+extern "C" {
+
+void xpcc_assert_evaluate(bool condition, const char * identifier);
+
+void xpcc_abandon(const char * module, const char * location, const char * failure);
+
+}
+
+#endif // __DOXYGEN__
+
+#endif // XPCC_ASSERT_HPP

--- a/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can.hpp
+++ b/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can.hpp
@@ -1,0 +1,73 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+// AVR AT90CAN128 breakout board AL-AVREB_CAN
+// https://www.alvidi.de/products/DE/AVR_Entwicklungsboards/avr_modul_avreb_can.php
+// Tested with 16MHz external crystal
+
+#ifndef XPCC_AL_AVREB_CAN_HPP
+#define XPCC_AL_AVREB_CAN_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+
+using namespace xpcc::at90;
+
+namespace Board
+{
+
+using systemClock = xpcc::avr::SystemClock;
+
+// Arduino Footprint
+using Led0 = xpcc::GpioInverted<GpioOutputF0>;
+using Led1 = xpcc::GpioInverted<GpioOutputF1>;
+using Led2 = xpcc::GpioInverted<GpioOutputF2>;
+using Led3 = xpcc::GpioInverted<GpioOutputF3>;
+
+using Button = xpcc::GpioUnused;
+using Leds = xpcc::SoftwareGpioPort< Led3, Led2, Led1, Led0 >;
+
+
+inline void
+initialize()
+{
+	systemClock::enable();
+
+	GpioD2::connect(Uart1::Rx);
+	GpioD3::connect(Uart1::Tx);
+	Uart1::initialize<systemClock, 38400>();
+
+	// xpcc::Clock initialization
+	// Clear Timer on Compare Match Mode
+	TCCR0A = (1 << WGM01);
+	TIMSK0 = (1 << OCIE0A);
+#if F_CPU > 16000000
+	// Set and enable output compare A
+	OCR0A = F_CPU / (1000ul * 256);
+	// Set prescaler 256 and enable timer
+	TCCR0A = (1 << CS02);
+#elif F_CPU > 2000000
+	// Set and enable output compare A
+	OCR0A = F_CPU / (1000ul * 64);
+	// Set prescaler 64 and enable timer
+	TCCR0A = (1 << CS01) | (1 << CS00);
+#elif F_CPU > 1000000
+	// Set and enable output compare A
+	OCR0A = F_CPU / (1000ul * 8);
+	// Set prescaler 8 and enable timer
+	TCCR0A = (1 << CS01);
+#endif
+
+	enableInterrupts();
+}
+
+}
+
+using namespace Board;
+extern xpcc::IOStream serialStream;
+
+#endif	// XPCC_ARDUINO_UNO_HPP

--- a/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can_clock.cpp
+++ b/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can_clock.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "al_avreb_can.hpp"
+#include <xpcc/architecture/driver/clock.hpp>
+
+ISR(TIMER0_COMP_vect)
+{
+	xpcc::Clock::increment();
+}

--- a/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can_serial.cpp
+++ b/src/xpcc/architecture/platform/board/al_avreb_can/al_avreb_can_serial.cpp
@@ -1,0 +1,11 @@
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "al_avreb_can.hpp"
+
+xpcc::IODeviceWrapper< Uart1, xpcc::IOBuffer::BlockIfFull > serialDevice;
+xpcc::IOStream serialStream(serialDevice);

--- a/src/xpcc/architecture/platform/board/al_avreb_can/board.cfg
+++ b/src/xpcc/architecture/platform/board/al_avreb_can/board.cfg
@@ -1,0 +1,12 @@
+[build]
+device = at90can128
+clock = 16000000
+
+[avrdude]
+port = usb
+programmer = avrispmkII
+
+[fusebits]
+efuse = 0xff
+hfuse = 0xd9
+lfuse = 0xfe

--- a/src/xpcc/architecture/platform/devices/hosted/darwin.xml
+++ b/src/xpcc/architecture/platform/devices/hosted/darwin.xml
@@ -5,6 +5,7 @@
     <naming-schema>{{ platform }}/{{ family }}</naming-schema>
     <driver type="can" name="hosted"/>
     <driver type="can" name="canusb"/>
+    <driver type="core" name="hosted"/>
     <driver type="uart" name="hosted"/>
     <driver type="uart" name="posix"/>
   </device>

--- a/src/xpcc/architecture/platform/devices/hosted/linux.xml
+++ b/src/xpcc/architecture/platform/devices/hosted/linux.xml
@@ -5,6 +5,7 @@
     <naming-schema>{{ platform }}/{{ family }}</naming-schema>
     <driver type="can" name="socketcan"/>
     <driver type="can" name="canusb"/>
+    <driver type="core" name="hosted"/>
     <driver type="graphics" name="hosted"/>
     <driver type="uart" name="hosted"/>
     <driver type="uart" name="posix"/>

--- a/src/xpcc/architecture/platform/driver/core/avr/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/avr/assert.cpp
@@ -1,0 +1,52 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <xpcc/architecture/interface/assert.hpp>
+#include <stdlib.h>
+#include <string.h>
+#include <avr/pgmspace.h>
+
+using xpcc::AssertionHandler;
+using xpcc::Abandonment;
+
+extern AssertionHandler __assertion_table_start;
+extern AssertionHandler __assertion_table_end;
+
+extern "C"
+{
+
+void xpcc_assert_evaluate(bool condition, const char * identifier)
+{
+	if (!condition)
+	{
+		uint8_t state(uint8_t(Abandonment::DontCare));
+		const char * module = identifier;
+		const char * location = module + strlen_P(module) + 1;
+		const char * failure = location + strlen_P(location) + 1;
+
+		AssertionHandler * table_addr = &__assertion_table_start;
+		for (; table_addr < &__assertion_table_end; table_addr++)
+		{
+			AssertionHandler handler = (AssertionHandler) pgm_read_word(table_addr);
+			state |= (uint8_t) handler(module, location, failure);
+		}
+
+		if (state == (uint8_t) Abandonment::DontCare or
+			state & (uint8_t) Abandonment::Fail)
+		{
+			xpcc_abandon(module, location, failure);
+			exit(1);
+		}
+	}
+}
+
+void xpcc_abandon(const char *, const char *, const char *) __attribute__((weak));
+void xpcc_abandon(const char *, const char *, const char *) {}
+
+}

--- a/src/xpcc/architecture/platform/driver/core/avr/driver.xml
+++ b/src/xpcc/architecture/platform/driver/core/avr/driver.xml
@@ -6,6 +6,7 @@
 		<static>newdelete.cpp</static>
 		<static>ram.hpp</static>
 		<static>main.hpp</static>
+		<static>assert.cpp</static>
 		<static device-family="xmega">utils.hpp</static>
 		<static device-family="xmega">utils.cpp</static>
 		<template>ram.cpp.in</template>

--- a/src/xpcc/architecture/platform/driver/core/avr/linkerscript.ld
+++ b/src/xpcc/architecture/platform/driver/core/avr/linkerscript.ld
@@ -1,0 +1,13 @@
+SECTIONS
+{
+	.xpcc_assertion : AT( ADDR(.text) + SIZEOF(.text) + SIZEOF(.data))
+	{
+		. = ALIGN(2);
+		__assertion_table_start = . + SIZEOF(.data);
+
+		KEEP(*(.assertion))
+
+		__assertion_table_end = . + SIZEOF(.data);
+	}
+}
+INSERT AFTER .data

--- a/src/xpcc/architecture/platform/driver/core/cortex/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/cortex/assert.cpp
@@ -1,0 +1,50 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <xpcc/architecture/interface/assert.hpp>
+
+extern "C" void exit(int);
+
+using xpcc::AssertionHandler;
+using xpcc::Abandonment;
+
+extern AssertionHandler __assertion_table_start;
+extern AssertionHandler __assertion_table_end;
+
+extern "C"
+{
+
+void xpcc_assert_evaluate(bool condition, const char * identifier)
+{
+	if (!condition)
+	{
+		uint8_t state(uint8_t(Abandonment::DontCare));
+		const char * module = identifier;
+		const char * location = module + strlen(module) + 1;
+		const char * failure = location + strlen(location) + 1;
+
+		AssertionHandler * handler = &__assertion_table_start;
+		for (; handler < &__assertion_table_end; handler++)
+		{
+			state |= (uint8_t) (*handler)(module, location, failure);
+		}
+
+		if (state == (uint8_t) Abandonment::DontCare or
+			state & (uint8_t) Abandonment::Fail)
+		{
+			xpcc_abandon(module, location, failure);
+			exit(1);
+		}
+	}
+}
+
+void xpcc_abandon(const char *, const char *, const char *) __attribute__((weak));
+void xpcc_abandon(const char *, const char *, const char *) {}
+
+}

--- a/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
+++ b/src/xpcc/architecture/platform/driver/core/cortex/driver.xml
@@ -39,6 +39,7 @@
 		<!-- stm32f7 -->
 		<template device-family="f7" out="linkerscript.ld">linkerscript/stm32_idtcm.ld.in</template>
 
+		<static>assert.cpp</static>
 		<!-- dealing with C++ -->
 		<static>cxxabi.cpp</static>
 		<!-- dealing with newlib -->

--- a/src/xpcc/architecture/platform/driver/core/cortex/linkerscript/linker.macros
+++ b/src/xpcc/architecture/platform/driver/core/cortex/linkerscript/linker.macros
@@ -308,6 +308,14 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		KEEP(*(.eh_frame*))
 	} >{{memory}}
 	 */
+
+	/* Assertion handler table */
+	.assertion : ALIGN(4)
+	{
+		__assertion_table_start = .;
+		KEEP(*(.assertion))
+		__assertion_table_end = .;
+	}
 %% endmacro
 
 

--- a/src/xpcc/architecture/platform/driver/core/hosted/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/hosted/assert.cpp
@@ -1,0 +1,60 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <stdlib.h>
+#include <xpcc/debug/logger.hpp>
+#include <xpcc/architecture/interface/assert.hpp>
+
+using xpcc::AssertionHandler;
+using xpcc::Abandonment;
+
+#ifdef XPCC__OS_OSX
+extern AssertionHandler __assertion_table_start __asm("section$start$__DATA$xpcc_assertion");
+extern AssertionHandler __assertion_table_end __asm("section$end$__DATA$xpcc_assertion");
+#else
+extern AssertionHandler __assertion_table_start __asm("__start_xpcc_assertion");
+extern AssertionHandler __assertion_table_end __asm("__stop_xpcc_assertion");
+#endif
+
+extern "C"
+{
+
+void xpcc_assert_evaluate(bool condition, const char * identifier)
+{
+	if (!condition)
+	{
+		uint8_t state((uint8_t) Abandonment::DontCare);
+		const char * module = identifier;
+		const char * location = module + strlen(module) + 1;
+		const char * failure = location + strlen(location) + 1;
+
+		AssertionHandler * handler = &__assertion_table_start;
+		for (; handler < &__assertion_table_end; handler++)
+		{
+			state |= (uint8_t) (*handler)(module, location, failure);
+		}
+
+		if (state == (uint8_t) Abandonment::DontCare or
+			state & (uint8_t) Abandonment::Fail)
+		{
+			xpcc_abandon(module, location, failure);
+			exit(1);
+		}
+	}
+}
+
+void xpcc_abandon(const char * module, const char * location, const char * failure) __attribute__((weak));
+void xpcc_abandon(const char * module, const char * location, const char * failure)
+{
+	XPCC_LOG_ERROR << "Assertion '"
+			<< module << "." << location << "." << failure
+			<< "' failed! Abandoning." << xpcc::endl;
+}
+
+}


### PR DESCRIPTION
I'm working on adding a universal error model to xpcc via assertions that can be modified by the user application.

The principle is [described here in detail](https://gist.github.com/salkinium/66df1d7d3c5d3927690a722a5f880ae0) and was inspired by trying to find a solution to #114.

Note that this is very much WIP, and none of the interfaces are finalized. I plan to write a blog post about this for additional concept documentation.
I made the decision to have three fields, so that people are not tempted just to put a human readable string in there, which would defeat the purpose of the handlers.

Also [see this alternate implementation](https://github.com/salkinium/xpcc/commit/2fc66fddf38f6c8c8efa263c4a1e4fdd45bc3564) with binary errors. It's not very useful.

cc @ekiwi @dergraaf @strongly-typed 
