### PR TITLE
Add NUCLEO-F031K6 board and example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ env:
  - TEST_SUITE="check=examples examples=stm32f746g_discovery"
  - TEST_SUITE="check=examples examples=stm32f4_loa_v2b"
  - TEST_SUITE="check=examples examples=stm32f469_discovery"
+ - TEST_SUITE="check=examples examples=nucleo_f031k6"
  - TEST_SUITE="check=examples examples=nucleo_f103rb"
  - TEST_SUITE="check=examples examples=nucleo_f303k8"
  - TEST_SUITE="check=examples examples=nucleo_f411re"

--- a/examples/nucleo_f031k6/blink/SConstruct
+++ b/examples/nucleo_f031k6/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/nucleo_f031k6/blink/main.cpp
+++ b/examples/nucleo_f031k6/blink/main.cpp
@@ -1,0 +1,29 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change XPCC_LOG_LEVEL above to enable or disable these messages
+	XPCC_LOG_DEBUG   << "debug"   << xpcc::endl;
+	XPCC_LOG_INFO    << "info"    << xpcc::endl;
+	XPCC_LOG_WARNING << "warning" << xpcc::endl;
+	XPCC_LOG_ERROR   << "error"   << xpcc::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		LedD13::toggle();
+		xpcc::delayMilliseconds(Button::read() ? 100 : 500);
+
+		XPCC_LOG_INFO << "loop: " << counter++ << xpcc::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f031k6/blink/project.cfg
+++ b/examples/nucleo_f031k6/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = nucleo_f031k6
+buildpath = ${xpccpath}/build/nucleo_f031k6/${name}

--- a/src/xpcc/architecture/platform/board/nucleo_f031k6/board.cfg
+++ b/src/xpcc/architecture/platform/board/nucleo_f031k6/board.cfg
@@ -1,0 +1,16 @@
+[build]
+device = stm32f031k6
+
+[parameters]
+uart.stm32.2.tx_buffer = 256
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = B
+core.cortex.0.hardfault_handler_led_pin = 3
+# size optimizations to conserve memory
+core.cortex.0.main_stack_size = 992
+core.cortex.0.enable_hardfault_handler_log = false
+core.cortex.0.vector_table_in_ram = false
+core.cortex.0.allocator = block_allocator
+
+[openocd]
+configfile = board/st_nucleo_f0.cfg

--- a/src/xpcc/architecture/platform/board/nucleo_f031k6/nucleo_f031k6.cpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f031k6/nucleo_f031k6.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2017, Nick Sarten
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+#include "nucleo_f031k6.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+xpcc::IODeviceWrapper< Board::stlink::Uart, xpcc::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);

--- a/src/xpcc/architecture/platform/board/nucleo_f031k6/nucleo_f031k6.hpp
+++ b/src/xpcc/architecture/platform/board/nucleo_f031k6/nucleo_f031k6.hpp
@@ -1,0 +1,123 @@
+/* Copyright (c) 2017, Nick Sarten
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ * ------------------------------------------------------------------------ */
+
+//
+// NUCLEO-F031K6
+// Nucleo kit for STM32F031K6
+// http://www.st.com/en/evaluation-tools/nucleo-f031k6.html
+//
+
+#ifndef XPCC_STM32_NUCLEO_F031K6_HPP
+#define XPCC_STM32_NUCLEO_F031K6_HPP
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/debug/logger.hpp>
+#define XPCC_BOARD_HAS_LOGGER
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F031K6 running at 48MHz generated from the internal 8MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = MHz48;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb;
+
+	static constexpr uint32_t Spi1   = Apb;
+
+	static constexpr uint32_t Usart1 = Apb;
+
+	static constexpr uint32_t I2c1   = Apb;
+
+	static constexpr uint32_t Timer1  = Apb;
+	static constexpr uint32_t Timer2  = Apb;
+	static constexpr uint32_t Timer3  = Apb;
+	static constexpr uint32_t Timer14 = Apb;
+	static constexpr uint32_t Timer16 = Apb;
+	static constexpr uint32_t Timer17 = Apb;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableInternalClock();	// 8MHz
+		// (internal clock / 2) * 12 = 48MHz
+		ClockControl::enablePll(ClockControl::PllSource::InternalClock, 12, 1);
+		// set flash latency for 48MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		ClockControl::setApbPrescaler(ClockControl::ApbPrescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(4000 / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// Arduino Nano Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA3;
+using A3 = GpioA4;
+using A4 = GpioA5;
+using A5 = GpioA6;
+using A6 = GpioA7;
+using A7 = GpioA2;
+
+using D0  = GpioA10;
+using D1  = GpioA9;
+using D2  = GpioA12;
+using D3  = GpioB0;
+using D4  = GpioB7;
+using D5  = GpioB6;
+using D6  = GpioB1;
+using D7  = GpioF0;
+using D8  = GpioF1;
+using D9  = GpioA8;
+using D10 = GpioA11;
+using D11 = GpioB5;
+using D12 = GpioB4;
+using D13 = GpioB3;
+
+using Button = xpcc::GpioUnused;
+using LedD13 = D13;
+
+using Leds = xpcc::SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA15;
+using Tx = GpioOutputA2;
+using Uart = Usart1;
+}
+
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	stlink::Tx::connect(stlink::Uart::Tx);
+	stlink::Rx::connect(stlink::Uart::Rx, Gpio::InputType::PullUp);
+	stlink::Uart::initialize<systemClock, 115200>(12);
+}
+
+}
+
+#endif	// XPCC_STM32_NUCLEO_F031K6_HPP


### PR DESCRIPTION
Hi, I added support for the Nucleo F031k6 board to allow me to develop for it using XPCC. So far I've developed the platform definition based on the existing definition for the f103rb device (including support for other devices in the f031xx family). I've got the platform working with the basic blink example.

Still to be done:

- [x] OpenOCD support; there's no file for the nucleo f031k6 included with OpenOCD currently, so I have developed my own configuration file for this platform that seems to work, but I'm not sure where it fits in within XPCC.
- [x] Tests and examples for this platform.
- [x] Verify serial debugging works properly.

I would appreciate any guidance you can give me on whether this work will be valuable to the project, and how it might be improved (especially with respect to adding OpenOCD support for the platform) before it is merged.