### PR TITLE
[avr] Avoid implicit fallthrough warning in avr i2c driver

### DIFF
--- a/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.cpp.in
+++ b/src/xpcc/architecture/platform/driver/i2c/at90_tiny_mega/i2c_master.cpp.in
@@ -43,7 +43,7 @@ XPCC_ISR(TWI)
 	{
 		case TW_START:
 			// START has been transmitted
-			// Fall through...
+			XPCC_FALLTHROUGH;
 		case TW_REP_START:
 			{
 				DEBUG('s');
@@ -81,7 +81,7 @@ XPCC_ISR(TWI)
 
 		case TW_MT_SLA_ACK:
 			// SLA+W has been transmitted and ACK received
-			// Fall through...
+			XPCC_FALLTHROUGH;
 		case TW_MT_DATA_ACK:
 			// Data byte has been transmitted and ACK received
 			if (writing.length > 0)
@@ -126,7 +126,7 @@ XPCC_ISR(TWI)
 			DEBUG('0' + reading.length);
 			--reading.length;
 
-			// Fall through...
+			XPCC_FALLTHROUGH;
 		case TW_MR_SLA_ACK:
 			// SLA+R has been transmitted and ACK received
 			// See if last expected byte will be received ...
@@ -171,6 +171,8 @@ XPCC_ISR(TWI)
 				errorState = xpcc::I2cMaster::Error::AddressNack;
 			}
 			DEBUG('A');
+
+			XPCC_FALLTHROUGH;
 		case TW_MT_DATA_NACK:	// data transmitted, NACK received
 			if (errorState == xpcc::I2cMaster::Error::NoError) {
 				errorState = xpcc::I2cMaster::Error::DataNack;
@@ -178,12 +180,16 @@ XPCC_ISR(TWI)
 			DEBUG('d');
 			// generate a stop condition
 			TWCR = (1 << TWINT) | (1 << TWSTO) | (1 << TWEN);
+
+			XPCC_FALLTHROUGH;
 		case TW_MT_ARB_LOST:	// arbitration lost in SLA+W or data
 //		case TW_MR_ARB_LOST:	// arbitration lost in SLA+R or NACK
 			if (errorState == xpcc::I2cMaster::Error::NoError) {
 				errorState = xpcc::I2cMaster::Error::ArbitrationLost;
 			}
 			DEBUG('d');
+
+			XPCC_FALLTHROUGH;
 		default:
 			if (errorState == xpcc::I2cMaster::Error::NoError) {
 				errorState = xpcc::I2cMaster::Error::Unknown;


### PR DESCRIPTION
 See #276