### PR TITLE
[ci] Add deprecated-2017Q3 in response to image updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ compiler: gcc
 sudo: required
 dist: trusty
 
+group: deprecated-2017Q3
+
 addons:
  apt:
   sources:


### PR DESCRIPTION
https://blog.travis-ci.com/2017-08-29-trusty-image-updates