### PR TITLE
[DFG] Disable size_id only for AVR and not for STM32

### DIFF
--- a/tools/device_file_generator/dfg/avr/avr_writer.py
+++ b/tools/device_file_generator/dfg/avr/avr_writer.py
@@ -19,6 +19,8 @@ class AVRDeviceWriter(XMLDeviceWriter):
 	"""
 	def __init__(self, device, logger=None):
 		XMLDeviceWriter.__init__(self, device, logger)
+		
+		self.root.removeAttribute('size_id')
 
 		self.log.info(("Generating Device File for '%s'." % self.device.ids.string))
 

--- a/tools/device_file_generator/dfg/writer.py
+++ b/tools/device_file_generator/dfg/writer.py
@@ -36,7 +36,7 @@ class XMLDeviceWriter:
 		props = {p : props[p] for p in props if props[p] != None}
 		self.root = self.tree.addChild('device')
 		# Force an order onto a dictionary in the most stupid way I could think of
-		for name in ['platform', 'family', 'name', 'pin_id', 'type']:
+		for name in ['platform', 'family', 'name', 'pin_id', 'size_id', 'type']:
 			if name in props:
 				self.root.setAttribute(name, props[name])
 
@@ -89,6 +89,12 @@ class XMLElement:
 
 	def setAttribute(self, key, value):
 		self.root.set(key, str(value))
+	
+	def removeAttribute(self, key):
+		try:
+			del self.root.attrib[key]
+		except KeyError:
+			pass
 
 	def addChild(self, name):
 		element = XMLElement()


### PR DESCRIPTION
The previous PR disabled size_id in the general writer class which disabled it for AVR and STM32. This PR re-enables it in the base writer and removes it only for the AVR writer class.
