### PR TITLE
[io] Fixing printf format string.

### DIFF
--- a/examples/stm32f469_discovery/tlsf-allocator/main.cpp
+++ b/examples/stm32f469_discovery/tlsf-allocator/main.cpp
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 #include <xpcc/architecture/platform.hpp>
 
 int main()
@@ -17,7 +19,7 @@ int main()
 		d[ii] = new (xpcc::MemoryFastData) uint8_t[size];
 
 		// print what size we requested and if it succeeded
-		XPCC_LOG_INFO.printf(" malloc(%3ukB) = ", size/1024);
+		XPCC_LOG_INFO.printf(" malloc(%3" PRId32 "kB) = ", size/1024);
 		if (d[ii]) XPCC_LOG_INFO << d[ii];
 		else   XPCC_LOG_INFO << "NO MEMORY ";
 

--- a/examples/stm32f4_discovery/app_uart_sniffer/main.cpp
+++ b/examples/stm32f4_discovery/app_uart_sniffer/main.cpp
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 #include <xpcc/architecture/platform.hpp>
 #include <xpcc/debug/logger.hpp>
 #include <xpcc/processing.hpp>
@@ -37,7 +39,7 @@ setDirection(Direction dir)
 
 		xpcc::Timestamp timestamp = xpcc::Clock::now();
 
-		XPCC_LOG_INFO.printf("\e[39m\n%04d %02d:%03d +%01d:%03d ",
+		XPCC_LOG_INFO.printf("\e[39m\n%04" PRId16 " %02" PRId32 ":%03" PRId32 " +%01" PRId32 ":%03" PRId32 " ",
 				counter,
 				timestamp.getTime() / 1000,
 				timestamp.getTime() % 1000,

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/main.cpp
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/main.cpp
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 #include <xpcc/architecture/platform.hpp>
 #include <xpcc/driver/radio/nrf24/nrf24_phy.hpp>
 #include <xpcc/debug/logger.hpp>
@@ -76,16 +78,16 @@ main()
 		nrf24phy::setRxAddress(nrf24phy::Pipe::PIPE_0, 0xdeadb33f05);
 		addr = nrf24phy::getRxAddress(nrf24phy::Pipe::PIPE_0);
 		XPCC_LOG_INFO.printf("Setting RX_P0 address to:  0xDEADB33F05\n");
-		XPCC_LOG_INFO.printf("Reading RX_P0 address:     0x%x%x\n", static_cast<uint32_t>((addr >> 32) & 0xffffffff), static_cast<uint32_t>(addr & 0xffffffff));
+		XPCC_LOG_INFO.printf("Reading RX_P0 address:     0x%" PRIx32 "%" PRIx32 "\n", static_cast<uint32_t>((addr >> 32) & 0xffffffff), static_cast<uint32_t>(addr & 0xffffffff));
 
 		nrf24phy::setTxAddress(0xabcdef55ff);
 		addr = nrf24phy::getTxAddress();
 		XPCC_LOG_INFO.printf("Setting TX address to:     0xABCDEF55FF\n");
-		XPCC_LOG_INFO.printf("Reading TX address:        0x%x%x\n", static_cast<uint32_t>((addr >> 32) & 0xffffffff), static_cast<uint32_t>(addr & 0xffffffff));
+		XPCC_LOG_INFO.printf("Reading TX address:        0x%" PRIx32 "%" PRIx32 "\n", static_cast<uint32_t>((addr >> 32) & 0xffffffff), static_cast<uint32_t>(addr & 0xffffffff));
 
 		rf_ch = nrf24phy::readRegister(nrf24phy::NrfRegister::RF_CH);
 		XPCC_LOG_INFO.printf("Expected output for RF_CH: 0x2\n");
-		XPCC_LOG_INFO.printf("Reading RF_CH:             0x%x\n\n", rf_ch);
+		XPCC_LOG_INFO.printf("Reading RF_CH:             0x%" PRIx8 "\n\n", rf_ch);
 
 		xpcc::delayMilliseconds(1000);
 	}

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/main.cpp
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/main.cpp
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 #include <xpcc/architecture/platform.hpp>
 #include <xpcc/driver/radio/nrf24/nrf24_phy.hpp>
 #include <xpcc/debug/logger.hpp>
@@ -148,7 +150,7 @@ main()
 			XPCC_LOG_INFO.printf("\033[2J");
 			XPCC_LOG_INFO.printf("\033[1;10H");
 			XPCC_LOG_INFO.printf("2.4GHz scanner");
-			XPCC_LOG_INFO.printf("   max: %d", max);
+			XPCC_LOG_INFO.printf("   max: %" PRId32, max);
 
 			for(i = 0; i < max_channel; i++)
 			{

--- a/src/xpcc/architecture/interface/can_message.cpp
+++ b/src/xpcc/architecture/interface/can_message.cpp
@@ -8,6 +8,8 @@
 // ----------------------------------------------------------------------------
 
 #include <stdint.h>
+#include <inttypes.h>
+
 #include <xpcc/io/iostream.hpp>
 #include <xpcc/architecture/utils.hpp>
 #include <xpcc/architecture/interface/can_message.hpp>
@@ -21,7 +23,7 @@ namespace can
 xpcc::IOStream&
 operator << (xpcc::IOStream& s, const xpcc::can::Message m)
 {
-    s.printf("id = %04x, len = ", m.identifier);
+    s.printf("id = %04" PRIx32 ", len = ", m.identifier);
     s << m.length;
     s.printf(", flags = %c%c, data = ",
              m.flags.rtr ? 'R' : 'r',

--- a/src/xpcc/architecture/platform/driver/core/hosted/assert.cpp
+++ b/src/xpcc/architecture/platform/driver/core/hosted/assert.cpp
@@ -68,7 +68,7 @@ xpcc_weak
 void xpcc_abandon(const char * module, const char * location, const char * failure, uintptr_t context)
 {
 	XPCC_LOG_ERROR.printf("Assertion '%s.%s.%s'", module, location, failure);
-	if (context) { XPCC_LOG_ERROR.printf(" @ %p (%d)", (void *) context, context); }
+	if (context) { XPCC_LOG_ERROR.printf(" @ %p (%lu)", (void *) context, context); }
 	XPCC_LOG_ERROR.printf(" failed! Abandoning...\n");
 }
 

--- a/src/xpcc/container/test/bounded_deque_test.cpp
+++ b/src/xpcc/container/test/bounded_deque_test.cpp
@@ -245,14 +245,14 @@ BoundedDequeTest::testOneElementQueue()
 {
 	xpcc::BoundedDeque<int16_t, 1> deque;
 
-	TEST_ASSERT_EQUALS(deque.getSize(), 0);
-	TEST_ASSERT_EQUALS(deque.getMaxSize(), 1);
+	TEST_ASSERT_EQUALS(deque.getSize(), 0U);
+	TEST_ASSERT_EQUALS(deque.getMaxSize(), 1U);
 
 	TEST_ASSERT_TRUE(deque.isEmpty());
 	TEST_ASSERT_FALSE(deque.isFull());
 
 	TEST_ASSERT_TRUE(deque.append(123));
-	TEST_ASSERT_EQUALS(deque.getSize(), 1);
+	TEST_ASSERT_EQUALS(deque.getSize(), 1U);
 
 	TEST_ASSERT_FALSE(deque.isEmpty());
 	TEST_ASSERT_TRUE(deque.isFull());

--- a/src/xpcc/driver/pressure/bme280_data_impl_fp.hpp
+++ b/src/xpcc/driver/pressure/bme280_data_impl_fp.hpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <cmath>
+#include <inttypes.h>
 
 #include <xpcc/debug/logger/logger.hpp>
 
@@ -31,7 +32,7 @@ Data::calculateCalibratedTemperature()
 	int32_t adc = (((int32_t(raw[3])) << 16) | (raw[4] << 8) | (raw[5] << 0));
 	adc >>= 4;
 
-	XPCC_LOG_DEBUG.printf("adc = 0x%05x\n", adc);
+	XPCC_LOG_DEBUG.printf("adc = 0x%05" PRIx32 "\n", adc);
 
 	int32_t T1 = calibration.T1;
 	int32_t T2 = calibration.T2;

--- a/src/xpcc/driver/pressure/bmp085_data_impl_double.hpp
+++ b/src/xpcc/driver/pressure/bmp085_data_impl_double.hpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <cmath>
+#include <inttypes.h>
 
 #include <xpcc/debug/logger/logger.hpp>
 
@@ -85,7 +86,7 @@ DataDouble::calculateCalibratedPressure()
 	XPCC_LOG_DEBUG.printf("raw[2:5] = %02x %02x %02x\n", raw[2], raw[3], raw[4]);
 
 	uint32_t up = ( (uint32_t(raw[2]) << 16) | (uint16_t(raw[3]) << 8) | raw[4] );
-	XPCC_LOG_DEBUG.printf("up = %9d\n", up);
+	XPCC_LOG_DEBUG.printf("up = %9" PRId32 "\n", up);
 
 	double pu = up / double(256.0);
 	XPCC_LOG_DEBUG.printf("pu = %9.5f\n", pu);

--- a/src/xpcc/driver/pressure/bmp085_data_impl_fp.hpp
+++ b/src/xpcc/driver/pressure/bmp085_data_impl_fp.hpp
@@ -8,6 +8,7 @@
 // ----------------------------------------------------------------------------
 
 #include <stdio.h>
+#include <inttypes.h>
 #include <cmath>
 
 #include <xpcc/debug/logger/logger.hpp>
@@ -30,19 +31,19 @@ Data::calculateCalibratedTemperature()
 {
 	int32_t x1, x2;
 	uint16_t ut = (uint16_t(raw[0]) << 8) | raw[1];
-	XPCC_LOG_DEBUG.printf("ut = %d\n", ut);
+	XPCC_LOG_DEBUG.printf("ut = %" PRId16 "\n", ut);
 
 	x1 = xpcc::math::mul( int16_t(ut - calibration.ac6), int16_t(calibration.ac5)) >> 15;
-	XPCC_LOG_DEBUG.printf("x1 = %d\n", x1);
+	XPCC_LOG_DEBUG.printf("x1 = %" PRId32 "\n", x1);
 
 	x2 = (int32_t(calibration.mc) << 11) / (x1 + calibration.md);
-	XPCC_LOG_DEBUG.printf("x2 = %d\n", x2);
+	XPCC_LOG_DEBUG.printf("x2 = %" PRId32 "\n", x2);
 
 	b5 = x1 + x2;
-	XPCC_LOG_DEBUG.printf("b5 = %d\n", b5);
+	XPCC_LOG_DEBUG.printf("b5 = %" PRId32 "\n", b5);
 
 	calibratedTemperature = int16_t((b5 + 8) >> 4);
-	XPCC_LOG_DEBUG.printf("T = %d\n", calibratedTemperature);
+	XPCC_LOG_DEBUG.printf("T = %" PRId16 "\n", calibratedTemperature);
 
 	meta |= TEMPERATURE_CALCULATED;
 }

--- a/src/xpcc/driver/pressure/test/bme280_test.cpp
+++ b/src/xpcc/driver/pressure/test/bme280_test.cpp
@@ -178,7 +178,7 @@ Bme280Test::testConversion()
 
 			int32_t error = tempDouble - temp;
 
-			XPCC_LOG_DEBUG.printf("%05x\t%5d\t%5d\t%2d\n", adc, tempDouble, temp, error);
+			XPCC_LOG_DEBUG.printf("%05" PRIx32 "\t%5" PRId32 "\t%5" PRId32 "\t%2" PRId32 "\n", adc, tempDouble, temp, error);
 
 			error = std::abs(error);
 			total_error += error;
@@ -188,8 +188,8 @@ Bme280Test::testConversion()
 		}
 
 		XPCC_LOG_DEBUG.printf("== Errors ==\n");
-		XPCC_LOG_DEBUG.printf(" max = %d\n", max_error);
-		XPCC_LOG_DEBUG.printf(" sum = %d\n", total_error);
+		XPCC_LOG_DEBUG.printf(" max = %" PRId32 "\n", max_error);
+		XPCC_LOG_DEBUG.printf(" sum = %" PRId32 "\n", total_error);
 
 		TEST_ASSERT_TRUE(total_error < 51000);
 		TEST_ASSERT_TRUE(max_error <= 1);
@@ -225,7 +225,7 @@ Bme280Test::testConversion()
 			double temp;
 			dataDouble->getTemperature(temp);
 
-			XPCC_LOG_DEBUG.printf("adc_temp = %05x, T = %f\n", adc_temp, temp);
+			XPCC_LOG_DEBUG.printf("adc_temp = %05" PRIx32 ", T = %f\n", adc_temp, temp);
 
 			uint32_t adc_press_span = adc_press_max[jj] - adc_press_min[jj];
 
@@ -257,7 +257,7 @@ Bme280Test::testConversion()
 				}
 
 				int32_t error = pressFp - pressDp;
-				XPCC_LOG_DEBUG.printf("  adc_press = %05x  PressFp = %9d Pa\t PressDp = %9d Pa \t Diff = %5d Pa\n", 
+				XPCC_LOG_DEBUG.printf("  adc_press = %05" PRIx32 "  PressFp = %9" PRId32 " Pa\t PressDp = %9" PRId32 " Pa \t Diff = %5" PRId32 " Pa\n", 
 					adc_press, pressFp, pressDp, error);
 
 				error = std::abs(error);
@@ -269,8 +269,8 @@ Bme280Test::testConversion()
 		}
 
 		XPCC_LOG_DEBUG.printf("== Errors ==\n");
-		XPCC_LOG_DEBUG.printf(" max = %d\n", max_error);
-		XPCC_LOG_DEBUG.printf(" sum = %d\n", total_error);
+		XPCC_LOG_DEBUG.printf(" max = %" PRId32 "\n", max_error);
+		XPCC_LOG_DEBUG.printf(" sum = %" PRId32 "\n", total_error);
 
 		TEST_ASSERT_TRUE(total_error <= 2455);
 		TEST_ASSERT_TRUE(max_error <= 50);

--- a/src/xpcc/driver/pressure/test/bmp085_test.cpp
+++ b/src/xpcc/driver/pressure/test/bmp085_test.cpp
@@ -179,7 +179,7 @@ Bmp085Test::testConversion()
 				}
 
 				int16_t error = pressFp - pressDp;
-				XPCC_LOG_DEBUG.printf("  adc_press = %04x  PressFp = %6d Pa\t PressDp = %6d Pa \t Diff = %3d Pa\n", adc_press, pressFp, pressDp, error);
+				XPCC_LOG_DEBUG.printf("  adc_press = %04" PRIx16 "  PressFp = %6" PRId32 " Pa\t PressDp = %6" PRId32 " Pa \t Diff = %3" PRId16 " Pa\n", adc_press, pressFp, pressDp, error);
 
 				uint16_t error_abs = std::abs(error);
 				total_error += error_abs;
@@ -193,7 +193,7 @@ Bmp085Test::testConversion()
 		XPCC_LOG_DEBUG.printf(" max = %d\n", max_error);
 		XPCC_LOG_DEBUG.printf(" sum = %d\n", total_error);
 
-		TEST_ASSERT_EQUALS_RANGE(total_error, 0, 1541);
-		TEST_ASSERT_EQUALS_RANGE(max_error,   0,   71);
+		TEST_ASSERT_EQUALS_RANGE(total_error, 0u, 1541u);
+		TEST_ASSERT_EQUALS_RANGE(max_error,   0u,   71u);
 	}
 }

--- a/src/xpcc/ui/gui/widgets/numberfield.cpp
+++ b/src/xpcc/ui/gui/widgets/numberfield.cpp
@@ -54,7 +54,7 @@ xpcc::gui::FloatField::render(View* view)
 	int afterComma = std::abs(static_cast<int>((this->getValue() - beforeComma) * 1000));
 
 	*out << beforeComma << ".";
-	out->printf("%03ld", afterComma);
+	out->printf("%03d", afterComma);
 
 //	*out << this->value;
 }


### PR DESCRIPTION
Continues work on 3f50e1d748a42a3bc4d8043454d2c61495e3d6a1.

No more format warnings for

     scons unittest
     scons unittest target=stm32
     scons unittest target=atmega