### PR TITLE
[tools] Add Python 3 support to xml parser

### DIFF
--- a/tools/system_design/xmlparser/action.py
+++ b/tools/system_design/xmlparser/action.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-import utils
-import xml_utils
+from . import utils
+from . import xml_utils
 
-from parser_exception import ParserException
+from .parser_exception import ParserException
 
 class Action(object):
 	

--- a/tools/system_design/xmlparser/action.py
+++ b/tools/system_design/xmlparser/action.py
@@ -31,10 +31,20 @@ class Action(object):
 				raise ParserException("Type '%s' is not defined. Used by Action '%s')" % (type, self.name))
 				
 		return type
-	
+
 	def __cmp__(self, other):
-		return cmp(self.id, other.id) or cmp(self.name, other.name)
-	
+		return 1 - self.__eq__(other) - 2 * self.__lt__(other)
+
+	def __lt__(self, other):
+		if self.id == other.id:
+			return self.name < other.name
+		if self.id is None:
+			return other.id is not None
+		return other.id is not None and self.id < other.id
+
+	def __eq__(self, other):
+		return self.id == other.id and self.name == other.name
+
 	def update(self, top):
 		assert self.name == top.name
 		for key, value in self.__dict__.items():

--- a/tools/system_design/xmlparser/component.py
+++ b/tools/system_design/xmlparser/component.py
@@ -3,10 +3,10 @@
 
 import copy
 
-import utils
-import action
-import xml_utils
-from parser_exception import ParserException
+from . import utils
+from . import action
+from . import xml_utils
+from .parser_exception import ParserException
 
 class ComponentDictionary(utils.SingleAssignDictionary):
 	

--- a/tools/system_design/xmlparser/component.py
+++ b/tools/system_design/xmlparser/component.py
@@ -111,12 +111,14 @@ class ComponentDictionary(utils.SingleAssignDictionary):
 		"""
 		class ComponentIterator:
 			def __init__(self, list, abstract):
-				self.list = list
-				self.list.sort()
+				self.list = sorted(list)
 				self.abstract = abstract
 			
 			def __iter__(self):
 				return self
+
+			def __next__(self):
+				return self.next()
 			
 			def next(self):
 				try:
@@ -282,10 +284,20 @@ class Component(object):
 				raise ParserException("No id defined for the non abstract component '%s'!" % flat.name)
 		
 		self.__flattened = flat
-	
+
 	def __cmp__(self, other):
-		return cmp(self.id, other.id) or cmp(self.name, other.name)
-	
+		return 1 - self.__eq__(other) - 2 * self.__lt__(other)
+
+	def __lt__(self, other):
+		if self.id == other.id:
+			return self.name < other.name
+		if self.id is None:
+			return other.id is not None
+		return other.id is not None and self.id < other.id
+
+	def __eq__(self, other):
+		return self.id == other.id and self.name == other.name
+
 	def dump(self):
 		"""
 		Print a nice UML-like box of content of the component

--- a/tools/system_design/xmlparser/container.py
+++ b/tools/system_design/xmlparser/container.py
@@ -98,7 +98,17 @@ class Container:
 		self.indexReady = True
 	
 	def __cmp__(self, other):
-		return cmp(self.name.lower(), other.name.lower()) or cmp(self.id, other.id)
+		return 1 - self.__eq__(other) - 2 * self.__lt__(other)
+
+	def __lt__(self, other):
+		if self.id == other.id:
+			return self.name < other.name
+		if self.id is None:
+			return other.id is not None
+		return other.id is not None and self.id < other.id
+
+	def __eq__(self, other):
+		return self.id == other.id and self.name == other.name
 	
 	def dump(self):
 		str = "%s : container\n" % self.__str__()

--- a/tools/system_design/xmlparser/container.py
+++ b/tools/system_design/xmlparser/container.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-import utils
-import xml_utils
-from component import EventContainer
+from . import utils
+from . import xml_utils
+from .component import EventContainer
 
-from parser_exception import ParserException
+from .parser_exception import ParserException
 
 class Container:
 	""" Representation of a container which bundles components.

--- a/tools/system_design/xmlparser/domain.py
+++ b/tools/system_design/xmlparser/domain.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-import utils
-import xml_utils
+from . import utils
+from . import xml_utils
 
-from parser_exception import ParserException
+from .parser_exception import ParserException
 
 class Domain:
 	""" Representation of a domain ids.

--- a/tools/system_design/xmlparser/event.py
+++ b/tools/system_design/xmlparser/event.py
@@ -54,10 +54,20 @@ class Event(object):
 		The assert statement checks this, nothing else needs to be done.
 		"""
 		assert id(self) == id(other)
-		
+
 	def __cmp__(self, other):
-		return cmp(self.id, other.id) or cmp(self.name, other.name)
-	
+		return 1 - self.__eq__(other) - 2 * self.__lt__(other)
+
+	def __lt__(self, other):
+		if self.id == other.id:
+			return self.name < other.name
+		if self.id is None:
+			return other.id is not None
+		return other.id is not None and self.id < other.id
+
+	def __eq__(self, other):
+		return self.id == other.id and self.name == other.name
+
 	def __str__(self):
 		if self.type is None:
 			type = None

--- a/tools/system_design/xmlparser/event.py
+++ b/tools/system_design/xmlparser/event.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-import utils
-import xml_utils
+from . import utils
+from . import xml_utils
 
-from parser_exception import ParserException
+from .parser_exception import ParserException
 
 class Event(object):
 	

--- a/tools/system_design/xmlparser/parser.py
+++ b/tools/system_design/xmlparser/parser.py
@@ -177,7 +177,7 @@ class Parser(object):
 			# Add file information that is not available in the lower classes
 			# to exception. See:
 			# http://www.ianbicking.org/blog/2007/09/re-raising-exceptions.html
-			e.args = ("'%s': %s" % (xmldocument.docinfo.URL, e.message),) + e.args[1:0]
+			e.args = ("'%s': %s" % (xmldocument.docinfo.URL, str(e)),) + e.args[1:0]
 			raise
 		
 	def _evaluate_tree(self):

--- a/tools/system_design/xmlparser/parser.py
+++ b/tools/system_design/xmlparser/parser.py
@@ -6,13 +6,13 @@ import os
 import sys
 import logging
 
-from parser_exception import ParserException
-import utils
-import type
-import event
-import component
-import container
-import domain
+from .parser_exception import ParserException
+from . import utils
+from . import type
+from . import event
+from . import component
+from . import container
+from . import domain
 
 #logging.basicConfig(level=logging.DEBUG)
 logging.basicConfig(level=logging.WARNING)

--- a/tools/system_design/xmlparser/type.py
+++ b/tools/system_design/xmlparser/type.py
@@ -4,9 +4,9 @@
 import re
 import copy
 
-from parser_exception import ParserException
-import utils
-import xml_utils
+from .parser_exception import ParserException
+from . import utils
+from . import xml_utils
 
 VALID_UNDERLYING_TYPES_FOR_ENUMS = [
 	'int8_t', 'uint8_t', 'int16_t', 'uint16_t', 'int32_t', 'uint32_t', 'int64_t', 'uint64_t' ]

--- a/tools/system_design/xmlparser/type.py
+++ b/tools/system_design/xmlparser/type.py
@@ -70,16 +70,27 @@ class BaseType(object):
 	def flattened(self):
 		""" Access the version with the flattened hierarchy """
 		return self
-	
+
 	def __cmp__(self, other):
+		return 1 - self.__eq__(other) - 2 * self.__lt__(other)
+
+	def __lt__(self, other):
 		""" Compare two types
-		
-		If types are sorted they are sorted first by level and then by name.
+
+		If types are sorted, they are sorted first by level and then by name.
 		"""
-		if isinstance(other, BaseType):
-			return cmp(self.level, other.level) or cmp(self.name, other.name)
-		else:
-			return 1
+		if not isinstance(other, BaseType):
+			return False
+		if self.level == other.level:
+			return self.name < other.name
+		if self.level is None:
+			return other.level is not None
+		return other.level is not None and self.level < other.level
+
+	def __eq__(self, other):
+		if not isinstance(other, BaseType):
+			return False
+		return self.level == other.level and self.name == other.name
 
 
 class BuiltIn(BaseType):

--- a/tools/system_design/xmlparser/utils.py
+++ b/tools/system_design/xmlparser/utils.py
@@ -21,12 +21,14 @@ class SortedDictionary(dict):
 	def __iter__(self):
 		class Iterator:
 			def __init__(self, list):
-				self.list = list
-				self.list.sort()
+				self.list = sorted(list)
 			
 			def __iter__(self):
 				return self
-			
+
+			def __next__(self):
+				return self.next()
+
 			def next(self):
 				try:
 					item = self.list.pop(0)
@@ -48,7 +50,7 @@ class SingleAssignDictionary(SortedDictionary):
 		SortedDictionary.__init__(self)
 	
 	def __setitem__(self, key, item):
-		if not self.has_key(key):
+		if key not in self:
 			SortedDictionary.__setitem__(self, key, item)
 		else:
 			raise ParserException("%s '%s' defined twice!" % (self.name.capitalize(), key))

--- a/tools/system_design/xmlparser/utils.py
+++ b/tools/system_design/xmlparser/utils.py
@@ -4,7 +4,7 @@
 import re
 import copy
 
-from parser_exception import ParserException
+from .parser_exception import ParserException
 
 def check_name(name):
 	""" Checks if a string comply with some rules for the notation


### PR DESCRIPTION
… doing the smallest possible changes to the code and keeping compatibility to python 2.7.

This is required to use the xml parser in new Python projects, that extract their information about the xpcc project directly from the xml files. I did not check the builder (code generator) for Python 3 support yet.

Unfortunately custom compare operators for objects get a little trickier in Python 3 and require some new checks. See https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons