### PR TITLE
[fix][io]fixed that only low 32Bit of an uint64_t were shown in Logstream

### DIFF
--- a/src/xpcc/io/iostream.hpp
+++ b/src/xpcc/io/iostream.hpp
@@ -300,7 +300,7 @@ public:
 
 // The 64-bit types on the AVR are extremely slow and are
 // therefore excluded here
-#if !defined(XPCC__CPU_AVR)
+#if not defined(XPCC__CPU_AVR)
 	xpcc_always_inline IOStream&
 	operator << (const uint64_t& v)
 	{
@@ -502,13 +502,18 @@ protected:
 	void
 	writeFloat(const float& value);
 
-#if !defined(XPCC__CPU_AVR)
+#if not defined(XPCC__CPU_AVR)
 	void
 	writeDouble(const double& value);
 #endif
 
-	void
-	writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill, bool isNegative);
+        void
+        writeUnsignedInteger(unsigned long unsignedValue, uint_fast8_t base, size_t width, char fill, bool isNegative);
+#if not defined(XPCC__CPU_AVR)
+        void
+        writeUnsignedLongLong(unsigned long long unsignedValue, uint_fast8_t base, size_t width, char fill, bool isNegative);
+#endif
+
 
 private:
 	enum class

--- a/src/xpcc/io/test/io_stream_test.cpp
+++ b/src/xpcc/io/test/io_stream_test.cpp
@@ -520,6 +520,23 @@ IoStreamTest::testPrintf2()
 #endif
 }
 
+void
+IoStreamTest::testPrintf3()
+{
+#if not defined(XPCC__CPU_AVR)
+
+	// Test for 64 bit uints and ints on printf
+	unsigned long long unsignedlonglong = 0xFEDCBA9876543210;
+	(*stream).printf("%llx",unsignedlonglong);
+	TEST_ASSERT_EQUALS_ARRAY("FEDCBA9876543210", device.buffer, 16);
+	(*stream).flush();
+	long long longlong = -9223372036854775806;
+	(*stream).printf("%lld",longlong);
+	TEST_ASSERT_EQUALS_ARRAY("-9223372036854775806", device.buffer, 20);
+	(*stream).flush();
+#endif
+}
+
 int myFunc1(void) { return -1; };
 int myFunc2(void) { return -1; };
 

--- a/src/xpcc/io/test/io_stream_test.hpp
+++ b/src/xpcc/io/test/io_stream_test.hpp
@@ -126,6 +126,9 @@ public:
 
 	void
 	testPrintf2();
+	
+	void
+	testPrintf3();
 
 	void
 	testFp();


### PR DESCRIPTION
While working with 40+Bit Register I stored into an uint64_t, I wanted to put them via printf into my  debug Logstream.
Problem was only the low 32Bits were shown in the log.

`//Example code`
`uint64_t a = 0xFEDCBA9876543210;`
`XPCC_LOG_DEBUG.printf("%llx",a);`
`// Output is "76543210"`

We (@AndreGilerson and I) fixxed the issue in the iostream.hpp and  iostream_printf.cpp editing the "long" variables to "long long"