### PR TITLE
[scons] Link against newlib-nano.

### DIFF
--- a/scons/site_tools/arm.py
+++ b/scons/site_tools/arm.py
@@ -207,6 +207,7 @@ def generate(env, **kw):
 		"-Wl,-wrap,_calloc_r",
 		"-Wl,-wrap,_realloc_r",
 		"-Wl,-wrap,_free_r",
+		"--specs=nano.specs",
 		"-nostartfiles",
 		"-L$LINKPATH",
 		"-T$LINKFILE",


### PR DESCRIPTION
This saves up to 2kB of static data and ~1.5kB of code.

Closes #126.
