### PR TITLE
CAN2USB: Move SerialInterface out of USB2CAN implementation.

### DIFF
--- a/examples/linux/can_debugger/main.cpp
+++ b/examples/linux/can_debugger/main.cpp
@@ -5,8 +5,6 @@
 #include <xpcc/architecture/interface/can.hpp>
 #include <xpcc/architecture/platform/driver/can/canusb/canusb.hpp>
 
-#include <cstdlib>
-
 /**
  * Simple example that listens to a CAN bus connected by a CAN2USB.
  *
@@ -22,15 +20,16 @@
  * - All CAN messages on the bus should appear on the screen.
  */
 
-static constexpr uint32_t canBusBaudRate = 125000;
+static constexpr xpcc::Can::Bitrate canBusBitRate = xpcc::Can::kBps125;
 
-xpcc::hosted::CanUsb canUsb;
+xpcc::hosted::SerialInterface port("/dev/ttyUSB0", 115200);
+xpcc::hosted::CanUsb<xpcc::hosted::SerialInterface> canUsb(port);
 
 int
 main()
 {
-	if (not canUsb.open("/dev/ttyUSB0", canBusBaudRate)) {
-		XPCC_LOG_ERROR << "Could not open port" << xpcc::endl;
+	if (not canUsb.open(canBusBitRate)) {
+		XPCC_LOG_ERROR << "Could not connect to CAN2USB port" << xpcc::endl;
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/xpcc/architecture/platform/driver/can/canusb/canusb.hpp
+++ b/src/xpcc/architecture/platform/driver/can/canusb/canusb.hpp
@@ -7,14 +7,12 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef XPCC_HOSTED_CAN_USB_HPP
-#define XPCC_HOSTED_CAN_USB_HPP
+#ifndef XPCC_CAN_USB_HPP
+#define XPCC_CAN_USB_HPP
 
 #include <queue>
 #include <string>
 
-// FIXME: remove this dependency!
-#include "../../uart/hosted/serial_interface.hpp"
 #include <xpcc/architecture/interface/can.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread.hpp>
@@ -32,15 +30,16 @@ namespace hosted
  * @see		http://www.can232.com/
  * @ingroup	hosted
  */
+template <typename SerialPort>
 class CanUsb : public ::xpcc::Can
 {
 public:
-	CanUsb();
+	CanUsb(SerialPort& serialPort);
 
 	~CanUsb();
 
 	bool
-	open(std::string deviceName, unsigned int serialBaudRate, xpcc::Can::Bitrate canBitrate = xpcc::Can::kBps125);
+	open(xpcc::Can::Bitrate canBitrate = xpcc::Can::kBps125);
 
 	void
 	close();
@@ -93,7 +92,7 @@ private:
 
 	BusState busState;
 
-	xpcc::hosted::SerialInterface serialPort;
+	SerialPort& serialPort;
 
 	std::string tmpRead;
 	std::queue<can::Message> readBuffer;
@@ -105,4 +104,6 @@ private:
 
 }	// namespace xpcc
 
-#endif // XPCC_HOSTED_CAN_USB_HPP
+#include "canusb_impl.hpp"
+
+#endif // XPCC_CAN_USB_HPP

--- a/src/xpcc/architecture/platform/driver/can/canusb/driver.xml
+++ b/src/xpcc/architecture/platform/driver/can/canusb/driver.xml
@@ -3,6 +3,6 @@
 <rca version="1.0">
 	<driver type="can" name="canusb">
 		<static>canusb.hpp</static>
-		<static>canusb.cpp</static>
+		<static>canusb_impl.hpp</static>
 	</driver>
 </rca>

--- a/src/xpcc/architecture/platform/driver/uart/posix/serial_interface.cpp
+++ b/src/xpcc/architecture/platform/driver/uart/posix/serial_interface.cpp
@@ -70,7 +70,6 @@ bool
 xpcc::hosted::SerialInterface::setBaudRate(unsigned int rate)
 {
 	struct termios configuration;
-	int result1, result2, result3;
 
 	// Read current configuration structure
 	tcgetattr(this->fileDescriptor, &configuration);
@@ -89,11 +88,11 @@ xpcc::hosted::SerialInterface::setBaudRate(unsigned int rate)
 		(rate == 115200) ? B115200 : B0;
 
 	// Change the configuration structure
-	result1 = cfsetispeed(&configuration, baudRateConstant);
-	result2 = cfsetospeed(&configuration, baudRateConstant);
+	int result1 = cfsetispeed(&configuration, baudRateConstant);
+	int result2 = cfsetospeed(&configuration, baudRateConstant);
 
 	// Set the modified configuration structure
-	result3 = tcsetattr(this->fileDescriptor, TCSANOW, &configuration);
+	int result3 = tcsetattr(this->fileDescriptor, TCSANOW, &configuration);
 
 	if (result1 < 0 || result2 < 0 || result3 < 0)
 	{


### PR DESCRIPTION
Removes dependency on hosted/serial_interface.hpp in canusb.hpp