### PR TITLE
[build] GCC 7: avoid -Wimplicit-fallthrough warning

### DIFF
--- a/src/xpcc/architecture/utils.hpp
+++ b/src/xpcc/architecture/utils.hpp
@@ -152,6 +152,16 @@
 
 	#define XPCC_ARRAY_SIZE(x)	(sizeof(x) / sizeof(x[0]))
 
+	#ifdef __has_cpp_attribute
+		#if __has_cpp_attribute(fallthrough)
+		#	define XPCC_FALLTHROUGH [[fallthrough]]
+		#else
+		#	define XPCC_FALLTHROUGH
+		#endif
+	#else
+	#	define XPCC_FALLTHROUGH
+	#endif // __has_cpp_attribute
+
 #endif	// !__DOXYGEN__
 
 #endif	// XPCC__UTILS_HPP

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -87,8 +87,7 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 		{
 			case 'c':
 				c = va_arg(ap, int); // char promoted to int
-				/* no break */
-
+				XPCC_FALLTHROUGH;
 			default:
 				this->device->write(c);
 				continue;
@@ -107,8 +106,7 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 
 			case 'd':
 				isSigned = true;
-				/* no break */
-
+				XPCC_FALLTHROUGH;
 			case 'u':
 				base = 10;
 				break;
@@ -120,7 +118,7 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 				width = (XPCC__SIZEOF_POINTER * 2);
 				isLong = (XPCC__SIZEOF_POINTER == 4);
 				isLongLong = (XPCC__SIZEOF_POINTER == 8);
-				/* no break */
+				XPCC_FALLTHROUGH;
 			case 'x':
 				base = 16;
 				break;

--- a/src/xpcc/processing/protothread/macros.hpp
+++ b/src/xpcc/processing/protothread/macros.hpp
@@ -79,6 +79,7 @@
 #define PT_WAIT_WHILE(condition) \
     do { \
 		this->ptState = __LINE__; \
+		XPCC_FALLTHROUGH; \
 		case __LINE__: \
 			if (condition) \
 				return true; \
@@ -124,6 +125,7 @@
 #define PT_CALL(resumable) \
 	({ \
 		this->ptState = __LINE__; \
+		XPCC_FALLTHROUGH; \
 		case __LINE__: \
 			auto rfResult = resumable; \
 			if (rfResult.getState() > xpcc::rf::NestingError) { \

--- a/src/xpcc/processing/resumable/macros.hpp
+++ b/src/xpcc/processing/resumable/macros.hpp
@@ -195,6 +195,7 @@
 /// Required macro to set the same unique number twice
 #define RF_INTERNAL_SET_CASE(counter) \
 			this->setRf((counter % 255) + 1, rfIndex); \
+			XPCC_FALLTHROUGH; \
 		case ((counter % 255) + 1): ;
 
 /// Internal macro for yield


### PR DESCRIPTION
GCC 7 generates a lot `-Wimplicit-fallthrough` warnings from the resumable functions code.

This PR adds fallthrough attributes to the switch-cases:
```c++
[[gnu::fallthrough]];
```
[(This notation seems to be the most portable way using C++11)](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/)