### PR TITLE
[math] Fix scurve controller calculation with speed target > 0

### DIFF
--- a/src/xpcc/math/filter/s_curve_controller.hpp
+++ b/src/xpcc/math/filter/s_curve_controller.hpp
@@ -118,6 +118,9 @@ namespace xpcc
 		bool targetReached;
 		
 		Parameter parameter;
+		/// distance to add to the current error for speed calculation. This is automatically calculated from
+		/// speedtarget parameter.
+		T additionalDistanceToStop;
 	};
 }
 

--- a/src/xpcc/math/filter/s_curve_controller_impl.hpp
+++ b/src/xpcc/math/filter/s_curve_controller_impl.hpp
@@ -53,6 +53,7 @@ void
 xpcc::SCurveController<T>::setParameter(const Parameter& parameter)
 {
 	this->parameter = parameter;
+	this->additionalDistanceToStop = (parameter.speedTarget * parameter.speedTarget) / parameter.decreaseFactor / 2 ;
 }
 
 // ----------------------------------------------------------------------------
@@ -85,6 +86,7 @@ inline void
 xpcc::SCurveController<T>::setSpeedTarget( const T& speed )
 {
 	this->parameter.speedTarget = speed;
+	this->additionalDistanceToStop = (speed * speed) / parameter.decreaseFactor / 2;
 }
 
 // ----------------------------------------------------------------------------
@@ -112,15 +114,16 @@ xpcc::SCurveController<T>::update(T error, const T& speed)
 	
 	T outputIncrement = currentValue + parameter.increment;
 	T outputDecrement;
+
+	targetReached = (error <= parameter.targetArea);
+	error += this->additionalDistanceToStop;
+
 	if (error <= parameter.targetArea)
 	{
-		targetReached = true;
-		outputDecrement = error * parameter.kp + parameter.speedTarget;
+		outputDecrement = error * parameter.kp;
 	}
 	else {
-		targetReached = false;
-		outputDecrement = std::sqrt((error) *
-			parameter.decreaseFactor * 2) + parameter.speedTarget;
+		outputDecrement = std::sqrt(error * parameter.decreaseFactor * 2);
 	}
 	
 	output = xpcc::min(outputIncrement, outputDecrement);


### PR DESCRIPTION
In order to achieve a constant breaking acceleration when using an SCurve controller with a target speed > 0, the input (error) value of the controller must be shifted instead of the output (speed). The required shift in error for a desired target speed must be calculated each time the target speed changes.

This pull request is urgent for the Eurobot competition next weekend.

cc @georgi-g 