### PR TITLE
Feature/mingw

### DIFF
--- a/examples/windows/build_info/SConstruct
+++ b/examples/windows/build_info/SConstruct
@@ -1,0 +1,7 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')
+
+# build xpcc_build_info.hpp file
+env.BuildInfoHeader()

--- a/examples/windows/build_info/main.cpp
+++ b/examples/windows/build_info/main.cpp
@@ -1,0 +1,28 @@
+#include <xpcc/architecture.hpp>
+#include <xpcc/debug/logger.hpp>
+
+#include <xpcc_build_info.hpp>
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+// SDLMain will generate WinMain function and call main bellow
+int main(int argc, char** argv)
+{
+	// ensure the console has been allocated
+	AllocConsole();
+
+	// recover the (stolen) console from SDL
+	freopen ("CON", "a", stdout);
+	freopen ("CON", "r", stdin);
+	freopen ("CON", "a", stderr);
+
+	// Let's print some information that is provided in the xpcc_build_info.hpp
+	XPCC_LOG_INFO << "Machine:  " << XPCC_BUILD_MACHINE << xpcc::endl;
+	XPCC_LOG_INFO << "User:     " << XPCC_BUILD_USER << xpcc::endl;
+	XPCC_LOG_INFO << "Os:       " << XPCC_BUILD_OS << xpcc::endl;
+	XPCC_LOG_INFO << "Compiler: " << XPCC_BUILD_COMPILER << xpcc::endl;
+
+	return 0;
+}

--- a/examples/windows/build_info/project.cfg
+++ b/examples/windows/build_info/project.cfg
@@ -1,0 +1,9 @@
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/windows/${name}
+
+[environment]
+# using /= will completely replace the value
+CXX/=x86_64-w64-mingw32-g++
+RANLIB/=x86_64-w64-mingw32-ranlib
+AR/=x86_64-w64-mingw32-ar

--- a/ext/fatfs/ff.h
+++ b/ext/fatfs/ff.h
@@ -57,15 +57,15 @@ extern PARTITION VolToPart[];	/* Volume - Partition resolution table */
 #endif
 #ifndef _INC_TCHAR
 typedef WCHAR TCHAR;
-#define _T(x) L ## x
-#define _TEXT(x) L ## x
+#define FF_T(x) L ## x
+#define FF_TEXT(x) L ## x
 #endif
 
 #else						/* ANSI/OEM string */
 #ifndef _INC_TCHAR
 typedef char TCHAR;
-#define _T(x) x
-#define _TEXT(x) x
+#define FF_T(x) x
+#define FF_TEXT(x) x
 #endif
 
 #endif

--- a/scons/site_tools/hosted.py
+++ b/scons/site_tools/hosted.py
@@ -42,6 +42,8 @@ def generate(env, **kw):
 		env['LIBS'] = ['boost_thread', 'boost_system', 'pthread']
 	elif env['HOSTED_DEVICE'] == 'darwin':
 		env['LIBS'] = ['boost_thread-mt', 'boost_system']
+	elif env.System() == 'windows':
+		env['LIBS'] = ['winpthread', 'boost_thread-mt', 'boost_system', 'wsock32', 'mingw32', 'SDLmain', 'SDL', 'winmm', 'gdi32', 'dxguid', 'gdi32', 'winmm', 'gdi32']
 
 	if 'CC' in os.environ:
 		c_compiler = os.environ['CC']
@@ -55,7 +57,7 @@ def generate(env, **kw):
 
 	env.Append(ENV = {'PATH' : os.environ['PATH']})
 
-	if platform.system() == 'Windows':
+	if env.System() == 'windows':
 		env.Tool('mingw')
 	else:
 		env.Tool('gcc')
@@ -110,9 +112,14 @@ def generate(env, **kw):
 		flags = "".join(os.environ['LDFLAGS'])
 		env['LINKFLAGS'] = flags
 
-	# required for __attribute__((packed))
-	if platform.system() == 'Windows':
-		env['CXXFLAGS'].append("-mno-ms-bitfields")
+	if env.System() == 'windows':
+		env['CXXFLAGS'].append("-mno-ms-bitfields") # required for __attribute__((packed))
+		env['CXXFLAGS'].append("-static") # static link libraries if possible on windows
+		env['CXXFLAGS'].append("-mconsole")
+		env['LINKFLAGS'].append("-Wl,--export-all-symbols")
+		env['LINKFLAGS'].append("-static") # static link libraries if possible on windows
+		env['LINKFLAGS'].append("-static-libgcc") # aims for a console even if we use SDL, so we can mix a Window + Debug console
+		env['LINKFLAGS'].append("-static-libstdc++")
 
 def exists(env):
 	return env.Detect('g++')

--- a/scons/site_tools/xpcc.py
+++ b/scons/site_tools/xpcc.py
@@ -198,10 +198,31 @@ def c_string_literal(env, string):
 		Escapes string and adds quotes.
 	"""
 	# Warning: Order Matters! Replace '\\' first!
-	e = [("\\", "\\\\"), ("\'", "\\\'"), ("\"", "\\\""), ("\t", "\\t"), ("\n", "\\n")]
+	e = [("\\", "\\\\"), ("\'", "\\\'"), ("\"", "\\\""), ("\t", "\\t"), ("\n", "\\n"), ("\f", ""), ("\r", "")]
 	for r in e:
 		string = string.replace(r[0], r[1])
 	return "\"" + string + "\""
+
+def detect_system(env):
+	"""
+		Provide an unified method to determine running platform.
+	"""
+	# will return lowcase names so it can be used building paths
+
+	system_name = platform.system()
+	standards = {'Darwin': 'darwin', 'Linux': 'linux',
+						'Windows': 'windows' }
+
+	if system_name in standards:
+		return standards[platform.system()]
+
+	if system_name.startswith('MSYS') or system_name.startswith('CYGWIN') or system_name.startswith('MINGW'):
+		return 'windows'
+
+	# if this fails, don't bother continuing, it can only escaladate
+	env.Error("Could not detect the running platform, " + system_name + " unsupported. " \
+		"Currently supported by xpcc : Linux, Windows (MSYS, Cygwin), Darwin")
+	env.Exit(1)
 
 def define_header(env, defines, header, comment, template="define_template.hpp.in"):
 	"""
@@ -230,22 +251,26 @@ def define_header(env, defines, header, comment, template="define_template.hpp.i
 	env.AppendUnique(CPPPATH = env['XPCC_BUILDPATH'])
 
 def build_info_header(env):
+	print('Building: Info Header xpcc_build_info.hpp')
 	defines = {}
 	defines['XPCC_BUILD_PROJECT_NAME'] = env.CStringLiteral(env['XPCC_PROJECT_NAME'])
 	defines['XPCC_BUILD_MACHINE'] = env.CStringLiteral(platform.node())
 	defines['XPCC_BUILD_USER'] = env.CStringLiteral(getpass.getuser())
 	# Generate OS String
-	if platform.system() == 'Linux':
+	if env.System() == 'linux':
 		os = " ".join(platform.linux_distribution())
-	elif platform.system() == 'Windows':
-		os = " ".join(platform.win32_ver())
-	elif platform.system() == 'Darwin':
+	elif env.System() == 'darwin':
 		os = "Mac {0} ({2})".format(*platform.mac_ver())
 	else:
 		os = platform.system()
 	defines['XPCC_BUILD_OS'] = env.CStringLiteral(os)
 	# This contains the version of the compiler that is used to build the project
-	c = subprocess.check_output([env['CXX'], '--version']).split('\n', 1)[0]
+	try:
+		c = subprocess.check_output([env['CXX'], '--version']).split('\n', 1)[0]
+	except Exception, e:
+		env.Error("[CXX] compiler " + env['CXX'] + " is not in path or could not be executed")
+		Exit(1)
+
 	m = re.match("(?P<name>[a-z\-\+]+)[a-zA-Z\(\) ]* (?P<version>\d+\.\d+\.\d+)", c)
 	if m: comp = "{0} {1}".format(m.group('name'), m.group('version'))
 	else: comp = c
@@ -261,6 +286,8 @@ def generate(env, **kw):
 	# features from this version like os.path.relpath() are used.
 	EnsurePythonVersion(2, 6)
 	EnsureSConsVersion(1, 0)
+
+	env.AddMethod(detect_system, 'System')
 
 	# Import Logger Tool
 	env.Tool('logger_tools')
@@ -329,8 +356,8 @@ def generate(env, **kw):
 
 		device = parser.get('build', 'device')
 
-		hosted_device = {'Darwin': 'darwin', 'Linux': 'linux',
-						 'Windows': 'windows' }[platform.system()]
+		hosted_device = env.System()
+
 		if device == 'hosted':
 			device = hosted_device
 		elif device.startswith('hosted/'):
@@ -541,13 +568,25 @@ def generate(env, **kw):
 		Exit(1)
 
 	# append all values from environment section to the real environment
+	#
+	# adding * to a key name will add a space before and append to existing values
+	# adding / to a key name will replace any existing value
+	# raw key name means it will append to existing env value without any adjustment
 	for key, value in configuration['environment'].iteritems():
-		if key.endswith('*'):
+		replace = False
+		if '/' in key:
+			replace = True
+		if '*' in key or '/' in key:
+			if '*' in key:
+				value = " " + value
 			key = key[:-1]
-			value = " " + value
 		if key.upper() == "CPPPATH":
 			value = value.split(':')
-		env.Append(**{ key.upper(): value } )
+
+		if replace:
+			env.Replace(**{ key.upper(): value } )
+		else:
+			env.Append(**{ key.upper(): value } )
 
 	# append defines from user config
 	user_conf = {}

--- a/src/xpcc/architecture/detect.hpp
+++ b/src/xpcc/architecture/detect.hpp
@@ -130,8 +130,13 @@
 #	define XPCC__COMPILER_STRING	"Clang"
 #	define XPCC__COMPILER_CLANG 1
 #elif defined __GNUC__
-#	define XPCC__COMPILER_STRING	"Gnu GCC"
 #	define XPCC__COMPILER_GCC 1
+#	if defined __MINGW32__
+#		define XPCC__COMPILER_STRING	"MinGW / MinGW-w64"
+#		define XPCC__COMPILER_MINGW 1
+#	else
+#		define XPCC__COMPILER_STRING	"Gnu GCC"
+#	endif
 #endif
 
 #if defined _MSC_VER

--- a/src/xpcc/architecture/platform/devices/hosted/windows.xml
+++ b/src/xpcc/architecture/platform/devices/hosted/windows.xml
@@ -3,5 +3,7 @@
 <rca version="1.0">
   <device platform="hosted" family="windows">
     <naming-schema>{{ platform }}/{{ family }}</naming-schema>
+    <driver type="graphics" name="hosted"/>
+    <driver type="uart" name="hosted"/>
   </device>
 </rca>

--- a/src/xpcc/architecture/utils.hpp
+++ b/src/xpcc/architecture/utils.hpp
@@ -117,7 +117,6 @@
 
 	#define xpcc_always_inline		inline __attribute__((always_inline))
 	#define xpcc_unused				__attribute__((unused))
-	#define xpcc_weak				__attribute__((weak))
 	#define xpcc_aligned(n)			__attribute__((aligned(n)))
 	#define xpcc_packed				__attribute__((packed))
 	// see http://dbp-consulting.com/tutorials/StrictAliasing.html
@@ -126,6 +125,16 @@
 	#define xpcc_likely(x)			__builtin_expect(!!(x), 1)
 	#define xpcc_unlikely(x)		__builtin_expect(!!(x), 0)
 	#define xpcc_section(s)			__attribute__((section(s)))
+
+	#ifdef XPCC__COMPILER_MINGW
+	 	// FIXME: Windows Object Format PE does not support weak symbols
+	 	//	- Bug reported for mingw32 : https://sourceware.org/bugzilla/show_bug.cgi?id=9687
+	 	// 	- Investigate Boost libs how they solve this issue
+	 	//	- __attribute__ ((weak, alias ("__aliasedFunction"))) seems to work on Windows
+	#	define xpcc_weak
+	#else
+ 	#	define xpcc_weak			__attribute__((weak))
+	#endif
 
 	#ifdef XPCC__OS_HOSTED
 	#	define xpcc_fastcode

--- a/src/xpcc/debug/logger/level.hpp
+++ b/src/xpcc/debug/logger/level.hpp
@@ -28,6 +28,9 @@
 #ifndef XPCC_LOG__LEVEL_HPP
 #define XPCC_LOG__LEVEL_HPP
 
+#pragma push_macro("ERROR") // avoid collision with ERROR defined macro in winsock.h
+#undef ERROR
+
 namespace xpcc
 {
 	namespace log
@@ -68,5 +71,7 @@ namespace xpcc
 	 */
 	#define XPCC_LOG_LEVEL xpcc::log::DEBUG
 #endif // XPCC_LOG_LEVEL
+
+#pragma pop_macro("ERROR")
 
 #endif // XPCC_LOG__LEVEL_HPP

--- a/src/xpcc/io/iostream_float.cpp
+++ b/src/xpcc/io/iostream_float.cpp
@@ -24,7 +24,7 @@ xpcc::IOStream::writeFloat(const float& value)
 #if defined(XPCC__CPU_AVR)
 	dtostre(value, str, 5, 0);
 	this->device->write(str);
-#elif defined(XPCC__CPU_CORTEX_M4) || defined(XPCC__CPU_CORTEX_M3) || defined(XPCC__CPU_CORTEX_M0)
+#elif defined(XPCC__CPU_CORTEX_M4) || defined(XPCC__CPU_CORTEX_M3) || defined(XPCC__CPU_CORTEX_M0) || defined(XPCC__OS_WIN32)
 	float v;
 	char *ptr = &str[0];
 
@@ -89,7 +89,7 @@ xpcc::IOStream::writeFloat(const float& value)
 void
 xpcc::IOStream::writeDouble(const double& value)
 {
-#if defined(XPCC__CPU_CORTEX_M4) || defined(XPCC__CPU_CORTEX_M3) || defined(XPCC__CPU_CORTEX_M0)
+#if defined(XPCC__CPU_CORTEX_M4) || defined(XPCC__CPU_CORTEX_M3) || defined(XPCC__CPU_CORTEX_M0) || defined(XPCC__OS_WIN32)
 	// TODO do this better
 	writeFloat(static_cast<float>(value));
 #else


### PR DESCRIPTION
Added Cygwin / Msys2 and Native MinGW-w64 compilation support for Windows

### Source files
- Rename ext/fatfs/ff.h _T macros to avoid conflicts
- Add Windows build_info example
- Added MinGW and Win64 defines in detect.hpp 
- Added push_macro("ERROR") to avoid collision with ERROR defined macro in winsock.h
- Suppressed __attribute__((weak)) aka xpcc_weak for MinGW
- Suppressed snprintf for Windows compilation

### Windows device file (windows.xml)
- Added uart device for console output
- Added graphics device for SDL support

### Build system
- add env.System() function to centralize system detection
- add \f and \r to complete escapes in c_string_literal function
- remove platform.win32_ver() call as it does not work on win64
- print error in case of CXX has failed to be detected / defined
- added /= operator for [environement] section in project.cfg files
- fixed compilation/linker flags for fully static linked windows compilation (with POSIX threads, boost and SDL)