### PR TITLE
[scons] Add DFU programming method to universal SConstruct.

### DIFF
--- a/scons/SConstruct
+++ b/scons/SConstruct
@@ -89,6 +89,10 @@ else:
         env.Alias('debug', env.GdbDebug(program))
         env.Alias('bin', env.Bin(program))
 
+        # Most STM32's can be programmed by USB DFU if board allows
+        binfile = env.Bin(program)
+        env.Alias('dfu', env.DfuStm32Programmer(binfile))
+
     env.Alias('listing', env.Listing(program))
     env.Alias('build', hexfile)
     env.Alias('all', ['build', 'size'])


### PR DESCRIPTION
Maybe that is a bit broad? Did not find an easy check for STM32 in scons.