### PR TITLE
Add .mailmap file for correct author assignment

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,29 @@
+Antal Szabó <szabo.antal.92@gmail.com>
+Christian Menard <christian.menard@gmx.de>
+Christoph Rüdi <christoph.ruedi@rwth-aachen.de>
+Christopher Durand <christopher.durand@rwth-aachen.de>
+Daniel Krebs <github@daniel-krebs.net>
+Daniel Krebs <github@daniel-krebs.net> <da.krebs@web.de>
+David Hebbeker <david.hebbeker@rwth-aachen.de> <david.hebbeker@gmail.com>
+Fabian Greif <fabian.greif@rwth-aachen.de> <fabian.greif@dlr.de>
+Georgi Grinshpun <georgi.grinshpun@rwth-aachen.de> <georgi-grinshpun@rwth-aachen.de>
+Georgi Grinshpun <georgi.grinshpun@rwth-aachen.de> <Georgi@FlipFlip>
+Hans Schily <hans.schily@rwth-aachen.de>
+Julia Gutheil <julia.gutheil@rwth-aachen.de>
+Kevin Läufer <kevin.laeufer@rwth-aachen.de>
+Kevin Läufer <kevin.laeufer@rwth-aachen.de> <electron.kiwi@gmail.com>
+Martin Esser <martin.esser@rwth-aachen.de>
+Martin Rosekeit <martin.rosekeit@rwth-aachen.de> <martin.rosekeit@rwth-aachen.de>
+Michael Thies <mail@mhthies.de>
+Nick Sarten <gen.battle@gmail.com>
+Niclas Rohrer <niclas.rohrer@rwth-aachen.de> <Niclas>
+Niklas Hauser <niklas.hauser@rwth-aachen.de> <niklas.hauser@arm.com>
+Niklas Hauser <niklas.hauser@rwth-aachen.de> <niklas.hauser@gmail.com>
+Raphael Lehmann <raphael@rleh.de>
+Sascha Schade <stronglytyp3d@gmail.com>
+Sascha Schade <stronglytyp3d@gmail.com> <davedwebb8211@gmail.com>
+Sascha Schade <stronglytyp3d@gmail.com> <strongly-typed@nan>
+Sascha Schade <stronglytyp3d@gmail.com> <stronly@typed.nan>
+Tarik TIRE <kronos@aspbooster.com>
+Thorsten Lajewski <thorsten.lajewski@rwth-aachen.de>
+Tomasz Chyrowicz <tomasz.chyrowicz@gmail.com>

--- a/tools/authors.py
+++ b/tools/authors.py
@@ -11,19 +11,6 @@ import subprocess
 from collections import defaultdict
 import argparse
 
-# some authors have aliases cos estupido
-author_alias = {
-    "Sascha Schade": ["strongly-typed", "Webb"],
-    "Kevin Läufer": ["Laeufer", "Kiwi", "Kevin"],
-    "Daniel Krebs": ["daniel"],
-    "Niclas Rohrer": ["Niclas"],
-    "Martin Rosekeit": ["martin", "thundernail"],
-    "Georgi Grinshpun": ["Georgi"],
-    "Thorsten Lajewski": ["thorsten"],
-    "Hans Schily": ["hans"],
-    "Christoph Rüdi": ["Ruedi"]
-}
-
 author_handles = {
     "Niklas Hauser": "salkinium",
     "Antal Szabó": "Sh4rK",
@@ -58,25 +45,13 @@ def get_author_log(since = None, until = None, handles = True, count = False):
     # get the shortlog summary
     output = subprocess.Popen(sl_command, shell=True, stdout=subprocess.PIPE).stdout.read()
     # parse the shortlog
-    shortlog = {}
+    shortlog = defaultdict(int)
     for line in output.splitlines():
         commits, author = line.split("\t")
-        shortlog[author] = int(commits)
-
-    # cleaned up dictionary
-    commit_count = defaultdict(int)
-    # merge authors
-    for slauthor in shortlog.keys():
-        for author, aliases in author_alias.items():
-            if any(name in slauthor for name in aliases):
-                commit_count[author] += shortlog[slauthor]
-                break;
-        else:
-            commit_count[slauthor] += shortlog[slauthor]
-            # print slauthor, "not in aliases"
+        shortlog[author] += int(commits)
 
     # convert to list of tuples for sorting
-    commit_tuples = [(c, a) for a, c in commit_count.items()]
+    commit_tuples = [(c, a) for a, c in shortlog.items()]
     if count:
         # sort by number of commits, then alphabetically by author
         commit_tuples.sort(key=lambda a: (-a[0], a[1]))


### PR DESCRIPTION
GitHub apparently [does not use the `.mailmap`](https://github.com/holman/ama/issues/551) for assigning authorship in the stats. But maybe it changed since 2014.

@daniel-k: which email do you prefer?
@dergraaf: is this ok for you?

cc @strongly-typed @ekiwi 