### PR TITLE
Fix ZeroMQ communication backend

### DIFF
--- a/src/xpcc/communication/xpcc/backend/zeromq/build.cfg
+++ b/src/xpcc/communication/xpcc/backend/zeromq/build.cfg
@@ -1,0 +1,3 @@
+
+[build]
+target = hosted

--- a/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
@@ -1,0 +1,122 @@
+// coding: utf-8
+/* Copyright (c) 2017, Roboterclub Aachen e. V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include "connector.hpp"
+
+namespace xpcc
+{
+
+ZeroMQConnector::ZeroMQConnector(std::string endpointIn, std::string endpointOut, Mode mode) :
+	socketIn (context, (mode == Mode::SubPush ? zmqpp::socket_type::sub  : zmqpp::socket_type::pull)),
+	socketOut(context, (mode == Mode::SubPush ? zmqpp::socket_type::push : zmqpp::socket_type::pub)),
+	reader(socketIn)
+{
+	switch(mode)
+	{
+		case
+		Mode::SubPush:
+			this->socketIn.connect(endpointIn);
+			this->socketIn.subscribe("");
+
+			this->socketOut.connect(endpointOut);
+		break;
+
+		case
+		Mode::PubPull:
+			this->socketIn.bind(endpointIn);
+			this->socketOut.bind(endpointOut);
+		break;
+	}
+
+	this->reader.start();
+}
+
+// ----------------------------------------------------------------------------
+ZeroMQConnector::~ZeroMQConnector()
+{
+	this->reader.stop();
+	this->socketIn.unsubscribe("");
+	this->socketOut.unsubscribe("");
+	this->socketIn.close();
+	this->socketOut.close();
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQConnector::sendPacket(const Header &header, SmartPointer payload)
+{
+	// Publish the reassembled message with zeromq
+	zmqpp::message message;
+
+	// Manual serialisation of XPCC Header and Payload into a byte buffer
+	// The mapping of type, ack, dest, src and id into a uint32_t from
+	// CanConnectorBase is used.
+
+	// 5 bytes for header
+	uint16_t buf_size = 5 + payload.getSize();
+	uint8_t buf[buf_size];
+
+	buf[0] = static_cast<uint8_t>(header.type);
+	buf[1] = header.isAcknowledge;
+	buf[2] = header.destination;
+	buf[3] = header.source;
+	buf[4] = header.packetIdentifier;
+
+	memcpy(buf + 5, payload.getPointer(), payload.getSize());
+
+#	if ZMQPP_VERSION_MAJOR >= 4
+	/**
+	* Breaking change in 4.1.1:
+	* Removed message::add(pointer, size_t) as there were situations it conflicts with the new easier 
+	* to use templated add. This has been replaced with a message::add_raw(pointer, size_t) method.
+	* https://github.com/zeromq/zmqpp/blob/develop/CHANGES.md
+	*/
+	message.add_raw(buf, buf_size);
+#	else
+	message.add(buf, buf_size);
+#	endif
+
+	socketOut.send(message, /* dont_block = */ true);
+}
+
+// ----------------------------------------------------------------------------
+bool
+ZeroMQConnector::isPacketAvailable() const
+{
+	return this->reader.isPacketAvailable();
+}
+
+// ----------------------------------------------------------------------------
+const Header&
+ZeroMQConnector::getPacketHeader() const
+{
+	return this->reader.getPacket().header;
+};
+
+// ----------------------------------------------------------------------------
+const xpcc::SmartPointer
+ZeroMQConnector::getPacketPayload() const
+{
+	return this->reader.getPacket().payload;
+};
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQConnector::dropPacket()
+{
+	this->reader.dropPacket();
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQConnector::update()
+{
+}
+
+} // xpcc namespace

--- a/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
@@ -1,5 +1,6 @@
 // coding: utf-8
-/* Copyright (c) 2017, Roboterclub Aachen e. V.
+/* Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Christopher Durand
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD

--- a/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/connector.cpp
@@ -22,7 +22,10 @@ ZeroMQConnector::ZeroMQConnector(std::string endpointIn, std::string endpointOut
 		case
 		Mode::SubPush:
 			this->socketIn.connect(endpointIn);
-			this->socketIn.subscribe("");
+
+			if(this->socketIn.type() == zmqpp::socket_type::sub) {
+				this->socketIn.subscribe("");
+			}
 
 			this->socketOut.connect(endpointOut);
 		break;
@@ -41,8 +44,11 @@ ZeroMQConnector::ZeroMQConnector(std::string endpointIn, std::string endpointOut
 ZeroMQConnector::~ZeroMQConnector()
 {
 	this->reader.stop();
-	this->socketIn.unsubscribe("");
-	this->socketOut.unsubscribe("");
+
+	if(this->socketIn.type() == zmqpp::socket_type::sub) {
+		this->socketIn.unsubscribe("");
+	}
+
 	this->socketIn.close();
 	this->socketOut.close();
 }

--- a/src/xpcc/communication/xpcc/backend/zeromq/connector.hpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/connector.hpp
@@ -1,5 +1,6 @@
 // coding: utf-8
-/* Copyright (c) 2016, Roboterclub Aachen e. V.
+/* Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Christopher Durand
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -33,6 +34,14 @@ public:
 	};
 };
 
+/**
+ * @brief	ZeroMQ communication backend for hosted
+ *
+ * @ingroup	backend
+ *
+ * @author	strongly-typed
+ * @author	Christopher Durand <christopher.durand@rwth-aachen.de>
+ */
 class ZeroMQConnector : public ZeroMQConnectorBase, public BackendInterface
 {
 public:

--- a/src/xpcc/communication/xpcc/backend/zeromq/connector.hpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/connector.hpp
@@ -36,107 +36,30 @@ public:
 class ZeroMQConnector : public ZeroMQConnectorBase, public BackendInterface
 {
 public:
-	ZeroMQConnector(std::string endpointIn, std::string endpointOut, Mode mode = Mode::SubPush) :
-		socketIn (context, (mode == Mode::SubPush ? zmqpp::socket_type::sub  : zmqpp::socket_type::pull)),
-		socketOut(context, (mode == Mode::SubPush ? zmqpp::socket_type::push : zmqpp::socket_type::pub)),
-		reader(socketIn)
-	{
-		switch(mode)
-		{
-			case
-			Mode::SubPush:
-				this->socketIn.connect(endpointIn);
-				this->socketIn.subscribe("");
-
-				this->socketOut.connect(endpointOut);
-			break;
-
-			case
-			Mode::PubPull:
-				this->socketIn.bind(endpointIn);
-				this->socketOut.bind(endpointOut);
-			break;
-		}
-
-		this->reader.start();
-	}
+	ZeroMQConnector(std::string endpointIn, std::string endpointOut,
+					Mode mode = Mode::SubPush);
 
 	virtual
-	~ZeroMQConnector()
-	{
-		this->reader.stop();
-		this->socketIn.unsubscribe("");
-		this->socketOut.unsubscribe("");
-		this->socketIn.close();
-		this->socketOut.close();
-	}
+	~ZeroMQConnector() override;
 
 	virtual void
-	sendPacket(const Header &header, SmartPointer payload)
-	{
-		// Publish the reassembled message with zeromq
-		zmqpp::message message;
-
-		// Manual serialisation of XPCC Header and Payload into a byte buffer
-		// The mapping of type, ack, dest, src and id into a uint32_t from
-		// CanConnectorBase is used.
-
-		// 5 bytes for header
-		uint16_t buf_size = 5 + payload.getSize();
-		uint8_t buf[buf_size];
-
-		buf[0] = static_cast<uint8_t>(header.type);
-		buf[1] = header.isAcknowledge;
-		buf[2] = header.destination;
-		buf[3] = header.source;
-		buf[4] = header.packetIdentifier;
-
-		memcpy(buf + 5, payload.getPointer(), payload.getSize());
-
-#		if ZMQPP_VERSION_MAJOR >= 4
-		/**
-		 * Breaking change in 4.1.1:
-		 * Removed message::add(pointer, size_t) as there were situations it conflicts with the new easier 
-		 * to use templated add. This has been replaced with a message::add_raw(pointer, size_t) method.
-		 * https://github.com/zeromq/zmqpp/blob/develop/CHANGES.md
-		 */
-		message.add_raw(buf, buf_size);
-#		else
-		message.add(buf, buf_size);
-#		endif
-
-		socketOut.send(message, /* dont_block = */ true);
-	}
+	sendPacket(const Header &header, SmartPointer payload) override;
 
 	virtual bool
-	isPacketAvailable() const
-	{
-		return this->reader.isPacketAvailable();
-	}
+	isPacketAvailable() const override;
 
 	virtual const Header&
-	getPacketHeader() const
-	{
-		return this->reader.getPacket().header;
-	};
+	getPacketHeader() const override;
 
 	virtual const xpcc::SmartPointer
-	getPacketPayload() const
-	{
-		return this->reader.getPacket().payload;
-	};
+	getPacketPayload() const override;
 
 	virtual void
-	dropPacket()
-	{
-		this->reader.dropPacket();
-	}
+	dropPacket() override;
 
 	virtual void
-	update()
-	{
-		// Nothing to do here
-	}
+	update() override;
+
 protected:
 	zmqpp::context context;
 	zmqpp::socket socketIn;

--- a/src/xpcc/communication/xpcc/backend/zeromq/reader.cpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/reader.cpp
@@ -1,5 +1,6 @@
 // coding: utf-8
-/* Copyright (c) 2017, Roboterclub Aachen e. V.
+/* Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Christopher Durand
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD

--- a/src/xpcc/communication/xpcc/backend/zeromq/reader.cpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/reader.cpp
@@ -1,0 +1,146 @@
+// coding: utf-8
+/* Copyright (c) 2017, Roboterclub Aachen e. V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include "reader.hpp"
+
+#include <algorithm>
+
+namespace xpcc
+{
+
+// ----------------------------------------------------------------------------
+ZeroMQReader::ZeroMQReader(zmqpp::socket& socketIn_, std::size_t maxQueueSize_) :
+	socketIn(socketIn_), maxQueueSize(maxQueueSize_), stopThread(false)
+{
+}
+
+// ----------------------------------------------------------------------------
+ZeroMQReader::~ZeroMQReader()
+{
+	stop();
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQReader::start()
+{
+	stop();
+
+	this->stopThread = false;
+	this->thread = std::thread([this]() {
+		receiveThread();
+	});
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQReader::stop()
+{
+	if(this->thread.joinable()) {
+		this->stopThread = true;
+		this->thread.join();
+	}
+}
+
+// ----------------------------------------------------------------------------
+bool
+ZeroMQReader::isPacketAvailable() const
+{
+	std::lock_guard<std::mutex> lock(this->queueMutex);
+	return not this->queue.empty();
+}
+
+// ----------------------------------------------------------------------------
+const ZeroMQReader::Packet&
+ZeroMQReader::getPacket() const
+{
+	std::lock_guard<std::mutex> lock(this->queueMutex);
+	return this->queue.front();
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQReader::dropPacket()
+{
+	std::lock_guard<std::mutex> lock(this->queueMutex);
+
+	if(not this->queue.empty()) {
+		this->queue.pop_front();
+	}
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQReader::receiveThread()
+{
+	zmqpp::poller poller;
+	zmqpp::message message;
+
+	poller.add(this->socketIn, zmqpp::poller::poll_in);
+
+	while(not this->stopThread) {
+		while(this->socketIn.receive(message, /* no_block = */ true)) {
+			readPacket(message);
+
+#			if ZMQPP_VERSION_MAJOR < 4
+			// swap and discard old message as in zmqpp 3
+			// "receiving can only be done to empty messages"
+			zmqpp::message emptyMessage;
+			std::swap(emptyMessage, message);
+#			endif
+		}
+		poller.poll(PollTimeoutMs);
+	}
+}
+
+// ----------------------------------------------------------------------------
+void
+ZeroMQReader::readPacket(const zmqpp::message& message)
+{
+	constexpr uint16_t headerSize = 5;
+
+	// Maximum payload size of xpcc::SmartPointer
+	constexpr uint16_t maxPayloadSize = 65529;
+
+	const auto size = message.size(0);
+
+	if(size >= headerSize && size <= (headerSize + maxPayloadSize)) {
+		const uint8_t* const data = static_cast<const uint8_t*>(message.raw_data());
+		const auto payloadSize = size - headerSize;
+
+		xpcc::Header header = xpcc::Header(
+			/* type = */ xpcc::Header::Type(data[0]),
+			/* ack  = */ data[1],
+			/* dest = */ data[2],
+			/* src  = */ data[3],
+			/* id   = */ data[4]);
+
+		{
+			std::lock_guard<std::mutex> lock(this->queueMutex);
+
+			if (this->queue.size() >= this->maxQueueSize) {
+				this->queue.pop_front();
+
+				XPCC_LOG_ERROR << XPCC_FILE_INFO;
+				XPCC_LOG_ERROR << "Receive queue is full, dropping packets" << xpcc::endl;
+			}
+
+			this->queue.emplace_back(payloadSize, header);
+
+			// Copy received payload to packet
+			uint8_t* const payloadBuffer = this->queue.back().payload.getPointer();
+			std::copy_n(data + headerSize, payloadSize, payloadBuffer);
+		}
+	} else {
+		XPCC_LOG_ERROR << XPCC_FILE_INFO;
+		XPCC_LOG_ERROR << "Invalid message length: " << size << xpcc::endl;
+	}
+}
+
+} // xpcc namespace

--- a/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
@@ -1,0 +1,177 @@
+// coding: utf-8
+/* Copyright (c) 2016, Roboterclub Aachen e. V.
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef	XPCC__ZEROMQ_READER_HPP
+#define	XPCC__ZEROMQ_READER_HPP
+
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <deque>
+
+#include <zmqpp/zmqpp.hpp>
+
+#include <xpcc/debug/logger.hpp>
+#undef XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::ERROR
+
+namespace xpcc
+{
+
+class ZeroMQReader
+{
+public:
+	static constexpr int PollTimeoutMs = 100;
+
+	struct Packet
+	{
+		Packet(uint8_t size, const Header& inHeader) :
+			header(inHeader), payload(size) {}
+
+		xpcc::Header header;
+		xpcc::SmartPointer payload;
+	};
+
+	ZeroMQReader(zmqpp::socket& socketIn_, std::size_t maxQueueSize_ = 1000) :
+		socketIn(socketIn_), maxQueueSize(maxQueueSize_), stopThread(false)
+	{
+	}
+
+	~ZeroMQReader()
+	{
+		stop();
+	}
+
+	ZeroMQReader(const ZeroMQReader&) = delete;
+	ZeroMQReader& operator=(const ZeroMQReader&) = delete;
+
+	void
+	start()
+	{
+		stop();
+
+		this->stopThread = false;
+		this->thread = std::thread([this]() {
+			receiveThread();
+		});
+	}
+
+	void
+	stop()
+	{
+		if(this->thread.joinable()) {
+			this->stopThread = true;
+			this->thread.join();
+		}
+	}
+
+	bool
+	isPacketAvailable() const
+	{
+		std::lock_guard<std::mutex> lock(this->queueMutex);
+		return not this->queue.empty();
+	}
+
+	const Packet&
+	getPacket() const
+	{
+		std::lock_guard<std::mutex> lock(this->queueMutex);
+		return this->queue.front();
+	}
+
+	void
+	dropPacket()
+	{
+		std::lock_guard<std::mutex> lock(this->queueMutex);
+
+		if(not this->queue.empty()) {
+			this->queue.pop_front();
+		}
+	}
+
+private:
+	void
+	receiveThread()
+	{
+		zmqpp::poller poller;
+		zmqpp::message message;
+
+		poller.add(this->socketIn, zmqpp::poller::poll_in);
+
+		while(not this->stopThread) {
+			while(this->socketIn.receive(message, /* no_block = */ true)) {
+				readPacket(message);
+
+#				if ZMQPP_VERSION_MAJOR < 4
+				// swap and discard old message as in zmqpp 3
+				// "receiving can only be done to empty messages"
+				zmqpp::message emptyMessage;
+				std::swap(emptyMessage, message);
+#				endif
+			}
+			poller.poll(PollTimeoutMs);
+		}
+	}
+
+	void
+	readPacket(const zmqpp::message& message)
+	{
+		constexpr uint16_t headerSize = 5;
+
+		// Maximum payload size of xpcc::SmartPointer
+		constexpr uint16_t maxPayloadSize = 65529;
+
+		const auto size = message.size(0);
+
+		if(size >= headerSize && size <= (headerSize + maxPayloadSize)) {
+			const uint8_t* const data = static_cast<const uint8_t*>(message.raw_data());
+			const auto payloadSize = size - headerSize;
+
+			xpcc::Header header = xpcc::Header(
+				/* type = */ xpcc::Header::Type(data[0]),
+				/* ack  = */ data[1],
+				/* dest = */ data[2],
+				/* src  = */ data[3],
+				/* id   = */ data[4]);
+
+			{
+				std::lock_guard<std::mutex> lock(this->queueMutex);
+
+				if (this->queue.size() >= this->maxQueueSize) {
+					this->queue.pop_front();
+
+					XPCC_LOG_ERROR << XPCC_FILE_INFO;
+					XPCC_LOG_ERROR << "Receive queue is full, dropping packets" << xpcc::endl;
+				}
+
+				this->queue.emplace_back(payloadSize, header);
+
+				// Copy received payload to packet
+				uint8_t* const payloadBuffer = this->queue.back().payload.getPointer();
+				std::copy_n(data + headerSize, payloadSize, payloadBuffer);
+			}
+		} else {
+			XPCC_LOG_ERROR << XPCC_FILE_INFO;
+			XPCC_LOG_ERROR << "Invalid message length: " << size << xpcc::endl;
+		}
+	}
+private:
+	zmqpp::socket& socketIn;
+
+	std::deque<Packet> queue;
+	mutable std::mutex queueMutex;
+	const std::size_t maxQueueSize;
+
+	std::thread thread;
+	std::atomic<bool> stopThread;
+};
+
+} // xpcc namespace
+
+#endif // XPCC__ZEROMQ_CONNECTOR_HPP

--- a/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
@@ -33,7 +33,7 @@ public:
 
 	struct Packet
 	{
-		Packet(uint8_t size, const Header& inHeader) :
+		Packet(uint16_t size, const Header& inHeader) :
 			header(inHeader), payload(size) {}
 
 		xpcc::Header header;

--- a/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
+++ b/src/xpcc/communication/xpcc/backend/zeromq/reader.hpp
@@ -1,5 +1,6 @@
 // coding: utf-8
-/* Copyright (c) 2017, Roboterclub Aachen e. V.
+/* Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Christopher Durand
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -26,6 +27,14 @@
 namespace xpcc
 {
 
+/**
+ * @brief	Reads packets from a zmqpp socket in a background thread
+ *
+ * @ingroup	backend
+ *
+ * @author	Christopher Durand <christopher.durand@rwth-aachen.de>
+ * @author	strongly-typed
+ */
 class ZeroMQReader
 {
 public:


### PR DESCRIPTION
This fixes several problems in the ZeroMQ backend. The header-only implementation is also moved to cpp files. Thus ZeroMQ and zmqpp will be required for building xpcc on hosted. Is this a problem?