### PR TITLE
[XPCC] Require Identifier for containers.

### DIFF
--- a/examples/communication/xml/communication.dtd
+++ b/examples/communication/xml/communication.dtd
@@ -79,4 +79,5 @@
 <!ELEMENT container (description|component)*>
 <!ATTLIST container
 	name CDATA #REQUIRED
+	id CDATA #REQUIRED
 >

--- a/examples/communication/xml/communication.xml
+++ b/examples/communication/xml/communication.xml
@@ -71,24 +71,24 @@
 </component>
 
 <!-- Containers -->
-<container name="sender">
+<container name="sender" id="0x10">
 	<component name="sender" />
 </container>
 
-<container name="receiver">
+<container name="receiver" id="0x20">
 	<component name="receiver" />
 </container>
 
-<container name="odometry">
+<container name="odometry" id="0x30">
 	<component name="odometry" />
 </container>
 
-<container name="senderreceiver">
+<container name="sender receiver" id="0x40">
 	<component name="sender" />
 	<component name="receiver" />
 </container>
 
-<container name="gui">
+<container name="gui" id="0x50">
 	<component name="gui" />
 </container>
 

--- a/examples/linux/communication/basic/project.cfg
+++ b/examples/linux/communication/basic/project.cfg
@@ -1,5 +1,5 @@
 [communication]
-container = senderreceiver
+container = sender receiver
 source = ../../../communication/xml/communication.xml
 
 [environment]

--- a/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f429zi/nucleo_f429zi.hpp
@@ -89,7 +89,7 @@ struct systemClock
 		xpcc::clock::fcpu     = Frequency;
 		xpcc::clock::fcpu_kHz = Frequency / 1000;
 		xpcc::clock::fcpu_MHz = Frequency / 1000000;
-		xpcc::clock::ns_per_loop = std::round(3000 / (Frequency / 1000000));
+		xpcc::clock::ns_per_loop = ::round(3000 / (Frequency / 1000000));
 
 		return true;
 	}

--- a/tools/system_design/builder/builder_base.py
+++ b/tools/system_design/builder/builder_base.py
@@ -66,8 +66,8 @@ class Builder(object):
 												component 'driver'
 	self.tree.components["driver"].events.publish
 	self.tree.components["driver"].events.subscribe
-	self.tree.container
-	self.tree.container["PC"].components	--	only components form the
+	self.tree.containers
+	self.tree.containers["PC"].components	--	only components form the
 												container 'PC'
 	self.tree.types
 	self.tree.events

--- a/tools/system_design/builder/cpp_identifier.py
+++ b/tools/system_design/builder/cpp_identifier.py
@@ -55,6 +55,7 @@ class IdentifierBuilder(builder_base.Builder):
 
 		cppFilter = {
 			'enumElement': filter.enumElement,
+			'enumElementStrong': filter.typeName,
 			'enumValue': filter.toHexValue,
 		}
 		
@@ -66,6 +67,7 @@ class IdentifierBuilder(builder_base.Builder):
 		
 		substitutions = {
 			'domains' : self.tree.domains,
+			'containers' : self.tree.containers,
 			'components': components,
 			'actions': self.tree.components.actions,
 			'events': self.tree.events,

--- a/tools/system_design/builder/cpp_postman.py
+++ b/tools/system_design/builder/cpp_postman.py
@@ -57,7 +57,7 @@ class PostmanBuilder(builder_base.Builder):
 		# check the commandline options
 		if not self.options.outpath:
 			raise builder_base.BuilderException("You need to provide an output path!")
-		if not self.options.container or self.options.container not in self.tree.container:
+		if not self.options.container or self.options.container not in self.tree.containers:
 			raise builder_base.BuilderException("Please specify a valid container!")
 
 		if self.options.namespace:
@@ -72,7 +72,7 @@ class PostmanBuilder(builder_base.Builder):
 			'CAMELCASE': filter.enumElement,
 		}
 
-		container = self.tree.container[self.options.container]
+		container = self.tree.containers[self.options.container]
 
 		components = []
 		for component in container.components:

--- a/tools/system_design/builder/system_layout.py
+++ b/tools/system_design/builder/system_layout.py
@@ -100,7 +100,7 @@ class SystemLayoutBuilder(builder_base.Builder):
 	  
 	def get_graph_width(self, tree):
 	    width = 0
-	    for container in tree.container:
+	    for container in tree.containers:
 	        # skip containers that the user asked to skip
 	        if self.options.skipList is not None and container.name in self.options.skipList:
 	            continue
@@ -173,12 +173,12 @@ class SystemLayoutBuilder(builder_base.Builder):
 		self.eventsSorted = []
 
 		print("Analysing containers:")
-		for container in self.tree.container:
+		for container in self.tree.containers:
 			print " * " + container.name
 
 		print("Done. Creating graph")
 
-		for container in self.tree.container:
+		for container in self.tree.containers:
 			if container.name is None:
 				continue
 			if self.options.skipList is not None and container.name in self.options.skipList:
@@ -270,7 +270,7 @@ class SystemLayoutBuilder(builder_base.Builder):
 
 		# Draw containers at the top
 		container_x = 2.5
-		for container in self.tree.container:
+		for container in self.tree.containers:
 			# skip containers that are requested to skip
 			if self.options.skipList is not None and container.name in self.options.skipList:
 				continue

--- a/tools/system_design/builder/templates/robot_identifier.tpl
+++ b/tools/system_design/builder/templates/robot_identifier.tpl
@@ -35,6 +35,16 @@ namespace {{ namespace }}
 			}
 		}
 	}
+
+	namespace container
+	{
+		enum class Identifier : uint8_t
+		{
+		{%- for item in containers %}
+			{{ item.name | enumElementStrong }} = {{ item.id | enumValue }},
+		{%- endfor %}
+		};
+	}
 	
 	namespace component
 	{

--- a/tools/system_design/xml/dtd/rca_container.dtd
+++ b/tools/system_design/xml/dtd/rca_container.dtd
@@ -13,6 +13,7 @@
 <!ELEMENT container (description|bootloader|component)*>
 <!ATTLIST container
 	name CDATA #REQUIRED
+	id CDATA #REQUIRED
 >
 
 <!ELEMENT domain (#PCDATA)>

--- a/tools/system_design/xmlparser/component.py
+++ b/tools/system_design/xmlparser/component.py
@@ -311,10 +311,7 @@ class Component(object):
 		hexadecimal). First block shows the actions and the second the events.
 		
 		"""
-		if self.id is None:
-			name = "%s" % self.name
-		else:
-			name = "%s [%02x]" % (self.name, self.id)
+		name = self.__str__()
 		max_length = len(name)
 		
 		elements = [["actions:"], ["publish:"], ["subscribe:"]]

--- a/tools/system_design/xmlparser/container.py
+++ b/tools/system_design/xmlparser/container.py
@@ -9,9 +9,11 @@ from parser_exception import ParserException
 
 class Container:
 	""" Representation of a container which bundles components.
+		For microcontrollers, each container runs on a separate controller.
 	
 	Attributes:
 	name			--	Name of the container
+	id				--	Globally unique identifier of the container (0..255).
 	bootloader		--	Information about a bootloader used to program this
 						container.
 	description		--	Description string
@@ -43,6 +45,7 @@ class Container:
 		self.bootloader = bootloader
 		
 		self.description = xml_utils.get_description(node)
+		self.id = xml_utils.get_identifier(self.node)
 		
 		self.components = None
 		self.events = EventContainer()
@@ -95,7 +98,7 @@ class Container:
 		self.indexReady = True
 	
 	def __cmp__(self, other):
-		return cmp(self.name.lower(), other.name.lower())
+		return cmp(self.name.lower(), other.name.lower()) or cmp(self.id, other.id)
 	
 	def dump(self):
 		str = "%s : container\n" % self.__str__()
@@ -104,4 +107,8 @@ class Container:
 		return str[:-1]
 	
 	def __str__(self):
-		return self.name
+		if self.id is None:
+			name = "[--] %s" % self.name
+		else:
+			name = "[%02x] %s" % (self.id, self.name)
+		return name

--- a/tools/system_design/xmlparser/container.py
+++ b/tools/system_design/xmlparser/container.py
@@ -98,7 +98,7 @@ class Container:
 		return cmp(self.name.lower(), other.name.lower())
 	
 	def dump(self):
-		str = "%s : container\n" % self.name
+		str = "%s : container\n" % self.__str__()
 		for component in self.components:
 			str += "- %s\n" % '\n'.join(["  " + line for line in component.__str__().split('\n')])[2:]
 		return str[:-1]

--- a/tools/system_design/xmlparser/parser.py
+++ b/tools/system_design/xmlparser/parser.py
@@ -25,15 +25,15 @@ class Tree(object):
 	types		-- List of all types
 	events		-- List of all events
 	components	-- List of all components
-	container	-- List of all container
+	containers	-- List of all container
 	domains		-- List of all domains
 	"""
 	def __init__(self):
 		self.types = utils.SingleAssignDictionary("types")
 		self.events = utils.SingleAssignDictionary("events")
 		self.components = component.ComponentDictionary("components")
-		self.container = utils.SingleAssignDictionary("container")
-		self.domains = utils.SingleAssignDictionary("domain")
+		self.containers = utils.SingleAssignDictionary("containers")
+		self.domains = utils.SingleAssignDictionary("domains")
 	
 	def dump(self):
 		output = "Types:\n"
@@ -45,8 +45,8 @@ class Tree(object):
 		output += "\nComponents:\n"
 		for element in self.components:
 			output += "- %s\n" % element
-		output += "\nContainer:\n"
-		for element in self.container:
+		output += "\nContainers:\n"
+		for element in self.containers:
 			output += "- %s\n" % element
 		output += "\nDomains:\n"
 		for element in self.domains:
@@ -86,12 +86,12 @@ class Parser(object):
 		
 		Parsing is done in two steps: Creating the empty elements first, fill and link them then.
 		 1. Creating the elements and add them to the tree parsing the names only. This should be an independent task
-		  types, events, components, container, doains
+		  types, events, components, containers, domains
 		 2. Evaluate the elements parsing the remaining xml elements. Since all elements are in tree already, these may be also independent tasks.
 		  1. Evaluate types, create dependency hierarchy
 		  2. Evaluate events, link with types 
 		  3. Evaluate components, link with types and events
-		  4. Evaluate container, link with components
+		  4. Evaluate containers, link with components
 		
 		After all a checking and optimizing step is performed
 		
@@ -198,7 +198,7 @@ class Parser(object):
 			component.flattened()
 		self.tree.components.updateIndex()
 		
-		for container in self.tree.container:
+		for container in self.tree.containers:
 			container.updateIndex()
 
 	@staticmethod
@@ -266,10 +266,10 @@ class Parser(object):
 	def _parse_container(self, xmltree):
 		for node in xmltree.findall('container'):
 			element = container.Container(node)
-			self.tree.container[element.name] = element
+			self.tree.containers[element.name] = element
 			
 	def _evaluate_container(self):
-		for c in self.tree.container:
+		for c in self.tree.containers:
 			c.evaluate(self.tree)
 	
 	def _parse_domains(self, xmltree):
@@ -302,4 +302,4 @@ if __name__ == "__main__":
 	#print tree.components["driver"].flattened().dump()
 	#print tree.components["driver"].abstract
 	
-	#print tree.container["drive"].subscriptions
+	#print tree.containers["drive"].subscriptions


### PR DESCRIPTION
In the progress of adding raw Ethernet frames as a backend for XPCC
communication, each container requires a unique id.

When using CAN as a backend filtering is done by component id.
Normally, each CAN controller has enough filters to accommodate up to
ten components per container. E.g. STM32F4 has 14 CAN filters.

When moving to Ethernet, the Ethernet MAC controller only has two or
six filters which may be not enough. The filters are more difficult to
configure.

The fifth byte of the MAC address will be used for the container Id and
the sixth byte for the component Id.
MAC filtering then can be easily implemented by filtering for the first
five bytes of the MAC address.

There is no overhead for CAN communication as container Id is omitted.
