### PR TITLE
[driver] LTC298x: Calculate negative temperatures correctly

### DIFF
--- a/examples/stm32f4_discovery/temperature_ltc2984/main.cpp
+++ b/examples/stm32f4_discovery/temperature_ltc2984/main.cpp
@@ -74,7 +74,14 @@ public:
 	bool
 	update()
 	{
-		PT_BEGIN()
+		PT_BEGIN();
+
+		while(!PT_CALL(tempSensor.ping())) {
+			logger << "Device not reachable" << xpcc::endl;
+			this->timeout.restart(100);
+			PT_WAIT_UNTIL(this->timeout.isExpired());
+		}
+
 
 		// Configure the device
 		PT_CALL(tempSensor.configureChannel(xpcc::ltc2984::Channel::Ch2, xpcc::ltc2984::Configuration::rsense(

--- a/src/xpcc/driver/temperature/ltc2984.hpp
+++ b/src/xpcc/driver/temperature/ltc2984.hpp
@@ -100,7 +100,7 @@ struct ltc2984
 		//EepromStatus		= 0x0f9,
 		MuxConfigDelay		= 0x0f4,
 		ChannelConfig		= 0x200,
-		//CustomDataTable	= 0x250,
+		CustomDataTable		= 0x250,
 	};
 
 	enum class
@@ -350,6 +350,17 @@ public:
 	 * Sets used pins as output. SPI must be initialized by the user!
 	 */
 	Ltc2984();
+
+	/**
+	 * \brief	Ping the LTC298x device.
+	 * \warning Do not use ping() while any measurement is running.
+	 * The ping() function writes data to the Custom Sensor Table Data memory
+	 * region but restores the data before finishing the device available check.
+	 *
+	 * \return	config	True if the device is reachable.
+	 */
+	xpcc::ResumableResult<bool>
+	ping();
 
 	/**
 	 * \brief	Configure

--- a/src/xpcc/driver/temperature/ltc2984.hpp
+++ b/src/xpcc/driver/temperature/ltc2984.hpp
@@ -66,24 +66,22 @@ struct ltc2984
 		float
 		getTemperatureFloat() const
 		{
-			float temp = static_cast<float>((this->data & 0x7fffff)) / 1024.f;
-			return ((this->data & 0x800000) == 0) ? temp : -temp;
+			return getTemperatureFixed() / 1024.f;
 		}
 
 		/// @return the temperature in the configured unit divided by 1024
 		int32_t
 		getTemperatureFixed() const
 		{
-			int32_t ret((this->data & 0x7fffff));
-			return (this->data & 0x800000) ? -ret : ret;
+			int32_t ret(this->data & 0xfffffful);
+			return (this->data & 0x800000) ? -(((~ret) + 1) & 0xffffff) : ret;
 		}
 
-		/// @return only the signed integer part of the temperature in the configured unit
+		/// @return the temperature rounded to nearest integer in the configured unit
 		int16_t
 		getTemperatureInteger() const
 		{
-			int16_t ret((this->data & 0x7fffff) >> 10);
-			return (this->data & 0x800000) ? -ret : ret;
+			return ((getTemperatureFixed() + (1ul << 9)) / 1024);
 		}
 
 	public:

--- a/src/xpcc/driver/temperature/ltc2984_impl.hpp
+++ b/src/xpcc/driver/temperature/ltc2984_impl.hpp
@@ -20,6 +20,21 @@ xpcc::Ltc2984<SpiMaster, Cs>::Ltc2984()
 }
 
 template < class SpiMaster, class Cs >
+xpcc::ResumableResult<bool>
+xpcc::Ltc2984<SpiMaster, Cs>::ping()
+{
+	RF_BEGIN();
+	// Store first byte of Custom Sensor Table Data into buffer[4]
+	RF_CALL(readByte(Register::CustomDataTable, buffer[4]));
+	buffer[5] = 0x42;
+	RF_CALL(writeData(Register::CustomDataTable, &buffer[5], 1));
+	RF_CALL(readByte(Register::CustomDataTable, buffer[6]));
+	// Restore first byte of Custom Sensor Table Data from buffer[4]
+	RF_CALL(writeData(Register::CustomDataTable, &buffer[4], 1));
+	RF_END_RETURN(buffer[5] == buffer[6]);
+}
+
+template < class SpiMaster, class Cs >
 xpcc::ResumableResult<void>
 xpcc::Ltc2984<SpiMaster, Cs>::configure(ltc2984::Configuration::Rejection rejection,
                                         ltc2984::Configuration::TemperatureUnit temperatureUnit,

--- a/src/xpcc/driver/temperature/test/ltc2984_test.cpp
+++ b/src/xpcc/driver/temperature/test/ltc2984_test.cpp
@@ -1,0 +1,89 @@
+#include <xpcc/driver/temperature/ltc2984.hpp>
+#include <xpcc/debug/logger/logger.hpp>
+
+#include "ltc2984_test.hpp"
+
+#undef  XPCC_LOG_LEVEL
+#define XPCC_LOG_LEVEL xpcc::log::DISABLED
+
+void
+Ltc2984Test::testDataStatus()
+{
+	// Test valid bit
+	TEST_ASSERT_TRUE(xpcc::ltc2984::Data(0x01 << 24).isValid());
+	TEST_ASSERT_TRUE(xpcc::ltc2984::Data(0xff << 24).isValid());
+	TEST_ASSERT_FALSE(xpcc::ltc2984::Data(0ul).isValid());
+
+	// Test other status bits
+	TEST_ASSERT_EQUALS(static_cast<uint8_t>(xpcc::ltc2984::Data(0xAAul << 24).getStatus()), 0xAA);
+	TEST_ASSERT_EQUALS(static_cast<uint8_t>(xpcc::ltc2984::Data(0x55ul << 24).getStatus()), 0x55);
+}
+
+void
+Ltc2984Test::testDataTemperature()
+{
+	// Example data output words from datasheet, Table 9A, page 22.
+	// http://cds.linear.com/docs/en/datasheet/2984fb.pdf
+
+	uint32_t dataTable[8];
+	float temperatureTableFloat[8];
+	int32_t temperatureTableFixed[8];
+	int16_t temperatureTableInteger[8];
+
+	// 8191.999°C
+	dataTable[0] = 0b00000001011111111111111111111111;
+	temperatureTableFloat[0] = 8191.999;
+	temperatureTableFixed[0] = 1024 * 8191.999f;
+	temperatureTableInteger[0] = 8192;
+
+	// 1024°C
+	dataTable[1] = 0b00000001000100000000000000000000;
+	temperatureTableFloat[1] = 1024;
+	temperatureTableFixed[1] = 1024 * 1024;
+	temperatureTableInteger[1] = 1024;
+
+	// 1°C
+	dataTable[2] = 0b00000001000000000000010000000000;
+	temperatureTableFloat[2] = 1;
+	temperatureTableFixed[2] = 1024 * 1;
+	temperatureTableInteger[2] = 1;
+
+	// 1/1024°C
+	dataTable[3] = 0b00000001000000000000000000000001;
+	temperatureTableFloat[3] = 1 / 1024.f;
+	temperatureTableFixed[3] = 1024 * 1 / 1024;
+	temperatureTableInteger[3] = 0;
+
+	// 0°C
+	dataTable[4] = 0b00000001000000000000000000000000;
+	temperatureTableFloat[4] = 0;
+	temperatureTableFixed[4] = 0;
+	temperatureTableInteger[4] = 0;
+
+	// -1/1024°C
+	dataTable[5] = 0b00000001111111111111111111111111;
+	temperatureTableFloat[5] = -1 / 1024.f;
+	temperatureTableFixed[5] = 1024 * (-1) / 1024;
+	temperatureTableInteger[5] = 0;
+
+	// -1°C
+	dataTable[6] = 0b00000001111111111111110000000000;
+	temperatureTableFloat[6] = -1;
+	temperatureTableFixed[6] = 1024 * -1;
+	temperatureTableInteger[6] = -1;
+
+	// -273.15°C
+	dataTable[7] = 0b00000001111110111011101101100111;
+	temperatureTableFloat[7] = -273.15;
+	temperatureTableFixed[7] = -1024 * 273.15f;
+	temperatureTableInteger[7] = -273;
+
+
+	for (size_t jj = 0; jj < XPCC_ARRAY_SIZE(dataTable); ++jj)
+	{
+		xpcc::ltc2984::Data temperature(dataTable[jj]);
+		TEST_ASSERT_TRUE(fabs(temperature.getTemperatureFloat() - temperatureTableFloat[jj]) <= 0.001f);
+		TEST_ASSERT_EQUALS(temperature.getTemperatureFixed(), temperatureTableFixed[jj]);
+		TEST_ASSERT_EQUALS(temperature.getTemperatureInteger(), temperatureTableInteger[jj]);
+	}
+}

--- a/src/xpcc/driver/temperature/test/ltc2984_test.hpp
+++ b/src/xpcc/driver/temperature/test/ltc2984_test.hpp
@@ -1,0 +1,11 @@
+#include <unittest/testsuite.hpp>
+
+class Ltc2984Test : public unittest::TestSuite
+{
+public:
+	void
+	testDataStatus();
+
+	void
+	testDataTemperature();
+};


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/2820734/31746208-770f1326-b466-11e7-8008-01d4c1081be2.png)

The sign bit from the datasheet is not a real sign bit ❄️