### PR TITLE
Import OPENOCD_SCRIPTS env variable to OpenOCD

### DIFF
--- a/scons/site_tools/openocd.py
+++ b/scons/site_tools/openocd.py
@@ -44,6 +44,10 @@ def openocd_run(env, source, alias='openocd_run'):
 	if platform.system() == "Windows":
 		env['OPENOCD_COMMANDS'] = env['OPENOCD_COMMANDS'].replace("$SOURCE", str(source[0]).replace("\\","/"))
 
+	# Provide additional search paths via the OPENOCD_SCRIPTS environment variable
+	# See http://openocd.org/doc/html/Running.html
+	env['ENV']['OPENOCD_SCRIPTS'] = os.environ.get('OPENOCD_SCRIPTS')
+
 	commands = [c for c in env['OPENOCD_COMMANDS'].split('\n') if c != '']
 	action = Action("$OPENOCD -f $OPENOCD_CONFIGFILE %s" % ' '.join(['-c "%s"' % c for c in commands]),
 		cmdstr="$OPENOCD_COMSTR")


### PR DESCRIPTION
As described in the OpenOCD documentation :
http://openocd.org/doc/html/Running.html

It is possible to specify the OpenOCD scripts directory path by setting
an environment variable. This is particulary handy for Windows users
(specialy if the scons command is executed within Visual Studio.