### PR TITLE
Add context value to xpcc_assert

### DIFF
--- a/examples/avr/assert/main.cpp
+++ b/examples/avr/assert/main.cpp
@@ -22,13 +22,15 @@ using xpcc::accessor::asFlash;
 extern "C" void
 xpcc_abandon(const char * module,
 			 const char * location,
-			 const char * failure)
+			 const char * failure,
+			 uintptr_t context)
 {
 	serialStream << IFS("Assertion '")
 			<< asFlash(module) << '.'
 			<< asFlash(location) << '.'
 			<< asFlash(failure)
-			<< IFS("' failed! Abandoning.") << xpcc::endl;
+			<< IFS("' @ ") << (void *) context
+			<< IFS(" failed! Abandoning.") << xpcc::endl;
 
 	Leds::setOutput();
 	while(1) {
@@ -42,7 +44,8 @@ xpcc_abandon(const char * module,
 static xpcc::Abandonment
 test_assertion_handler(const char * module,
 					   const char * /* location */,
-					   const char * /* failure */)
+					   const char * /* failure */,
+					   uintptr_t /* context */)
 {
 	serialStream << IFS("#1: '") << asFlash(module) << IFS("'!") << xpcc::endl;
 	// The strings are located in FLASH!!!
@@ -55,7 +58,8 @@ XPCC_ASSERTION_HANDLER(test_assertion_handler);
 static xpcc::Abandonment
 test_assertion_handler2(const char * /* module */,
 						const char * location,
-						const char * /* failure */)
+						const char * /* failure */,
+						uintptr_t /* context */)
 {
 	serialStream << IFS("#2: '") << asFlash(location) << IFS("'!") << xpcc::endl;
 	return xpcc::Abandonment::DontCare;
@@ -65,7 +69,8 @@ XPCC_ASSERTION_HANDLER(test_assertion_handler2);
 static xpcc::Abandonment
 test_assertion_handler3(const char * /* module */,
 						const char * /* location */,
-						const char * failure)
+						const char * failure,
+						uintptr_t /* context */)
 {
 	serialStream << IFS("#3: '") << asFlash(failure) << IFS("'!") << xpcc::endl;
 	return xpcc::Abandonment::DontCare;

--- a/examples/linux/assert/main.cpp
+++ b/examples/linux/assert/main.cpp
@@ -6,8 +6,9 @@
 
 static xpcc::Abandonment
 test_assertion_handler(const char * module,
-					   const char * location,
-					   const char * failure)
+					   const char * /* location */,
+					   const char * /* failure */,
+					   uintptr_t /* context */)
 {
 	if (strcmp(module, XPCC_IOBUFFER_MODULE_NAME) == 0)
 		return xpcc::Abandonment::Ignore;

--- a/examples/stm32f469_discovery/assert/main.cpp
+++ b/examples/stm32f469_discovery/assert/main.cpp
@@ -8,11 +8,13 @@ using namespace Board;
 
 extern "C" void xpcc_abandon(const char * module,
 							 const char * location,
-							 const char * failure)
+							 const char * failure,
+							 uintptr_t context)
 {
 	XPCC_LOG_ERROR << "Assertion '"
 			<< module << "." << location << "." << failure
-			<< "' failed! Abandoning." << xpcc::endl;
+			<< "' @ " << (void *) context
+			<< " failed! Abandoning..." << xpcc::endl;
 
 	LedGreen::setOutput();
 	while(1) {
@@ -26,7 +28,8 @@ extern "C" void xpcc_abandon(const char * module,
 static xpcc::Abandonment
 test_assertion_handler(const char * module,
 					   const char * /* location */,
-					   const char * /* failure */)
+					   const char * /* failure */,
+					   uintptr_t /* context */)
 {
 	if (strcmp(module, XPCC_IOBUFFER_MODULE_NAME) == 0)
 		return xpcc::Abandonment::Ignore;

--- a/src/xpcc/architecture/platform/driver/core/avr/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/avr/assert.cpp
@@ -21,7 +21,7 @@ extern AssertionHandler __assertion_table_end;
 extern "C"
 {
 
-void xpcc_assert_fail(const char * identifier)
+void xpcc_assert_fail(const char * identifier, uintptr_t context)
 {
 	uint8_t state(uint8_t(Abandonment::DontCare));
 	const char * module = identifier;
@@ -32,18 +32,18 @@ void xpcc_assert_fail(const char * identifier)
 	for (; table_addr < &__assertion_table_end; table_addr++)
 	{
 		AssertionHandler handler = (AssertionHandler) pgm_read_word(table_addr);
-		state |= (uint8_t) handler(module, location, failure);
+		state |= (uint8_t) handler(module, location, failure, context);
 	}
 
 	if (state == (uint8_t) Abandonment::DontCare or
 		state & (uint8_t) Abandonment::Fail)
 	{
-		xpcc_abandon(module, location, failure);
+		xpcc_abandon(module, location, failure, context);
 		exit(1);
 	}
 }
 
-void xpcc_abandon(const char *, const char *, const char *) __attribute__((weak));
-void xpcc_abandon(const char *, const char *, const char *) {}
+xpcc_weak
+void xpcc_abandon(const char *, const char *, const char *, uintptr_t) {}
 
 }

--- a/src/xpcc/architecture/platform/driver/core/cortex/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/cortex/assert.cpp
@@ -20,7 +20,7 @@ extern AssertionHandler __assertion_table_end;
 extern "C"
 {
 
-void xpcc_assert_fail(const char * identifier)
+void xpcc_assert_fail(const char * identifier, uintptr_t context)
 {
 	uint8_t state(uint8_t(Abandonment::DontCare));
 	const char * module = identifier;
@@ -30,18 +30,18 @@ void xpcc_assert_fail(const char * identifier)
 	AssertionHandler * handler = &__assertion_table_start;
 	for (; handler < &__assertion_table_end; handler++)
 	{
-		state |= (uint8_t) (*handler)(module, location, failure);
+		state |= (uint8_t) (*handler)(module, location, failure, context);
 	}
 
 	if (state == (uint8_t) Abandonment::DontCare or
 		state & (uint8_t) Abandonment::Fail)
 	{
-		xpcc_abandon(module, location, failure);
+		xpcc_abandon(module, location, failure, context);
 		exit(1);
 	}
 }
 
-void xpcc_abandon(const char *, const char *, const char *) __attribute__((weak));
-void xpcc_abandon(const char *, const char *, const char *) {}
+xpcc_weak
+void xpcc_abandon(const char *, const char *, const char *, uintptr_t) {}
 
 }

--- a/src/xpcc/processing/resumable/macros.hpp
+++ b/src/xpcc/processing/resumable/macros.hpp
@@ -224,7 +224,7 @@
 	this->template checkRfType<true>(); \
 	constexpr uint8_t rfIndex = 0; \
 	if (!this->nestingOkRf()) { \
-		xpcc_assert(false, XPCC_RESUMABLE_MODULE_NAME, "begin", "nesting"); \
+		xpcc_assert(false, XPCC_RESUMABLE_MODULE_NAME, "begin", "nesting", this); \
 		return {xpcc::rf::NestingError}; \
 	} \
 	switch (this->pushRf(0)) { \

--- a/src/xpcc/processing/resumable/test/resumable_test.cpp
+++ b/src/xpcc/processing/resumable/test/resumable_test.cpp
@@ -346,7 +346,8 @@ static bool testing_nesting_assertion(false);
 xpcc::Abandonment
 resumable_test_nesting_handler(const char * module,
 							   const char * location,
-							   const char * function)
+							   const char * function,
+							   uintptr_t)
 {
 	if (testing_nesting_assertion) {
 		TEST_ASSERT_EQUALS_STRING(module, XPCC_RESUMABLE_MODULE_NAME);


### PR DESCRIPTION
This is a breaking change for the assertion and abandon handlers (additional argument required).

The context is of type `uintptr_t` instead of `void *`, because it can also be used to pass instance parameters as integers like for instances of peripherals (e.g. CAN1 vs. CAN2). The context value must be interpreted differently depending on the passed identifiers. The context type needs to be documented, together with an annotation of functions that can "throw" an assert.

cc @chris-durand @ekiwi @dergraaf 