### PR TITLE
[math][fix]fixed matrix multiplication with non square matrices, fixe…

### DIFF
--- a/src/xpcc/math/lu_decomposition.hpp
+++ b/src/xpcc/math/lu_decomposition.hpp
@@ -67,16 +67,30 @@ namespace xpcc
 		decompose(const Matrix<T, N, N> &matrix,
 				Matrix<T, N, N> *l,
 				Matrix<T, N, N> *u,
+				Matrix<T, N, N> *p);
+
+		template <typename T, uint8_t N>
+		static bool
+		decompose(const Matrix<T, N, N> &matrix,
+				Matrix<T, N, N> *l,
+				Matrix<T, N, N> *u,
 				Vector<int8_t, N> *p);
+
 
 		template <typename T, uint8_t N, uint8_t BXWIDTH>
 		static bool
 		solve(const Matrix<T, N, N> &l,
-				const Matrix<T, N, N> &u,
-				Matrix<T, BXWIDTH, N> *xb);
+		      const Matrix<T, N, N> &u,
+			    Matrix<T, N, BXWIDTH> *xb);
+
+		template <typename T, uint8_t N, uint8_t BXWIDTH>
+		static bool
+		solve(const Matrix<T, N, N> &A,
+			    Matrix<T, N, BXWIDTH> *xb);
+
 		
 	private:
-		template<typename T, uint8_t OFFSET, uint8_t WIDTH, uint8_t HEIGHT>
+		template<typename T, uint8_t OFFSET, uint8_t HEIGHT, uint8_t WIDTH>
 		class LUSubDecomposition
 		{
 		public:
@@ -95,21 +109,21 @@ namespace xpcc
 			template<uint8_t BXWIDTH>
 			static bool
 			solveLyEqualsB(
-					Matrix<T, WIDTH, HEIGHT> *l,
-					Matrix<T, BXWIDTH, HEIGHT> *bx);
+					Matrix<T, HEIGHT, WIDTH> *l,
+					Matrix<T, HEIGHT, BXWIDTH> *bx);
 
 			template<uint8_t BXWIDTH>
 			static bool
 			solveUxEqualsY(
-					Matrix<T, WIDTH, HEIGHT> *u,
-					Matrix<T, BXWIDTH, HEIGHT> *bx);
+					Matrix<T, HEIGHT, WIDTH> *u,
+					Matrix<T, HEIGHT, BXWIDTH> *bx);
 
 			template<uint8_t BXWIDTH>
 			static bool
 			solve(
-					const Matrix<T, WIDTH, HEIGHT> &l, 
-					const Matrix<T, WIDTH, HEIGHT> &u,
-					Matrix<T, BXWIDTH, HEIGHT> *bx);
+					const Matrix<T, HEIGHT, WIDTH> &l,
+					const Matrix<T, HEIGHT, WIDTH> &u,
+					Matrix<T, HEIGHT, BXWIDTH> *bx);
 		};
 
 		template<typename T, uint8_t HEIGHT>
@@ -161,14 +175,14 @@ namespace xpcc
 			template<uint8_t BXWIDTH>
 			static bool
 			solveUxEqualsY(
-					Matrix<T, WIDTH, OFFSET> *u, 
-					Matrix<T, BXWIDTH, OFFSET> *bx);
+					Matrix<T, WIDTH, OFFSET> *u,
+					Matrix<T, OFFSET, BXWIDTH> *bx);
 			
 			template<uint8_t BXWIDTH>
 			static bool
 			solveLyEqualsB(
-					Matrix<T, WIDTH, OFFSET> *l, 
-					Matrix<T, BXWIDTH, OFFSET> *bx);
+					Matrix<T, WIDTH, OFFSET> *l,
+					Matrix<T, OFFSET, BXWIDTH> *bx);
 		};
 	};
 }

--- a/src/xpcc/math/matrix.hpp
+++ b/src/xpcc/math/matrix.hpp
@@ -175,7 +175,7 @@ namespace xpcc
 		
 		/// Matrix multiplication with different size matrices
 		template<uint8_t RHSCOL>
-		Matrix<T, ROWS, ROWS>
+		Matrix<T, ROWS, RHSCOL>
 		operator * (const Matrix<T, COLUMNS, RHSCOL> &rhs) const;
 		
 		Matrix<T, COLUMNS, ROWS>

--- a/src/xpcc/math/matrix_impl.hpp
+++ b/src/xpcc/math/matrix_impl.hpp
@@ -261,19 +261,19 @@ xpcc::Matrix<T, ROWS, COLUMNS>::operator -= (const xpcc::Matrix<T, ROWS, COLUMNS
 // ----------------------------------------------------------------------------
 template<typename T, uint8_t ROWS, uint8_t COLUMNS>
 template<uint8_t RHSCOL>
-xpcc::Matrix<T, ROWS, ROWS>
+xpcc::Matrix<T, ROWS, RHSCOL>
 xpcc::Matrix<T, ROWS, COLUMNS>::operator * (const Matrix<T, COLUMNS, RHSCOL> &rhs) const
 {
-	xpcc::Matrix<T, ROWS, ROWS> m;
+	xpcc::Matrix<T, ROWS, RHSCOL> m;
 	
 	for (uint_fast8_t i = 0; i < ROWS; ++i)
 	{
 		for (uint_fast8_t j = 0; j < RHSCOL; ++j)
 		{
-			m[j][i] = element[j * COLUMNS] * rhs[0][i];
+			m[i][j] = element[i * COLUMNS] * rhs[0][j];
 			for (uint_fast8_t x = 1; x < COLUMNS; ++x)
 			{
-				m[j][i] += element[j * COLUMNS + x] * rhs[x][i];
+				m[i][j] += element[i * COLUMNS + x] * rhs[x][j];
 			}
 		}
 	}

--- a/src/xpcc/math/test/LUDecomposition_test.cpp
+++ b/src/xpcc/math/test/LUDecomposition_test.cpp
@@ -1,0 +1,64 @@
+#include <xpcc/math/matrix.hpp>
+#include <xpcc/math/lu_decomposition.hpp>
+#include "LUDecomposition_test.hpp"
+
+void
+LUDecompositionTest::testLUD()
+{
+	//https://www.wolframalpha.com/input/?i=LU+Decomposition+of+%7B%7B1,2,3%7D,%7B0,1,2%7D,%7B3,4,6%7D%7D
+
+	const float m[] = {
+		1.f, 2.f, 3.f,
+		0.f, 1.f, 2.f,
+		3.f, 4.f, 6.f
+	};
+
+
+	xpcc::Matrix<float, 3, 3> A(m);
+	xpcc::Matrix<float, 3, 3> l;
+	xpcc::Matrix<float, 3, 3> u;
+	TEST_ASSERT_TRUE(xpcc::LUDecomposition::decompose(A, &l, &u));
+	TEST_ASSERT_EQUALS(l[0][0],  1);
+	TEST_ASSERT_EQUALS(l[0][1],  0);
+	TEST_ASSERT_EQUALS(l[0][2],  0);
+	TEST_ASSERT_EQUALS(l[1][0],  0);
+	TEST_ASSERT_EQUALS(l[1][1],  1);
+	TEST_ASSERT_EQUALS(l[1][2],  0);
+	TEST_ASSERT_EQUALS(l[2][0],  3);
+	TEST_ASSERT_EQUALS(l[2][1], -2);
+	TEST_ASSERT_EQUALS(l[2][2],  1);
+
+	TEST_ASSERT_EQUALS(u[0][0], 1);
+	TEST_ASSERT_EQUALS(u[0][1], 2);
+	TEST_ASSERT_EQUALS(u[0][2], 3);
+	TEST_ASSERT_EQUALS(u[1][0], 0);
+	TEST_ASSERT_EQUALS(u[1][1], 1);
+	TEST_ASSERT_EQUALS(u[1][2], 2);
+	TEST_ASSERT_EQUALS(u[2][0], 0);
+	TEST_ASSERT_EQUALS(u[2][1], 0);
+	TEST_ASSERT_EQUALS(u[2][2], 1);
+	//test if the inverse is calculated
+	xpcc::Matrix<float, 3, 3> AI = xpcc::Matrix<float, 3, 3>::identityMatrix();
+	TEST_ASSERT_TRUE(xpcc::LUDecomposition::solve(l, u, &AI));
+	//test if (inverse of A) * (A) = E
+	TEST_ASSERT_TRUE(A * AI == (xpcc::Matrix<float, 3, 3>::identityMatrix()));
+
+	//test Ax=b
+	//https://www.wolframalpha.com/input/?i=solve%7B%7B1,2,3%7D,%7B0,1,2%7D,%7B3,4,6%7D%7D+%7B%7Bx%7D,%7By%7D,%7Bz%7D%7D%3D+%7B%7B0%7D,%7B1%7D,%7B2%7D%7D
+	const float n[] = {
+		0.f,
+		1.f,
+		2.f
+	};
+	xpcc::Matrix<float, 3, 1> b(n);
+	TEST_ASSERT_TRUE(xpcc::LUDecomposition::solve(l, u, &b));
+	TEST_ASSERT_EQUALS(b[0][0],  2);
+	TEST_ASSERT_EQUALS(b[1][0], -7);
+	TEST_ASSERT_EQUALS(b[2][0],  4);
+	b = xpcc::Matrix<float, 3, 1>(n);
+	TEST_ASSERT_TRUE(xpcc::LUDecomposition::solve(A, &b));
+	TEST_ASSERT_EQUALS(b[0][0],  2.f);
+	TEST_ASSERT_EQUALS(b[1][0], -7.f);
+	TEST_ASSERT_EQUALS(b[2][0],  4.f);
+}
+

--- a/src/xpcc/math/test/LUDecomposition_test.hpp
+++ b/src/xpcc/math/test/LUDecomposition_test.hpp
@@ -1,0 +1,8 @@
+#include <unittest/testsuite.hpp>
+
+class LUDecompositionTest : public unittest::TestSuite
+{
+public:
+	void
+	testLUD();
+};

--- a/src/xpcc/math/test/matrix_test.cpp
+++ b/src/xpcc/math/test/matrix_test.cpp
@@ -174,8 +174,8 @@ MatrixTest::testAccess()
 	xpcc::Matrix<int16_t, 3, 1> b = a.getColumn(1);
 	
 	TEST_ASSERT_EQUALS(b[0][0], 2);
-	TEST_ASSERT_EQUALS(b[0][1], 5);
-	TEST_ASSERT_EQUALS(b[0][2], 8);
+	TEST_ASSERT_EQUALS(b[1][0], 5);
+	TEST_ASSERT_EQUALS(b[2][0], 8);
 	
 	xpcc::Matrix<int16_t, 1, 3> c = a.getRow(2);
 	
@@ -291,7 +291,7 @@ MatrixTest::testMatrixMultiplication()
 		3,
 	};
 	
-	xpcc::Matrix<int16_t, 3, 1> a(m);
+	const xpcc::Matrix<int16_t, 3, 1> a(m);
 	xpcc::Matrix<int16_t, 1, 3> b(m);
 	
 	xpcc::Matrix<int16_t, 3, 3> c = a * b;
@@ -337,8 +337,56 @@ MatrixTest::testMatrixMultiplication()
 	TEST_ASSERT_EQUALS(g[0][1], 28);
 	TEST_ASSERT_EQUALS(g[1][0], 49);
 	TEST_ASSERT_EQUALS(g[1][1], 64);
-}
 
+
+	// Testing non-square matrices
+	// https://www.wolframalpha.com/input/?i=%7B%7B1,2,3%7D,%7B4,5,6%7D,%7B7,8,9%7D%7D*%7B%7B1%7D,%7B2%7D,%7B3%7D%7D
+	const int16_t o[] = {
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9
+	};
+
+	xpcc::Matrix<int16_t, 3, 3> h(o);
+	xpcc::Matrix<int16_t, 3, 1> i = h * a;
+	TEST_ASSERT_EQUALS(i[0][0], 14);
+	TEST_ASSERT_EQUALS(i[1][0], 32);
+	TEST_ASSERT_EQUALS(i[2][0], 50);
+	//https://www.wolframalpha.com/input/?i=%7B%7B1,2,3%7D,%7B4,5,6%7D,%7B7,8,9%7D%7D*%7B%7B1,2%7D,%7B3,4%7D,%7B5,6%7D%7D
+	const int16_t p[] = {
+		1, 2,
+		3, 4,
+		5, 6,
+	};
+
+
+	xpcc::Matrix<int16_t, 3, 2> j(p);
+	xpcc::Matrix<int16_t, 3, 2> k = h * j;
+
+	TEST_ASSERT_EQUALS(k[0][0],  22);
+	TEST_ASSERT_EQUALS(k[0][1],  28);
+	TEST_ASSERT_EQUALS(k[1][0],  49);
+	TEST_ASSERT_EQUALS(k[1][1],  64);
+	TEST_ASSERT_EQUALS(k[2][0],  76);
+	TEST_ASSERT_EQUALS(k[2][1], 100);
+
+	//https://www.wolframalpha.com/input/?i=%7B%7B1,2,3,4,5%7D,%7B6,7,8,9,10%7D%7D*%7B%7B1,2,3%7D,%7B4,5,6%7D,%7B7,8,9%7D,%7B10,11,12%7D,%7B13,14,15%7D%7D
+	const int16_t q[] = {
+		 1,  2,  3,  4,  5,
+		 6,  7,  8,  9, 10,
+		11, 12, 13, 14, 15
+	};
+	xpcc::Matrix<int16_t, 2, 5> l(q);
+	xpcc::Matrix<int16_t, 5, 3> ll(q);
+	xpcc::Matrix<int16_t, 2, 3> aa = l * ll;
+
+	TEST_ASSERT_EQUALS(aa[0][0], 135);
+	TEST_ASSERT_EQUALS(aa[0][1], 150);
+	TEST_ASSERT_EQUALS(aa[0][2], 165);
+	TEST_ASSERT_EQUALS(aa[1][0], 310);
+	TEST_ASSERT_EQUALS(aa[1][1], 350);
+	TEST_ASSERT_EQUALS(aa[1][2], 390);
+	}
 void
 MatrixTest::testTranspose()
 {


### PR DESCRIPTION
…d LU-Decomposition + added unittests + added simple functions

Was working on some other stuff that does not work-> fixed it and wrote Unittests for it.

Took some time to debug this, most was a simple switch of Height and Width which someone implemented the wrong way around.
I added a LU-Decompostition function if someone just want to solve a simple Ax=b equation without getting the lower and upper matrix.
Additional I wrote a function with which argument returns a permutation Matrix P instead of a Vector.  