### PR TITLE
[architecture] Allow using XPCC_FLAGS macros in template classes

### DIFF
--- a/src/xpcc/architecture/interface/register.hpp
+++ b/src/xpcc/architecture/interface/register.hpp
@@ -920,15 +920,19 @@ constexpr ::xpcc::Flags<Enum> operator^(Enum const &a, Enum const &b) { return :
 	XPCC_INTERNAL_FLAGS(Parent, friend)
 
 #define XPCC_INTERNAL_FLAGS(Parent, scope) \
-	scope constexpr Parent operator compl (Parent::EnumType const &lhs) \
+	scope constexpr Parent operator compl (typename Parent::EnumType const &lhs) \
 	{ return compl Parent(lhs); } \
 	XPCC_INTERNAL_FLAGS_EOP(type, Parent, &, scope) \
 	XPCC_INTERNAL_FLAGS_EOP(type, Parent, |, scope) \
 	XPCC_INTERNAL_FLAGS_EOP(type, Parent, ^, scope)
 
 #define XPCC_INTERNAL_FLAGS_EOP(type, Parent, op, scope) \
-	scope constexpr Parent operator op (Parent::EnumType const &lhs, Parent::EnumType const &rhs) \
-	{ return Parent(Parent::EnumType(Parent::UnderlyingType(lhs) op Parent::UnderlyingType(rhs))); }
+	scope constexpr Parent operator op (typename Parent::EnumType const &lhs, typename Parent::EnumType const &rhs) \
+	{ \
+		using EnumType = typename Parent::EnumType; \
+		using UnderlyingType = typename Parent::UnderlyingType; \
+		return Parent(EnumType(UnderlyingType(lhs) op UnderlyingType(rhs))); \
+	}
 /// @endcond
 
 

--- a/src/xpcc/architecture/interface/test/register_test.hpp
+++ b/src/xpcc/architecture/interface/test/register_test.hpp
@@ -16,6 +16,7 @@
 namespace xpcc
 {
 
+template<typename T>
 struct testing
 {
 protected:
@@ -112,7 +113,7 @@ XPCC_TYPE_FLAGS(Test4_t)
 }
 
 // @author Niklas Hauser
-class RegisterTest : public unittest::TestSuite, public xpcc::testing
+class RegisterTest : public unittest::TestSuite, public xpcc::testing<void>
 {
 public:
 	void


### PR DESCRIPTION
Declaring flags inside a template class using the `XPCC_FLAGS8`/`XPCC_FLAGS16`/`XPCC_FLAGS32` macros fails to compile. `Parent::EnumType` in lines 923 and 930 of register.hpp may be a dependent name, thus we have to add `typename` here.