### PR TITLE
Drivers: Expose jinja template parameters as static constexpr.

### DIFF
--- a/src/xpcc/architecture/driver/atomic/queue.hpp
+++ b/src/xpcc/architecture/driver/atomic/queue.hpp
@@ -81,6 +81,9 @@ namespace xpcc
 
 			xpcc_always_inline bool
 			isEmpty() const;
+
+			xpcc_always_inline bool
+			isNotEmpty() const { return not isEmpty(); }
 			
 			/**
 			 * Check if the queue is nearly empty.

--- a/src/xpcc/architecture/interface/can.hpp
+++ b/src/xpcc/architecture/interface/can.hpp
@@ -74,6 +74,13 @@ public:
 	};
 #ifdef __DOXYGEN__
 public:
+	/// Size of the receive buffer.
+	static constexpr size_t RxBufferSize = 16;
+
+	/// Size of the transmit buffer.
+	static constexpr size_t TxBufferSize = 16;
+
+public:
 	/**
 	 * Initializes the hardware and sets the baudrate.
 	 *

--- a/src/xpcc/architecture/interface/i2c_master.hpp
+++ b/src/xpcc/architecture/interface/i2c_master.hpp
@@ -57,6 +57,10 @@ public:
 
 #ifdef __DOXYGEN__
 public:
+	/// Number of transactions which can be queued in this driver.
+	static constexpr size_t TransactionBufferSize = 8;
+
+public:
 	/**
 	 * Initializes the hardware and sets the datarate.
 	 *

--- a/src/xpcc/architecture/interface/uart.hpp
+++ b/src/xpcc/architecture/interface/uart.hpp
@@ -63,6 +63,13 @@ public:
 
 #ifdef __DOXYGEN__
 public:
+	/// Size of the receive buffer.
+	static constexpr size_t RxBufferSize = 16;
+
+	/// Size of the transmit buffer.
+	static constexpr size_t TxBufferSize = 16;
+
+public:
 	/**
 	 * Initializes the hardware and sets the baudrate.
 	 *

--- a/src/xpcc/architecture/platform/devices/lpc/lpc11c24.xml
+++ b/src/xpcc/architecture/platform/devices/lpc/lpc11c24.xml
@@ -12,9 +12,6 @@
 		<pin-count device-name="c24">48</pin-count>
 		<!-- Headers to be included with the {{ include_device_headers }} substitution-->
 		<header>LPC11xx.h</header>
-		<!-- set to a value > 0 to enable software buffering of CAN messages -->
-		<define>LPC11C_CAN_TX_BUFFER_SIZE = 16</define>
-		<define>LPC11C_CAN_RX_BUFFER_SIZE = 16</define>
 		<!-- Core Driver -->
 		<driver type="core" name="cortex">
 			<parameter name="main_stack_size">1024</parameter>

--- a/src/xpcc/architecture/platform/driver/can/lpc/build.cfg
+++ b/src/xpcc/architecture/platform/driver/can/lpc/build.cfg
@@ -1,2 +1,0 @@
-[build]
-target = lpc11c

--- a/src/xpcc/architecture/platform/driver/can/lpc/c_can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/lpc/c_can.cpp.in
@@ -15,12 +15,12 @@ namespace xpcc
 {
 namespace lpc
 {
-#if LPC11C_CAN_TX_BUFFER_SIZE > 0
-xpcc::atomic::Queue<xpcc::can::Message, LPC11C_CAN_TX_BUFFER_SIZE> txQueue;
-#endif
-#if LPC11C_CAN_RX_BUFFER_SIZE > 0
-xpcc::atomic::Queue<xpcc::can::Message, LPC11C_CAN_RX_BUFFER_SIZE> rxQueue;
-#endif
+%% if parameters.tx_buffer > 0
+xpcc::atomic::Queue<xpcc::can::Message, Can::TxBufferSize> txQueue;
+%% endif
+%% if parameters.rx_buffer > 0
+xpcc::atomic::Queue<xpcc::can::Message, Can::RxBufferSize> rxQueue;
+%% endif
 }
 }
 
@@ -142,7 +142,7 @@ xpcc::lpc::Can::getBusState()
 void
 xpcc::lpc::Can::CAN_tx(uint8_t /* msg_obj_num */)
 {
-#if LPC11C_CAN_TX_BUFFER_SIZE > 0
+%% if parameters.tx_buffer > 0
 	// Send next from queue, if available
 
 	// MOBs 16 to 32 are in TXREQ2, at the *lower* bits
@@ -150,7 +150,7 @@ xpcc::lpc::Can::CAN_tx(uint8_t /* msg_obj_num */)
 		// All message objects empty. Otherwise the order of messages
 		// is not maintained
 
-		while (!txQueue.isEmpty())
+		while (txQueue.isNotEmpty())
 		{
 			// Still messages in the queue.
 
@@ -179,7 +179,7 @@ xpcc::lpc::Can::CAN_tx(uint8_t /* msg_obj_num */)
 			}
 		}
 	}
-#endif
+%% endif
 }
 
 // ----------------------------------------------------------------------------
@@ -190,7 +190,7 @@ xpcc::lpc::Can::CAN_tx(uint8_t /* msg_obj_num */)
  * Called on the interrupt level by the CAN interrupt handler when
  * a new message has been successfully received.
  */
-#if LPC11C_CAN_RX_BUFFER_SIZE > 0
+%% if parameters.rx_buffer > 0
 void
 xpcc::lpc::Can::CAN_rx(uint8_t msg_obj_num)
 {
@@ -216,12 +216,12 @@ xpcc::lpc::Can::CAN_rx(uint8_t msg_obj_num)
 	}
 
 }
-#else
+%% else
 void
 xpcc::lpc::Can::CAN_rx(uint8_t /* msg_obj_num */)
 {
 }
-#endif
+%% endif
 
 // ----------------------------------------------------------------------------
 
@@ -258,7 +258,7 @@ xpcc::lpc::Can::sendMessage(const can::Message & message)
 	{
 		/* All Message Objects used for sending (17 to 32) are pending
 		 * at the moment. */
-#if LPC11C_CAN_TX_BUFFER_SIZE > 0
+%% if parameters.tx_buffer > 0
 		if (!txQueue.push(message)) {
 			xpcc::ErrorReport::report(xpcc::lpc::CAN_TX_OVERFLOW);
 			// All Message Objects are full and no space left in software buffer.
@@ -266,10 +266,10 @@ xpcc::lpc::Can::sendMessage(const can::Message & message)
 		}
 		// All Message Objects are full but message was stored in software buffer.
 		return true;
-#else
+%% else
 		// All Message Objects are full and no software buffers are available.
 		return false;
-#endif
+%% endif
 	}
 	else
 	{
@@ -292,7 +292,7 @@ xpcc::lpc::Can::sendMessage(const can::Message & message)
 bool
 xpcc::lpc::Can::getMessage(can::Message & message)
 {
-#if LPC11C_CAN_RX_BUFFER_SIZE > 0
+%% if parameters.rx_buffer > 0
 	if (rxQueue.isEmpty())
 	{
 		// no message in the receive buffer
@@ -316,7 +316,7 @@ xpcc::lpc::Can::getMessage(can::Message & message)
 		}
 		return true;
 	}
-#else
+%% else
 	// No interrupts, polling
 	if (LPC_CAN->ND1 & 0xffff)
 	{
@@ -328,7 +328,7 @@ xpcc::lpc::Can::getMessage(can::Message & message)
 		// No message available
 		return false;
 	}
-#endif
+%% endif
 }
 
 // ----------------------------------------------------------------------------
@@ -336,13 +336,13 @@ xpcc::lpc::Can::getMessage(can::Message & message)
 bool
 xpcc::lpc::Can::isMessageAvailable()
 {
-#if LPC11C_CAN_RX_BUFFER_SIZE > 0
-	return !rxQueue.isEmpty();
-#else
+%% if parameters.rx_buffer > 0
+	return rxQueue.isNotEmpty();
+%% else
 	/* Check if new data is available in the Message
 	 * Objects 1 to 16. */
 	return (LPC_CAN->ND1 & 0xffff);
-#endif
+%% endif
 }
 
 // ----------------------------------------------------------------------------
@@ -350,12 +350,12 @@ xpcc::lpc::Can::isMessageAvailable()
 bool
 xpcc::lpc::Can::isReadyToSend()
 {
-#if LPC11C_CAN_TX_BUFFER_SIZE > 0
+%% if parameters.tx_buffer > 0
 	return txQueue.isNotFull();
-#else
+%% else
 	/* Check if at least one Message Object 17 to 32
 	 * is not pending. If not all are pending at least
 	 * one is free. */
 	return ( (LPC_CAN->TXREQ2 & 0xffff) != 0xffff );
-#endif
+%% endif
 }

--- a/src/xpcc/architecture/platform/driver/can/lpc/c_can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/lpc/c_can.hpp.in
@@ -11,9 +11,6 @@
 
 #include "../../clock/generic/common_clock.hpp"
 
-// at least one queue, so activate interrupts
-#define LPC11C_USING_CAN_INTERRUPTS ((LPC11C_CAN_TX_BUFFER_SIZE > 0) || (LPC11C_CAN_RX_BUFFER_SIZE > 0))
-
 #define LPC11C_ROM_CAN (*((ROM **)0x1fff1ff8))
 
 namespace xpcc
@@ -49,7 +46,10 @@ namespace lpc
 class Can : public ::xpcc::Can
 {
 public:
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
 
+public:
 	template< class SystemClock, uint32_t bitrate = Bitrate::kBps125,
 			uint16_t tolerance = Tolerance::OnePercent >
 	static inline void
@@ -92,14 +92,13 @@ public:
 				0x00004500UL | prescaler  // CANBT: bit timing register:
 		};
 
-	// FIXME: turn into parameter
-	#if LPC11C_USING_CAN_INTERRUPTS
+	%% if parameters.rx_buffer > 0 or parameters.tx_buffer > 0
 		/* Interrupts enabled */
 		LPC11C_ROM_CAN->pCAND->init_can(&ClkInitTable[0], true);
-	#else
+	%% else
 		/* Interrupts disabled */
 		LPC11C_ROM_CAN->pCAND->init_can(&ClkInitTable[0], false);
-	#endif
+	%% endif
 
 		/* Configure the CAN callback functions */
 		CAN_CALLBACKS callbacks = {

--- a/src/xpcc/architecture/platform/driver/can/lpc/driver.xml
+++ b/src/xpcc/architecture/platform/driver/can/lpc/driver.xml
@@ -2,11 +2,13 @@
 <!DOCTYPE rca SYSTEM "../../xml/driver.dtd">
 <rca version="1.0">
 	<driver type="can" name="lpc">
-		<static>c_can.cpp</static>
-		<static>c_can.hpp</static>
+		<template out="c_can.hpp">c_can.hpp.in</template>
+		<template out="c_can.hpp">c_can.cpp.in</template>
 		<static>c_can_filter.cpp</static>
 		<static>c_can_filter.hpp</static>
 		<static>c_can_registers.h</static>
 		<static>error_code.hpp</static>
+		<parameter name="tx_buffer" type="int" min="0" max="254">16</parameter>
+		<parameter name="rx_buffer" type="int" min="0" max="254">16</parameter>
 	</driver>
 </rca>

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.cpp.in
@@ -232,7 +232,7 @@ XPCC_ISR({{ reg }}_TX)
 		{{ reg }}->TSR = CAN_TSR_RQCP0;
 	}
 	
-	if (!txQueue.isEmpty())
+	if (txQueue.isNotEmpty())
 	{
 		sendMailbox(txQueue.get(), mailbox);
 		txQueue.pop();
@@ -356,7 +356,7 @@ bool
 xpcc::stm32::Can{{ id }}::isMessageAvailable()
 {
 %% if parameters.rx_buffer > 0
-	return !rxQueue.isEmpty();
+	return rxQueue.isNotEmpty();
 %% else
 	// Check if there are any messages pending in the receive registers
 	return (({{ reg }}->RF0R & CAN_RF0R_FMP0) > 0 || ({{ reg }}->RF1R & CAN_RF1R_FMP1) > 0);

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -77,6 +77,10 @@ public:
 	static const TypeId::Can{{ id }}Rx Rx;
 	/// TypeId used to connect GPIO pins to this peripheral's tx.
 	static const TypeId::Can{{ id }}Tx Tx;
+public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
 private:
 	/// Private Initializer with computed prescaler and timing constants
 	static void

--- a/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/stm32/i2c_master.hpp.in
@@ -42,6 +42,9 @@ public:
 	static const TypeId::I2cMaster{{ id }}Scl Scl;
 
 public:
+	static constexpr size_t TransactionBufferSize = {{ parameters.transaction_buffer }};
+
+public:
 	/**
 	 * Set up the I2C module for master operation.
 	 *

--- a/src/xpcc/architecture/platform/driver/i2c/stm32l4/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/stm32l4/i2c_master.hpp.in
@@ -44,6 +44,9 @@ public:
 	static const TypeId::I2cMaster{{ id }}Scl Scl;
 
 public:
+	static constexpr size_t TransactionBufferSize = {{ parameters.transaction_buffer }};
+
+public:
 	/**
 	 * Set up the I2C module for master operation.
 	 *

--- a/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.hpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/xmega/i2c_master.hpp.in
@@ -36,6 +36,9 @@ public:
 	static const TypeId::I2cMaster{{ id }}Scl Scl;
 
 public:
+	static constexpr size_t TransactionBufferSize = {{ parameters.transaction_buffer }};
+
+public:
 	/**
 	 * Set up the I2C module for master operation.
 	 *

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart.hpp.in
@@ -54,6 +54,11 @@ public:
 	static const TypeId::Uart{{ id }}Rxd Rx;
 
 public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
+
+public:
 	// start documentation inherited
 	template< class SystemClock, uint32_t baudrate,
 			uint16_t tolerance = xpcc::Tolerance::TwoPercent >

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_rx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_rx.cpp.in
@@ -14,7 +14,7 @@
 #include "uart_defines.h"
 #include "uart{{ id }}.hpp"
 
-static xpcc::atomic::Queue<uint8_t, {{parameters.rx_buffer}}> rxBuffer;
+static xpcc::atomic::Queue<uint8_t, xpcc::{{target.family}}::Uart{{ id }}::RxBufferSize> rxBuffer;
 static uint8_t error;
 
 // ----------------------------------------------------------------------------

--- a/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_tx.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/at90_tiny_mega/uart_tx.cpp.in
@@ -14,7 +14,7 @@
 #include "uart_defines.h"
 #include "uart{{ id }}.hpp"
 
-static xpcc::atomic::Queue<uint8_t, {{parameters.tx_buffer}}> txBuffer;
+static xpcc::atomic::Queue<uint8_t, xpcc::{{target.family}}::Uart{{ id }}::TxBufferSize> txBuffer;
 
 // ----------------------------------------------------------------------------
 XPCC_ISR(USART{{ id }}_UDRE)

--- a/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/lpc/uart.cpp.in
@@ -23,10 +23,10 @@ namespace
 // If requested buffer size is larger than hardware buffer size create a
 // software queue for the remaining bytes.
 %% if parameters.rx_buffer > 16
-	static xpcc::atomic::Queue<uint8_t, {{ parameters.rx_buffer }} - 16> rxBuffer;
+	static xpcc::atomic::Queue<uint8_t, xpcc::lpc::Uart1::RxBufferSize - 16> rxBuffer;
 %% endif
 %% if parameters.tx_buffer > 16
-	static xpcc::atomic::Queue<uint8_t, {{ parameters.tx_buffer }} - 16> txBuffer;
+	static xpcc::atomic::Queue<uint8_t, xpcc::lpc::Uart1::TxBufferSize - 16> txBuffer;
 %% endif
 
 	/**

--- a/src/xpcc/architecture/platform/driver/uart/lpc/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/lpc/uart.hpp.in
@@ -57,6 +57,11 @@ public:
 	static const TypeId::Uart1Tx Tx;
 
 public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
+
+public:
 	template< class SystemClock, uint32_t baudrate,
 			uint16_t tolerance = xpcc::Tolerance::OnePercent >
 	static void xpcc_always_inline

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
@@ -52,6 +52,11 @@ private:
 %% endif
 
 public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
+
+public:
 template< 	class SystemClock, uint32_t baudrate,
 		uint16_t tolerance = xpcc::Tolerance::OnePercent >
 	static void xpcc_always_inline

--- a/src/xpcc/architecture/platform/driver/uart/xmega/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/xmega/uart.hpp.in
@@ -51,6 +51,11 @@ public:
 	static const TypeId::Uart{{ id }}Txd Tx;
 
 public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ parameters.rx_buffer }};
+	static constexpr size_t TxBufferSize = {{ parameters.tx_buffer }};
+
+public:
 	/**
 	 * Sets the baudrate.
 	 *


### PR DESCRIPTION
A static_assert in a driver can be used to check if e.g. a peripheral
provides a buffer of adequate size.