### PR TITLE
Driver and example for AD7928/AD7918/AD7908 adc

### DIFF
--- a/examples/stm32f746g_discovery/adc_ad7928/SConstruct
+++ b/examples/stm32f746g_discovery/adc_ad7928/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+execfile(xpccpath + '/scons/SConstruct')

--- a/examples/stm32f746g_discovery/adc_ad7928/main.cpp
+++ b/examples/stm32f746g_discovery/adc_ad7928/main.cpp
@@ -1,0 +1,118 @@
+// coding: utf-8
+/* Copyright (c) 2017, Christopher Durand
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include <xpcc/architecture/platform.hpp>
+#include <xpcc/driver/adc/ad7928.hpp>
+
+/**
+ * Example to demonstrate an XPCC driver for AD7928/AD7918/AD7908 Adc
+ *
+ * This example uses SpiMaster2 of STM32F746G
+ *
+ * SCK		PI1
+ * MOSI		PB15
+ * MISO		PB14
+ * CS		PA8
+ *
+ * A 2.5V reference voltage is applied to Vref.
+ */
+
+using Sck = GpioOutputI1;
+using Mosi = GpioOutputB15;
+using Miso = GpioInputB14;
+using Cs = GpioOutputA8;
+using SpiMaster = SpiMaster2;
+
+using namespace Board;
+
+using xpcc::ad7928;
+
+class ThreadOne : public xpcc::pt::Protothread
+{
+public:
+	static constexpr ad7928::SequenceChannels_t sequence1 =
+		ad7928::SequenceChannels::Ch0 |
+		ad7928::SequenceChannels::Ch1 |
+		ad7928::SequenceChannels::Ch2;
+
+	static constexpr ad7928::SequenceChannels_t sequence2 =
+		ad7928::SequenceChannels::Ch0 |
+		ad7928::SequenceChannels::Ch4 |
+		ad7928::SequenceChannels::Ch5;
+
+	bool
+	update()
+	{
+		PT_BEGIN();
+
+		XPCC_LOG_INFO << "Initialize device" << xpcc::endl;
+		PT_CALL(adc.initialize());
+
+		XPCC_LOG_INFO << "Test single conversions (Ch 0-2):" << xpcc::endl;
+
+		// Initiate first conversion, result will be output during the next conversion
+		PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch0));
+
+		XPCC_LOG_INFO << PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch1)) << xpcc::endl;
+		XPCC_LOG_INFO << PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch2)) << xpcc::endl;
+
+		// Enable auto-shutdown
+		adc.setAutoShutdownEnabled(true);
+
+		XPCC_LOG_INFO << PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch2)) << xpcc::endl;
+
+		XPCC_LOG_INFO << "Test single conversion with auto-shutdown (Ch 5):" << xpcc::endl;
+		PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch5));
+		XPCC_LOG_INFO << PT_CALL(adc.singleConversion(ad7928::InputChannel::Ch0)) << xpcc::endl;
+
+		adc.setAutoShutdownEnabled(false);
+
+		XPCC_LOG_INFO << "Test sequence mode" << xpcc::endl;
+		XPCC_LOG_INFO << "Program sequence Ch0,Ch1,Ch5, Ch0,Ch4,Ch5" << xpcc::endl;
+		PT_CALL(adc.startSequence(sequence1, sequence2));
+
+		// Run forever
+		while (true)
+		{
+			XPCC_LOG_INFO << PT_CALL(adc.nextSequenceConversion()) << xpcc::endl;
+
+			timeout.restart(500);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		PT_END();
+	}
+
+private:
+	xpcc::ShortTimeout timeout;
+	xpcc::Ad7928<SpiMaster, Cs> adc;
+} thread;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Cs::setOutput(xpcc::Gpio::High);
+
+	Sck::connect(SpiMaster::Sck);
+	Mosi::connect(SpiMaster::Mosi);
+	Miso::connect(SpiMaster::Miso);
+
+	// Initialize the SPI with a 13.5MHz clock (core frequency / 16)
+	SpiMaster::initialize<Board::systemClock, 13500000ul>();
+
+	XPCC_LOG_INFO << "AD7928/AD7918/AD7908 Example" << xpcc::endl;
+
+	while (1) {
+		thread.update();
+	}
+
+	return 0;
+}

--- a/examples/stm32f746g_discovery/adc_ad7928/project.cfg
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f746g_discovery
+buildpath = ${xpccpath}/build/stm32f746g_discovery/${name}

--- a/src/xpcc/driver/adc/ad7928.cpp
+++ b/src/xpcc/driver/adc/ad7928.cpp
@@ -1,0 +1,21 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/* Copyright (c) 2017, Christopher Durand
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#include "ad7928.hpp"
+
+// ----------------------------------------------------------------------------
+xpcc::IOStream&
+xpcc::operator<<(xpcc::IOStream& out, const xpcc::ad7928::Data& data)
+{
+	out	<< "(channel = " << static_cast<uint16_t>(data.channel())
+		<< ", value = " << data.value() << ")";
+
+	return out;
+}

--- a/src/xpcc/driver/adc/ad7928.hpp
+++ b/src/xpcc/driver/adc/ad7928.hpp
@@ -1,0 +1,228 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/* Copyright (c) 2017, Christopher Durand
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_AD7928_HPP
+#define XPCC_AD7928_HPP
+
+#include <xpcc/architecture/interface/spi_device.hpp>
+#include <xpcc/architecture/driver/accessor.hpp>
+#include <xpcc/processing.hpp>
+
+namespace xpcc
+{
+
+struct ad7928
+{
+public:
+	/// Control register
+	enum class
+	ControlRegister : uint16_t
+	{
+		/// Enables writing to the control register
+		WriteControlReg = Bit15,
+
+		// bit 14: SEQ bit, see SequenceMode
+		// bit 13: don't care
+		// bit 12,11,10: channel selection, see InputChannel
+		// bit 9,8: power mode, see PowerMode
+		// bit 7: SHADOW bit, see SequenceMode
+		// bit 6: don't care
+
+		/// If this bit is set, the input range is 0..Vref,
+		/// else 0..2*Vref (4.75V < AVdd < 5.25V required)
+		VrefRange = Bit5,
+
+		/// Unsigned output, else two's complement signed output for
+		/// differential signals (output 0 for input Vref/2)
+		UnsignedOutput = Bit4
+	};
+
+	XPCC_FLAGS16(ControlRegister);
+
+	/// Sequence mode
+	enum class
+	SequenceMode : uint16_t
+	{
+		/// Sequence mode disabled
+		NoSequence = 0,
+
+		/// If this bit is set, the next 2 bytes written to the device
+		/// will be clocked into the shadow register and non-continuous
+		/// sequence mode will be enabled
+		ProgramShadowRegister = Bit7,
+
+		/// Continue the current sequence, conversion settings can be changed
+		ContinueSequence = Bit14,
+
+		/// Enable continuous sequence mode, not supported
+		ContinuousSequence = Bit14 | Bit7
+	};
+	typedef xpcc::Configuration<ControlRegister_t, SequenceMode, Bit14 | Bit7> SequenceMode_t;
+
+	/// ADC input channels
+	enum class
+	InputChannel : uint8_t
+	{
+		Ch0 = 0,
+		Ch1 = Bit0,
+		Ch2 = Bit1,
+		Ch3 = Bit1 | Bit0,
+		Ch4 = Bit2,
+		Ch5 = Bit2 | Bit0,
+		Ch6 = Bit2 | Bit1,
+		Ch7 = Bit2 | Bit1 | Bit0
+	};
+	typedef xpcc::Configuration<ControlRegister_t, InputChannel, 0b111, 10> InputChannel_t;
+
+	/// Power mode
+	enum class
+	PowerMode : uint8_t
+	{
+		Normal = Bit1 | Bit0,
+		FullShutdown = Bit1,
+		AutoShutdown = Bit0
+	};
+	typedef xpcc::Configuration<ControlRegister_t, PowerMode, 0b11, 8> PowerMode_t;
+
+	/// Shadow register, used for channel selection in sequence mode
+	enum class
+	ShadowRegister : uint16_t
+	{};
+	XPCC_FLAGS16(ShadowRegister);
+
+	/// Configuration to select input channels for sequence conversion
+	enum class
+	SequenceChannels : uint8_t
+	{
+		Ch0 = Bit7,
+		Ch1 = Bit6,
+		Ch2 = Bit5,
+		Ch3 = Bit4,
+		Ch4 = Bit3,
+		Ch5 = Bit2,
+		Ch6 = Bit1,
+		Ch7 = Bit0
+	};
+	XPCC_FLAGS8(SequenceChannels);
+
+	typedef xpcc::Configuration<ShadowRegister_t, SequenceChannels, 0xFF, 8> Sequence1Channels_t;
+	typedef xpcc::Configuration<ShadowRegister_t, SequenceChannels, 0xFF, 0> Sequence2Channels_t;
+
+	using Register_t = xpcc::FlagsGroup<ControlRegister_t, ShadowRegister_t>;
+
+	struct xpcc_packed
+	Data
+	{
+		/// @return 12 bit result, for AD7918 and AD7908, respectively, 4 or 2 LSB are 0
+		inline uint16_t
+		value() const
+		{
+			return (data[1] & 0xFF) | ((static_cast<uint16_t>(data[0] & 0b1111)) << 8);
+		}
+
+		/// @return adc input channel
+		inline InputChannel
+		channel() const
+		{
+			return static_cast<InputChannel>((data[0] & 0b01110000) >> 4);
+		}
+
+		uint8_t data[2];
+	};
+}; // struct ad7928
+
+/**
+ * Driver for AD7928/AD7918/AD7908 ADC
+ *
+ * The AD7928/AD7918/AD7908 are, respectively, 12/10/8 bit analog-digital converters.
+ * The conversion time is determined by the Spi clock frequency. A maximum Spi clock
+ * of 20 Mhz is supported.
+ *
+ * @tparam	SpiMaster	SpiMaster interface
+ * @tparam	Cs			Chip-select pin
+ *
+ * @author	Christopher Durand
+ * @ingroup driver_adc
+ */
+template <typename SpiMaster, typename Cs>
+class Ad7928 : public ad7928, public xpcc::SpiDevice<SpiMaster>, protected xpcc::NestedResumable<3>
+{
+public:
+	Ad7928();
+
+	/// Call this function once before using the device
+	xpcc::ResumableResult<void>
+	initialize();
+
+	/// Initiate a single conversion and return the result of the previous conversion
+	/// A running sequence will be aborted.
+	/// If the device is in full shutdown, it will be woken up.
+	xpcc::ResumableResult<Data>
+	singleConversion(InputChannel channel);
+
+	/// Start a conversion sequence.
+	/// The device will automatically cycle through the specified channels, starting
+	/// with the lowest channel index in sequence1, when nextSequenceConversion() is called.
+	xpcc::ResumableResult<void>
+	startSequence(SequenceChannels_t channels1, SequenceChannels_t channels2 = SequenceChannels_t(0));
+
+	/// Perform the next sequence conversion
+	/// The result is undefined if the device is not in sequence mode or not in normal power mode.
+	xpcc::ResumableResult<Data>
+	nextSequenceConversion();
+
+	/// Enable extended range mode (0V < input < 2*Vref)
+	/// The configuration will be applied after the next conversion
+	/// Default mode: (0V < input < Vref)
+	void
+	setExtendedRange(bool enabled);
+
+	/// Test if extended range mode is enabled
+	bool
+	isExtendedRange();
+
+	/// Shutdown device after each conversion, not supported in sequence mode
+	void
+	setAutoShutdownEnabled(bool enabled);
+
+	/// Test if auto-shutdown is enabled
+	bool
+	isAutoShutdownEnabled();
+
+	/// Shutdown device
+	/// Calling wakeup() or initiating a conversion will wake up the device
+	xpcc::ResumableResult<void>
+	fullShutdown();
+
+	/// Wake up the device from full shutdown mode
+	xpcc::ResumableResult<void>
+	wakeup();
+
+private:
+	xpcc::ResumableResult<void>
+	transfer(Register_t reg);
+
+	ControlRegister_t config;
+	ShadowRegister_t sequenceChannels;
+
+	uint8_t outBuffer[2];
+	Data data;
+
+	PowerMode currentPowerMode;
+};
+
+IOStream&
+operator<<(IOStream& out, const ad7928::Data& data);
+
+} // namespace xpcc
+
+#include "ad7928_impl.hpp"
+
+#endif // XPCC_AD7928_HPP

--- a/src/xpcc/driver/adc/ad7928_impl.hpp
+++ b/src/xpcc/driver/adc/ad7928_impl.hpp
@@ -1,0 +1,232 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/* Copyright (c) 2017, Christopher Durand
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_AD7928_HPP
+#	error "Don't include this file directly! Use 'ad7928.hpp' instead."
+#endif
+
+// ----------------------------------------------------------------------------
+namespace xpcc
+{
+
+template <typename SpiMaster, typename Cs>
+Ad7928<SpiMaster, Cs>::Ad7928() : currentPowerMode{PowerMode::Normal}
+{
+	config = ControlRegister::WriteControlReg | ControlRegister::VrefRange;
+	config |= ControlRegister::UnsignedOutput;
+	SequenceMode_t::set(config, SequenceMode::NoSequence);
+	PowerMode_t::set(config, PowerMode::Normal);
+	InputChannel_t::reset(config);
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Ad7928<SpiMaster, Cs>::initialize()
+{
+	RF_BEGIN();
+
+	Cs::setOutput(xpcc::Gpio::High);
+	delayMicroseconds(1);
+
+	// reset device
+	RF_CALL(transfer(Register_t(0xFF)));
+	RF_CALL(transfer(Register_t(0xFF)));
+
+	config |= ControlRegister::WriteControlReg;
+	config |= ControlRegister::UnsignedOutput;
+
+	SequenceMode_t::set(config, SequenceMode::NoSequence);
+	PowerMode_t::set(config, PowerMode::Normal);
+	InputChannel_t::reset(config);
+
+	// write configuration
+	RF_CALL(transfer(config));
+	currentPowerMode = PowerMode::Normal;
+
+	RF_END();
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<ad7928::Data>
+Ad7928<SpiMaster, Cs>::singleConversion(ad7928::InputChannel channel)
+{
+	RF_BEGIN();
+
+	SequenceMode_t::set(config, SequenceMode::NoSequence);
+
+	if(currentPowerMode == PowerMode::FullShutdown) {
+		// power up device, will be in normal mode afterwards
+		RF_CALL(wakeup());
+	} else if(currentPowerMode == PowerMode::AutoShutdown) {
+		// dummy conversion to power up device
+		// does not alter control register (write bit = 0)
+		RF_CALL(transfer(ControlRegister(0)));
+	}
+
+	InputChannel_t::set(config, channel);
+	RF_CALL(transfer(config));
+	InputChannel_t::reset(config);
+
+	currentPowerMode = PowerMode_t::get(config);
+
+	RF_END_RETURN(data);
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Ad7928<SpiMaster, Cs>::startSequence(ad7928::SequenceChannels_t channels1,
+									 ad7928::SequenceChannels_t channels2)
+{
+	RF_BEGIN();
+
+	if(currentPowerMode == PowerMode::FullShutdown) {
+		// power up device, will be in normal mode afterwards
+		RF_CALL(wakeup());
+	} else if(currentPowerMode == PowerMode::AutoShutdown) {
+		// dummy conversion to power up device
+		// does not alter control register (write bit = 0)
+		RF_CALL(transfer(ControlRegister_t(0)));
+	}
+
+	PowerMode_t::set(config, PowerMode::Normal);
+	SequenceMode_t::set(config, SequenceMode::ProgramShadowRegister);
+	RF_CALL(transfer(config));
+	currentPowerMode = PowerMode::Normal;
+
+	// The next transfer writes to the shadow register
+	Sequence1Channels_t::set(sequenceChannels, static_cast<SequenceChannels>(channels1.value));
+	Sequence2Channels_t::set(sequenceChannels, static_cast<SequenceChannels>(channels2.value));
+	RF_CALL(transfer(sequenceChannels));
+
+	RF_END();
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<ad7928::Data>
+Ad7928<SpiMaster, Cs>::nextSequenceConversion()
+{
+	RF_BEGIN();
+
+	SequenceMode_t::set(config, SequenceMode::ContinueSequence);
+
+	// invalid if device is not in normal mode
+	if(currentPowerMode != PowerMode::Normal) {
+		RF_RETURN(data);
+	}
+
+	RF_CALL(transfer(config));
+	currentPowerMode = PowerMode_t::get(config);
+
+	RF_END_RETURN(data);
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+void
+Ad7928<SpiMaster, Cs>::setExtendedRange(bool enabled)
+{
+	if(enabled) {
+		config &= ~ControlRegister::VrefRange;
+	} else {
+		config |= ControlRegister::VrefRange;
+	}
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+bool
+Ad7928<SpiMaster, Cs>::isExtendedRange()
+{
+	return !(config & ControlRegister::VrefRange);
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+void
+Ad7928<SpiMaster, Cs>::setAutoShutdownEnabled(bool enabled)
+{
+	if(enabled) {
+		PowerMode_t::set(config, PowerMode::AutoShutdown);
+	} else {
+		PowerMode_t::set(config, PowerMode::Normal);
+	}
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+bool
+Ad7928<SpiMaster, Cs>::isAutoShutdownEnabled()
+{
+	return PowerMode_t::get(config) == PowerMode::AutoShutdown;
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Ad7928<SpiMaster, Cs>::fullShutdown()
+{
+	SequenceMode_t::set(config, SequenceMode::NoSequence);
+
+	ControlRegister_t controlRegister = config;
+	PowerMode_t::set(controlRegister, PowerMode::FullShutdown);
+
+	currentPowerMode = PowerMode::FullShutdown;
+
+	return transfer(controlRegister);
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Ad7928<SpiMaster, Cs>::wakeup()
+{
+	RF_BEGIN();
+	SequenceMode_t::set(config, SequenceMode::NoSequence);
+	PowerMode_t::set(config, PowerMode::Normal);
+
+	RF_CALL(transfer(config));
+
+	// Wait for the device to power up
+	delayMicroseconds(1);
+
+	currentPowerMode = PowerMode::Normal;
+
+	RF_END();
+}
+
+// ----------------------------------------------------------------------------
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Ad7928<SpiMaster, Cs>::transfer(Register_t reg)
+{
+	RF_BEGIN();
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+
+	SpiMaster::setDataMode(SpiMaster::DataMode::Mode1);
+
+	Cs::reset();
+
+	outBuffer[0] = (reg.value & 0xFF00) >> 8;
+	outBuffer[1] = reg.value & 0xFF;
+
+	RF_CALL(SpiMaster::transfer(outBuffer, data.data, 2));
+
+	if (this->releaseMaster())
+		Cs::set();
+
+	RF_END();
+}
+
+} // namespace xpcc


### PR DESCRIPTION
Driver for AD7928 8-channel 12 bit adc. Tested in hardware. AD7918 and AD7908 should also work, but have not been tested.