### PR TITLE
[travis] Use SCons v2.5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
  - arm-none-eabi-g++ --version
  - pip install --upgrade pip wheel
  - pip install jinja2 lxml
- - pip install --egg SCons
+ - pip install scons==2.5.1
 
 cache:
  directories:


### PR DESCRIPTION
SCons recently released v3.0.0 which supports Python 3.5+, which however
breaks our build system for now.

**THIS IS A QUICKFIX!**

We need to upgrade our build system for Python 3.5+, otherwise new developers who install SCons v3 will have a bad initial experience!