### PR TITLE
[io] Check arguments of printf format string

### DIFF
--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -460,10 +460,10 @@ public:
 	 * @param	fmt		Format string
 	 */
 	IOStream&
-	printf(const char* fmt, ...);
+	printf(const char* fmt, ...)  __attribute__((format(printf, 2, 3)));
 
 	IOStream&
-	vprintf(const char *fmt, va_list vlist);
+	vprintf(const char *fmt, va_list vlist) __attribute__((format(printf, 2, 0)));
 
 protected:
 	void


### PR DESCRIPTION
XPCC is missing checking the arguments of printf
When using `XPCC_LOG_INFO.printf("%d", (double)66.0)` a "0"  is written into the log stream w/out compile time warning

https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes