### PR TITLE
gitlab-ci: do same check as Travis CI because 'scons check' always fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,11 +2,36 @@ unittest:
   script:
     - env
     - scons unittest
-
-check:
+    - scons unittest target=stm32
+    - scons unittest target=atmega
+   
+devices:
   script:
     - env
-    - scons check
+    - scons check=devices
+
+examples:
+  script:
+    - env
+    - scons check=examples examples=stm32f4_discovery
+    - scons check=examples examples=stm32f3_discovery
+    - scons check=examples examples=avr
+    - scons check=examples examples=linux
+    - scons check=examples examples=stm32f429_discovery
+    - scons check=examples examples=stm32f1_discovery
+    - scons check=examples examples=stm32f072_discovery
+    - scons check=examples examples=lpcxpresso
+    - scons check=examples examples=stm32
+    - scons check=examples examples=arduino_uno
+    - scons check=examples examples=stm32f746g_discovery
+    - scons check=examples examples=stm32f4_loa_v2b
+    - scons check=examples examples=stm32f469_discovery
+    - scons check=examples examples=nucleo_f103rb
+    - scons check=examples examples=nucleo_f303k8
+    - scons check=examples examples=nucleo_f411re
+    - scons check=examples examples=nucleo_f429zi
+    - scons check=examples examples=unittest
+    - scons check=examples examples=zmq
 
 documentation:
   script:


### PR DESCRIPTION
This will be used on our RCA internal Gitlab instance.