### PR TITLE
Add unified interrupt declaration conventions

### DIFF
--- a/examples/avr/can/mcp2515_uart/main.cpp
+++ b/examples/avr/can/mcp2515_uart/main.cpp
@@ -40,7 +40,7 @@ FLASH_STORAGE(uint8_t canFilter[]) =
 Uart0 uart;
 
 // timer interrupt routine
-ISR(TIMER2_COMPA_vect)
+XPCC_ISR(TIMER2_COMPA)
 {
 	xpcc::Clock::increment();
 }

--- a/examples/avr/display/dogm128/benchmark/main.cpp
+++ b/examples/avr/display/dogm128/benchmark/main.cpp
@@ -34,7 +34,7 @@ xpcc::DogM128< lcd::SPI, lcd::Cs, lcd::A0, lcd::Reset, true > display;
 using namespace xpcc::glcd;
 
 // timer interrupt routine
-ISR(TIMER2_COMPA_vect)
+XPCC_ISR(TIMER2_COMPA)
 {
 	xpcc::Clock::increment();
 }

--- a/examples/avr/gpio/button_group/main.cpp
+++ b/examples/avr/gpio/button_group/main.cpp
@@ -14,7 +14,7 @@ typedef GpioOutputB0 Led;
 typedef GpioInputB3 Button;
 
 // Timer interrupt used to query the button status
-ISR(TIMER2_COMPA_vect)
+XPCC_ISR(TIMER2_COMPA)
 {
 	buttons.update(Button::read() ? BUTTON_1 : 0);
 }

--- a/examples/avr/protothread/main.cpp
+++ b/examples/avr/protothread/main.cpp
@@ -83,7 +83,7 @@ private:
 };
 
 // timer interrupt routine
-ISR(TIMER2_COMPA_vect)
+XPCC_ISR(TIMER2_COMPA)
 {
 	xpcc::Clock::increment();
 }

--- a/examples/avr/timeout/main.cpp
+++ b/examples/avr/timeout/main.cpp
@@ -8,7 +8,7 @@ using namespace xpcc::atmega;
 typedef GpioOutputB0 Led;
 
 // timer interrupt routine
-ISR(TIMER2_COMPA_vect)
+XPCC_ISR(TIMER2_COMPA)
 {
 	xpcc::Clock::increment();
 }

--- a/examples/stm32f3_discovery/adc/interrupt/main.cpp
+++ b/examples/stm32f3_discovery/adc/interrupt/main.cpp
@@ -57,8 +57,7 @@ main()
 }
 
 
-extern "C" void
-ADC4_IRQHandler(void)
+XPCC_ISR(ADC4)
 {
 	if (Adc4::getInterruptFlags() & Adc4::InterruptFlag::EndOfRegularConversion) {
 		Adc4::acknowledgeInterruptFlag(Adc4::InterruptFlag::EndOfRegularConversion);

--- a/examples/stm32f3_discovery/uart/hal/main.cpp
+++ b/examples/stm32f3_discovery/uart/hal/main.cpp
@@ -21,8 +21,7 @@ main()
 }
 
 // Interrupt Handler
-extern "C" void
-USART2_IRQHandler(void)
+XPCC_ISR(USART2)
 {
 	UsartHal2::getInterruptFlags();
 	if(UsartHal2::isTransmitRegisterEmpty()) {

--- a/examples/stm32f4_discovery/exti/main.cpp
+++ b/examples/stm32f4_discovery/exti/main.cpp
@@ -16,16 +16,15 @@ typedef GpioInputE11 Irq;
 
 /* When you choose a different pin you must choose the corresponding
  * interrupt handler: (x in A, B, C, D, E, F, G, H, I)
- * Px0:          EXTI0_IRQHandler(void)
- * Px1:          EXTI1_IRQHandler(void)
- * Px2:          EXTI2_IRQHandler(void)
- * Px3:          EXTI3_IRQHandler(void)
- * Px4:          EXTI4_IRQHandler(void)
- * Px5  to Px9:  EXTI9_5_IRQHandler(void)
- * Px10 to Px15: EXTI15_10_IRQHandler(void)
+ * Px0:          EXTI0
+ * Px1:          EXTI1
+ * Px2:          EXTI2
+ * Px3:          EXTI3
+ * Px4:          EXTI4
+ * Px5  to Px9:  EXTI9_5
+ * Px10 to Px15: EXTI15_10
  */
-extern "C" void
-EXTI0_IRQHandler(void)
+XPCC_ISR(EXTI0)
 {
 	Button::acknowledgeExternalInterruptFlag();
 	LedBlue::set();
@@ -34,8 +33,7 @@ EXTI0_IRQHandler(void)
 }
 
 
-extern "C" void
-EXTI15_10_IRQHandler(void)
+XPCC_ISR(EXTI15_10)
 {
 	Irq::acknowledgeExternalInterruptFlag();
 	LedOrange::set();

--- a/examples/stm32f4_discovery/timer_test/main.cpp
+++ b/examples/stm32f4_discovery/timer_test/main.cpp
@@ -235,49 +235,37 @@ main()
     return 0;
 }
 
-extern "C"
-void
-TIM2_IRQHandler(void)
+XPCC_ISR(TIM2)
 {
     xpcc::stm32::Timer2::acknowledgeInterruptFlags(xpcc::stm32::Timer2::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
-extern "C"
-void
-TIM3_IRQHandler(void)
+XPCC_ISR(TIM3)
 {
     xpcc::stm32::Timer3::acknowledgeInterruptFlags(xpcc::stm32::Timer3::InterruptFlag::Update);
     LedRed::toggle();
 }
 
-extern "C"
-void
-TIM4_IRQHandler(void)
+XPCC_ISR(TIM4)
 {
     xpcc::stm32::Timer4::acknowledgeInterruptFlags(xpcc::stm32::Timer4::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
-extern "C"
-void
-TIM5_IRQHandler(void)
+XPCC_ISR(TIM5)
 {
     xpcc::stm32::Timer5::acknowledgeInterruptFlags(xpcc::stm32::Timer5::InterruptFlag::Update);
     LedRed::toggle();
 }
 
-extern "C"
-void
-TIM6_DAC_IRQHandler(void)
+XPCC_ISR(TIM6_DAC)
 {
     xpcc::stm32::Timer6::acknowledgeInterruptFlags(xpcc::stm32::Timer6::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
-extern "C"
-void
-TIM7_IRQHandler(void)
+XPCC_ISR(TIM7)
 {
     xpcc::stm32::Timer7::acknowledgeInterruptFlags(xpcc::stm32::Timer7::InterruptFlag::Update);
     LedRed::toggle();
@@ -285,52 +273,40 @@ TIM7_IRQHandler(void)
 
 // For TIM8 See TIM13
 
-extern "C"
-void
-TIM1_BRK_TIM9_IRQHandler(void)
+XPCC_ISR(TIM1_BRK_TIM9)
 {
     xpcc::stm32::Timer9::acknowledgeInterruptFlags(xpcc::stm32::Timer9::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
 // Timer 1 and 10
-extern "C"
-void
-TIM1_UP_TIM10_IRQHandler(void)
+XPCC_ISR(TIM1_UP_TIM10)
 {
     xpcc::stm32::Timer1::acknowledgeInterruptFlags(xpcc::stm32::Timer1::InterruptFlag::Update);
     xpcc::stm32::Timer10::acknowledgeInterruptFlags(xpcc::stm32::Timer10::InterruptFlag::Update);
     LedRed::toggle();
 }
 
-extern "C"
-void
-TIM1_TRG_COM_TIM11_IRQHandler(void)
+XPCC_ISR(TIM1_TRG_COM_TIM11)
 {
     xpcc::stm32::Timer11::acknowledgeInterruptFlags(xpcc::stm32::Timer11::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
-extern "C"
-void
-TIM8_BRK_TIM12_IRQHandler(void)
+XPCC_ISR(TIM8_BRK_TIM12)
 {
     xpcc::stm32::Timer12::acknowledgeInterruptFlags(xpcc::stm32::Timer12::InterruptFlag::Update);
     LedRed::toggle();
 }
 
-extern "C"
-void
-TIM8_UP_TIM13_IRQHandler(void)
+XPCC_ISR(TIM8_UP_TIM13)
 {
     xpcc::stm32::Timer8::acknowledgeInterruptFlags(xpcc::stm32::Timer8::InterruptFlag::Update);
     xpcc::stm32::Timer13::acknowledgeInterruptFlags(xpcc::stm32::Timer13::InterruptFlag::Update);
     LedGreen::toggle();
 }
 
-extern "C"
-void
-TIM8_TRG_COM_TIM14_IRQHandler(void)
+XPCC_ISR(TIM8_TRG_COM_TIM14)
 {
     xpcc::stm32::Timer14::acknowledgeInterruptFlags(xpcc::stm32::Timer14::InterruptFlag::Update);
     LedRed::toggle();

--- a/src/xpcc/architecture/interface.hpp
+++ b/src/xpcc/architecture/interface.hpp
@@ -107,5 +107,6 @@ public:
 #include "interface/register.hpp"
 #include "interface/memory.hpp"
 #include "interface/assert.hpp"
+#include "interface/interrupt.hpp"
 
 #endif	// XPCC_INTERFACE_HPP

--- a/src/xpcc/architecture/interface/interrupt.hpp
+++ b/src/xpcc/architecture/interface/interrupt.hpp
@@ -1,0 +1,131 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_INTERRUPT_HPP
+#define XPCC_INTERRUPT_HPP
+
+#include <stdint.h>
+#include <xpcc/architecture/utils.hpp>
+
+#ifdef __DOXYGEN__
+
+/**
+ * Get the expanded interrupt name.
+ *
+ * On AVRs this maps to `{vector}_vect`.
+ * On Cortex-M this maps to `{vector}_IRQHandler`.
+ * On Hosted this maps to `{vector}_isr`.
+ * @warning These mappings are internal and can change without notice!
+ *
+ * @warning
+ * The CMSIS header files may define a macro with an identical name as an
+ * interrupt vector, such as `XPCC_ISR_NAME(ADC)` vs. the `ADC` peripheral.
+ * When defining interrupt vectors for compatibility, you MUST use this macro
+ * instead of manually defining it!
+ * @code
+ * #define               ADC                  ADC_CAN_TX  // will not compile!
+ * #define XPCC_ISR_NAME(ADC)   XPCC_ISR_NAME(ADC_CAN_TX) // will     compile
+ * XPCC_ISR(ADC) {...}
+ * @endcode
+ *
+ * @param vector
+ *        The name of the interrupt without any suffix (neither `_vect`, nor `_IRQHandler`).
+ *
+ * @ingroup	platform
+ */
+#define XPCC_ISR_NAME(vector)
+
+/**
+ * Forward declare in interrupt function.
+ *
+ * This maps to `extern void XPCC_ISR_NAME({vector})(void)`.
+ * `extern "C"` is used automatically in a C++ environment.
+ *
+ * @param vector
+ *        The name of the interrupt without any suffix (neither `_vect`, nor `_IRQHandler`).
+ *
+ * @ingroup	platform
+ */
+#define XPCC_ISR_DECL(vector)
+
+/**
+ * Directly calls an interrupt function.
+ *
+ * This maps to `XPCC_ISR_NAME({vector})()`.
+ * @note You may have to forward declare the interrupt using `XPCC_ISR_DECL({vector})`.
+ *
+ * @param vector
+ *        The name of the interrupt without any suffix (neither `_vect`, nor `_IRQHandler`).
+ *
+ * @ingroup	platform
+ */
+#define XPCC_ISR_CALL(vector)
+
+/**
+ * Declare an interrupt handler.
+ *
+ * This macro allows the declaration of interrupt handlers using the name
+ * declared in the datasheet in C or C++ code on any platform.
+ *
+ * On AVRs this maps to `ISR(XPCC_ISR_NAME({vector}), args)`.
+ * On Cortex-M and Hosted this maps to `void XPCC_ISR_NAME({vector})(void) args`.
+ * `extern "C"` is automatically added in a C++ environment.
+ *
+ * @param vector
+ *        The name of the interrupt without any suffix (neither `_vect`, nor `_IRQHandler`).
+ * @param ...
+ *        Multiple compiler attributes can be added to an interrupt. For example `xpcc_fastcode`.
+ *
+ * @ingroup	platform
+ */
+#define XPCC_ISR(vector, ...)
+
+#else
+
+#ifdef XPCC__CPU_AVR
+
+#	define XPCC_ISR_NAME(vector) \
+		vector ## _vect
+#	define XPCC_ISR_DECL(vector) \
+		xpcc_extern_c void vector ## _vect(void)
+#	define XPCC_ISR_CALL(vector) \
+		vector ## _vect()
+#	define XPCC_ISR(vector, ...) \
+		ISR( vector ## _vect, ##__VA_ARGS__)
+
+#elif defined XPCC__CPU_ARM
+
+#	define XPCC_ISR_NAME(vector) \
+		vector ## _IRQHandler
+#	define XPCC_ISR_DECL(vector) \
+		xpcc_extern_c void vector ## _IRQHandler(void)
+#	define XPCC_ISR_CALL(vector) \
+		vector ## _IRQHandler()
+#	define XPCC_ISR(vector, ...) \
+		xpcc_extern_c void vector ## _IRQHandler(void) \
+			__attribute__((externally_visible)) __VA_ARGS__; \
+		void vector ## _IRQHandler(void)
+
+#else
+
+#	define XPCC_ISR_NAME(vector) \
+		vector ## _isr
+#	define XPCC_ISR_DECL(vector) \
+		xpcc_extern_c void vector ## _isr(void)
+#	define XPCC_ISR_CALL(vector) \
+		vector ## _isr()
+#	define XPCC_ISR(vector, ...) \
+		xpcc_extern_c void vector ## _isr(void) __VA_ARGS__; \
+		void vector ## _isr(void)
+
+#endif
+
+#endif // __DOXYGEN__
+
+#endif // XPCC_INTERRUPT_HPP

--- a/src/xpcc/architecture/platform/board/arduino_uno/arduino_uno_clock.cpp
+++ b/src/xpcc/architecture/platform/board/arduino_uno/arduino_uno_clock.cpp
@@ -12,7 +12,7 @@
 #include "arduino_uno.hpp"
 #include <xpcc/architecture/driver/clock.hpp>
 
-ISR(TIMER0_COMPA_vect)
+XPCC_ISR(TIMER0_COMPA)
 {
 	xpcc::Clock::increment();
 }

--- a/src/xpcc/architecture/platform/driver/adc/at90_tiny_mega/adc_interrupt.cpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/at90_tiny_mega/adc_interrupt.cpp.in
@@ -15,7 +15,7 @@ xpcc::{{ target.family }}::AdcInterrupt::Handler
 xpcc::{{ target.family }}::AdcInterrupt::handler(xpcc::dummy);
 
 // ----------------------------------------------------------------------------
-ISR(ADC_vect, xpcc_weak)
+XPCC_ISR(ADC, xpcc_weak)
 {
 	xpcc::{{ target.family }}::AdcInterrupt::handler();
 }

--- a/src/xpcc/architecture/platform/driver/adc/stm32/adc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32/adc.hpp.in
@@ -326,8 +326,8 @@ public:
 	 * Enables the ADC Conversion Complete Interrupt.
 	 *
 	 * You could catch the interrupt using this example function:
-	 * @li for STM32F4XX: `extern "C" void ADC_IRQHandler()`
-	 * @li for STM32F10X: `extern "C" void ADC1_2_IRQHandler()`
+	 * @li for STM32F4XX: `XPCC_ISR(ADC)`
+	 * @li for STM32F10X: `XPCC_ISR(ADC1_2)`
 	 *
 	 * @pre The ADC clock must be started and the ADC switched on with
 	 * 	initialize(). Also the Interrupt Vector needs to be enabled first.

--- a/src/xpcc/architecture/platform/driver/adc/stm32/adc_interrupts.cpp
+++ b/src/xpcc/architecture/platform/driver/adc/stm32/adc_interrupts.cpp
@@ -20,8 +20,8 @@
 #	include "adc_interrupt_3.hpp"
 #endif
 
-extern "C" void
-ADC_IRQHandler(void)
+
+XPCC_ISR(ADC, xpcc_fastcode)
 {
 
 #ifdef ADC1

--- a/src/xpcc/architecture/platform/driver/can/lpc/c_can.cpp
+++ b/src/xpcc/architecture/platform/driver/can/lpc/c_can.cpp
@@ -236,8 +236,7 @@ xpcc::lpc::Can::CAN_error(uint32_t /* error_info */)
 /*	CAN interrupt handler */
 /*	The CAN interrupt handler must be provided by the user application.
 	It's function is to call the isr() API located in the ROM */
-extern "C" void
-CAN_IRQHandler(void) {
+XPCC_ISR(CAN) {
 	LPC11C_ROM_CAN->pCAND->isr();
 }
 

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
@@ -27,10 +27,10 @@
 #define CAN_BTR_TS1_POS		16
 
 %% if target is stm32f3
-#	define	CAN1_TX_IRQHandler		USB_HP_CAN1_TX_IRQHandler
-#	define	CAN1_RX0_IRQHandler		USB_LP_CAN1_RX0_IRQHandler
-#	define	CAN1_TX_IRQn			USB_HP_CAN1_TX_IRQn
-#	define	CAN1_RX0_IRQn			USB_LP_CAN1_RX0_IRQn
+#	define	XPCC_ISR_NAME(CAN1_TX)		XPCC_ISR_NAME(USB_HP_CAN1_TX)
+#	define	XPCC_ISR_NAME(CAN1_RX0)		XPCC_ISR_NAME(USB_LP_CAN1_RX0)
+#	define	CAN1_TX_IRQn				USB_HP_CAN1_TX_IRQn
+#	define	CAN1_RX0_IRQn				USB_LP_CAN1_RX0_IRQn
 %% endif
 
 // ----------------------------------------------------------------------------
@@ -207,8 +207,8 @@ readMailbox(xpcc::can::Message& message, uint32_t mailboxId)
  *
  * Generated when Transmit Mailbox 0..2 becomes empty.
  */
-extern "C" void
-{{ reg }}_TX_IRQHandler()
+
+XPCC_ISR({{ reg }}_TX)
 {
 %% if parameters.tx_buffer > 0
 	uint32_t mailbox;
@@ -241,8 +241,7 @@ extern "C" void
  * Generated on a new received message, FIFO0 full condition and Overrun
  * Condition.
  */
-extern "C" void
-{{ reg }}_RX0_IRQHandler()
+XPCC_ISR({{ reg }}_RX0)
 {
 	if ({{ reg }}->RF0R & CAN_RF0R_FOVR0) {
 		xpcc::ErrorReport::report(xpcc::stm32::CAN{{ id }}_FIFO0_OVERFLOW);
@@ -269,8 +268,7 @@ extern "C" void
  *
  * See FIFO0 Interrupt
  */
-extern "C" void
-{{ reg }}_RX1_IRQHandler()
+XPCC_ISR({{ reg }}_RX1)
 {
 	if ({{ reg }}->RF1R & CAN_RF1R_FOVR1) {
 		xpcc::ErrorReport::report(xpcc::stm32::CAN{{ id }}_FIFO1_OVERFLOW);
@@ -298,19 +296,18 @@ extern "C" void
 // the interrupt source and call the correct interrupts function defined above.
 // Sources for the different interrupts are specified in the Reference Manual
 // in the "bxCAN interrupts" section.
-extern "C" void
-CEC_CAN_IRQHandler()
+XPCC_ISR(CEC_CAN)
 {
 	if({{ reg }}->TSR & (CAN_TSR_RQCP0 | CAN_TSR_RQCP1 | CAN_TSR_RQCP2)) {
-		{{ reg }}_TX_IRQHandler();
+		XPCC_ISR_CALL({{ reg }}_TX);
 	}
 
 	if({{ reg }}->RF0R & (CAN_RF0R_FMP0 | CAN_RF0R_FULL0 | CAN_RF0R_FOVR0)) {
-		{{ reg }}_RX0_IRQHandler();
+		XPCC_ISR_CALL({{ reg }}_RX0);
 	}
 
 	if({{ reg }}->RF1R & (CAN_RF1R_FMP1 | CAN_RF1R_FULL1 | CAN_RF1R_FOVR1)) {
-		{{ reg }}_RX1_IRQHandler();
+		XPCC_ISR_CALL({{ reg }}_RX1);
 	}
 
 	// TODO: we do not handle status changes at the moment.

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -183,8 +183,7 @@ public:
 	 * You need to create you own interrupt handler for this interrupt.
 	 * The interrupt handler has a fixed name:
 	 * \code
-	 * extern "C" void
-	 * CAN{{ id }}_SCE_IRQHandler()
+	 * XPCC_ISR(CAN{{ id }}_SCE)
 	 * {
 	 *     ...
 	 *

--- a/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
+++ b/src/xpcc/architecture/platform/driver/core/cortex/hard_fault_handler.cpp.in
@@ -69,7 +69,7 @@ extern "C" void _toggleHardFaultHandlerLed()
 
 #include "../../uart/stm32/uart_{{ id }}.hpp"
 
-extern "C" void {{ uart | upper ~ id }}_IRQHandler(void);
+XPCC_ISR_DECL({{ uart | upper ~ id }});
 
 // since the hard fault handler cannot be preempted by any other handler or IRQ
 // we have to manually call it here. Not pretty, but it works.
@@ -80,7 +80,7 @@ void flushUart()
 	{
 		if (xpcc::stm32::{{ uart }}Hal{{ id }}::isTransmitRegisterEmpty())
 		{
-			{{ uart | upper ~ id }}_IRQHandler();
+			XPCC_ISR_CALL({{ uart | upper ~ id }});
 		}
 	}
 }

--- a/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.cpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.cpp.in
@@ -37,7 +37,7 @@ namespace
 
 // ----------------------------------------------------------------------------
 /// TWI state machine interrupt handler
-ISR(TWI_vect)
+XPCC_ISR(TWI)
 {
 	switch(TW_STATUS)
 	{

--- a/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.cpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.cpp.in
@@ -163,8 +163,7 @@
 #include <xpcc/architecture/driver/atomic.hpp>
 #include <xpcc/container.hpp>
 
-extern "C" void
-I2C{{ id }}_ER_IRQHandler(void);
+XPCC_ISR_DECL(I2C{{ id }}_ER);
 
 namespace
 {
@@ -227,7 +226,7 @@ namespace
 				// Call error handler manually to detach the transaction object and resolve the deadlock.
 				// Further transactions may not succeed either, but will not lead to a deadlock.
 				error = xpcc::I2cMaster::Error::BusBusy;
-				I2C{{ id }}_ER_IRQHandler();
+				XPCC_ISR_CALL(I2C{{ id }}_ER);
 				return;
 			}
 		}
@@ -276,8 +275,7 @@ namespace
 }
 
 // ----------------------------------------------------------------------------
-extern "C" void
-I2C{{ id }}_EV_IRQHandler(void)
+XPCC_ISR(I2C{{ id }}_EV)
 {
 	DEBUG_STREAM("\n--- interrupt ---");
 
@@ -529,8 +527,7 @@ I2C{{ id }}_EV_IRQHandler(void)
 }
 
 // ----------------------------------------------------------------------------
-extern "C" void
-I2C{{ id }}_ER_IRQHandler(void)
+XPCC_ISR(I2C{{ id }}_ER)
 {
 	DEBUG_STREAM("ERROR!");
 	uint16_t sr1 = I2C{{ id }}->SR1;

--- a/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.cpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.cpp.in
@@ -104,7 +104,7 @@ namespace
 
 // ----------------------------------------------------------------------------
 /// TWI state machine interrupt handler
-ISR(TWI{{ id }}_TWIM_vect)
+XPCC_ISR(TWI{{ id }}_TWIM)
 {
 	switch(TWI{{ id }}_MASTER_STATUS & TWI_MASTER_BUSSTATE_gm)
 	{

--- a/src/xpcc/architecture/platform/driver/timer/stm32/advanced.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/advanced.hpp.in
@@ -23,34 +23,33 @@ namespace stm32
  *
  * {% if id == 1 %}
  * Interrupt handler (for LD, MD, HD and CL):
- * - TIM1_BRK_IRQHandler
- * - TIM1_UP_IRQHandler
- * - TIM1_TRG_COM_IRQHandler
- * - TIM1_CC_IRQHandler
+ * - TIM1_BRK
+ * - TIM1_UP
+ * - TIM1_TRG_COM
+ * - TIM1_CC
  *
  * Interrupt handler for XL Density:
- * - TIM1_BRK_TIM9_IRQHandler
- * - TIM1_UP_TIM10_IRQn
- * - TIM1_TRG_COM_TIM11_IRQn
- * - TIM1_CC_IRQn
+ * - TIM1_BRK_TIM9
+ * - TIM1_UP_TIM10
+ * - TIM1_TRG_COM_TIM11
+ * - TIM1_CC
  * {% elif id == 8 %}
  * Interrupt handler for High Density:
- * - TIM8_BRK_IRQHandler
- * - TIM8_UP_IRQHandler
- * - TIM8_TRG_COM_IRQHandler
- * - TIM8_CC_IRQHandler
+ * - TIM8_BRK
+ * - TIM8_UP
+ * - TIM8_TRG_COM
+ * - TIM8_CC
  *
  * Interrupt handler for XL Density:
- * - TIM8_BRK_TIM12_IRQn
- * - TIM8_UP_TIM13_IRQn
- * - TIM8_TRG_COM_TIM14_IRQn
- * - TIM8_CC_IRQn
+ * - TIM8_BRK_TIM12
+ * - TIM8_UP_TIM13
+ * - TIM8_TRG_COM_TIM14
+ * - TIM8_CC
  * {% endif %}
  *
  * Example:
  * @code
- * extern "C" void
- * TIM{{ id }}_UP_IRQHandler(void)
+ * XPCC_ISR(TIM{{ id }}_UP)
  * {
  *     Timer{{ id }}::resetInterruptFlags(Timer{{ id }}::...);
  *

--- a/src/xpcc/architecture/platform/driver/timer/stm32/basic.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/basic.hpp.in
@@ -24,8 +24,7 @@ namespace stm32
  *
  * Interrupt handler:
  * \code
- * extern "C" void
- * TIM{{ id }}_IRQHandler(void)
+ * XPCC_ISR(TIM{{ id }})
  * {
  *     Timer{{ id }}::resetInterruptFlags(Timer{{ id }}::FLAG_UPDATE);
  *
@@ -36,8 +35,7 @@ namespace stm32
  {% if id == 6 -%}
  * For the STM32F2xx and STM32F4xx:
  * \code
- * extern "C" void
- * TIM{{ id }}_DAC_IRQHandler(void)
+ * XPCC_ISR(TIM{{ id }}_DAC)
  * {
  *     Timer{{ id }}::resetInterruptFlags(Timer{{ id }}::FLAG_UPDATE);
  *

--- a/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
+++ b/src/xpcc/architecture/platform/driver/timer/stm32/general_purpose.hpp.in
@@ -22,8 +22,7 @@ namespace stm32
  *
  * Interrupt handler:
  * @code
- * extern "C" void
- * TIM{{ id }}_IRQHandler(void)
+ * XPCC_ISR(TIM{{ id }})
  * {
  *     Timer{{ id }}::resetInterruptFlags(Timer{{ id }}::...);
  *

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_rx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_rx.cpp.in
@@ -18,7 +18,7 @@ static xpcc::atomic::Queue<uint8_t, {{parameters.rx_buffer}}> rxBuffer;
 static uint8_t error;
 
 // ----------------------------------------------------------------------------
-ISR(USART{{ id }}_RX_vect)
+XPCC_ISR(USART{{ id }}_RX)
 {
 	// first save the errors
 	error |= UCSR{{ id }}A & ((1 << FE{{ id }}) | (1 << DOR{{ id }}));

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_tx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_tx.cpp.in
@@ -17,7 +17,7 @@
 static xpcc::atomic::Queue<uint8_t, {{parameters.tx_buffer}}> txBuffer;
 
 // ----------------------------------------------------------------------------
-ISR(USART{{ id }}_UDRE_vect)
+XPCC_ISR(USART{{ id }}_UDRE)
 {
 	if (txBuffer.isEmpty())
 	{

--- a/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
@@ -308,8 +308,7 @@ xpcc::lpc::Uart1::discardReceiveBuffer()
 }
 
 // ----------------------------------------------------------------------------
-extern "C" void
-UART_IRQHandler()
+XPCC_ISR(UART)
 {
 	// read IIR to clear Interrupt Status and mask
 	uint8_t IIRValue = LPC_UART->IIR & IIR_INTID_MASK;

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
@@ -192,8 +192,7 @@ xpcc::stm32::{{ name }}::discardReceiveBuffer()
 
 %% if parameters.buffered
 %% set hal = "xpcc::stm32::" ~ hal
-extern "C" void
-{{ uart | upper ~ id }}_IRQHandler()
+XPCC_ISR({{ uart | upper ~ id }})
 {
 	if ({{ hal }}::isReceiveRegisterNotEmpty()) {
 		// TODO: save the errors

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_buffered.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_buffered.cpp.in
@@ -75,8 +75,7 @@ namespace
 		{{ className | upper }}{{ id }}->DR
 #endif
 
-extern "C" void
-{{ className | upper }}{{ id }}_IRQHandler()
+XPCC_ISR({{ className | upper }}{{ id }})
 {
 
 	uint32_t state = {{ className | upper }}{{ id }}_SR;

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_buffered_flow.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_buffered_flow.cpp.in
@@ -84,8 +84,7 @@ namespace
 		{{ className | upper }}{{ id }}->DR
 #endif
 
-extern "C" void
-{{ className | upper }}{{ id }}_IRQHandler()
+XPCC_ISR({{ className | upper }}{{ id }})
 {
 	uint32_t state = {{ className | upper }}{{ id }}_SR;
 	

--- a/src/xpcc/architecture/platform/driver/uart/xmega/uart_buffered_rx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/xmega/uart_buffered_rx.cpp.in
@@ -17,8 +17,8 @@ static xpcc::atomic::Queue<uint8_t, {{parameters.rx_buffer}}> rxBuffer;
 static uint8_t error;
 
 // ----------------------------------------------------------------------------
-ISR(USART{{ id }}_RXC_vect)
-{		
+XPCC_ISR(USART{{ id }}_RXC)
+{
 	// first save the errors
 	error |= USART{{ id }}_STATUS & (USART_FERR_bm | USART_BUFOVF_bm | USART_PERR_bm);
 	// then read the buffer

--- a/src/xpcc/architecture/platform/driver/uart/xmega/uart_buffered_tx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/xmega/uart_buffered_tx.cpp.in
@@ -16,7 +16,7 @@
 static xpcc::atomic::Queue<uint8_t, {{parameters.tx_buffer}}> txBuffer;
 
 // ----------------------------------------------------------------------------
-ISR(USART{{ id }}_DRE_vect)
+XPCC_ISR(USART{{ id }}_DRE)
 {
 	if (txBuffer.isEmpty())
 	{

--- a/src/xpcc/architecture/platform/driver/uart/xmega/uart_flow.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/xmega/uart_flow.cpp.in
@@ -61,8 +61,8 @@ namespace
 
 // ----------------------------------------------------------------------------
 #if UART{{ id }}_RTS_PIN != -1
-ISR(USART{{ id }}_RXC_vect)
-{		
+XPCC_ISR(USART{{ id }}_RXC)
+{
 	// first save the errors
 	error |= USART{{ id }}_STATUS & (USART_FERR_bm | USART_BUFOVF_bm | USART_PERR_bm);
 	

--- a/src/xpcc/architecture/utils.hpp
+++ b/src/xpcc/architecture/utils.hpp
@@ -135,6 +135,12 @@
 	#	define xpcc_fastdata		xpcc_section(".fastdata")
 	#endif
 
+	#ifdef __cplusplus
+	#	define xpcc_extern_c extern "C"
+	#else
+	#	define xpcc_extern_c
+	#endif
+
 	#define XPCC_ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
 
 #endif	// !__DOXYGEN__


### PR DESCRIPTION
As discussed in https://github.com/roboterclubaachen/xpcc/pull/180#issuecomment-244759464 I've added macros to unify declaring interrupts on AVR and ARM Cortex-M.

You can now declare an interrupts using `XPCC_ISR(vector)` where the vector is the vector name from the datasheet. This alleviates knowing any pre-/post-fix naming conventions, as `_vect` or `_IRQHandler` as used by `avr-gcc` and CMSIS.
However, these changes are backwards compatible with existing code using these postfix conventions!

Note that there are regressions associated with this, especially not being able to alias declare vector names! Instead this must be done using `XPCC_ISR_NAME(vector)` macro:

``` diff
-#  define  CAN1_TX_IRQHandler          USB_HP_CAN1_TX_IRQHandler
+#  define  XPCC_ISR_NAME(CAN1_TX)      XPCC_ISR_NAME(USB_HP_CAN1_TX)
```

In total four macros are added:
- `XPCC_ISR(vector, attributes...)` for declaring a static vector with attributes (e.g. `xpcc_fastcode`).
- `XPCC_ISR_NAME(vector)` for getting the raw vector name.
- `XPCC_ISR_DECL(vector)` for forward declarations of the vector.
- `XPCC_ISR_CALL(vector)` for calling a vector implementation manually from code.

cc @ekiwi @dergraaf 
