### PR TITLE
[travis] Update arm-none-eabi-gcc to 2017q4.

### DIFF
--- a/.travis.dep.sh
+++ b/.travis.dep.sh
@@ -5,7 +5,7 @@ if [ ! -f "$HOME/cache/avr-gcc.tar.bz2" ]; then
 fi
 if [ ! -f "$HOME/cache/cortex-m.tar.bz2" ]; then
 	echo "Downloading Cortex-M toolchain..."
-	(cd $HOME/cache && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O cortex-m.tar.bz2) &
+	(cd $HOME/cache && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2 -O cortex-m.tar.bz2) &
 fi
 if [ ! -f "$HOME/cache/boost.tar.bz2" ]; then
 	echo "Downloading libboost package..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ before_install:
  - export LD_LIBRARY_PATH="$HOME/toolchain/boost/lib:$LD_LIBRARY_PATH"
  - export CXXFLAGS="-isystem$HOME/toolchain/boost/include"
  - export LDFLAGS="-L$HOME/toolchain/boost/lib"
- - export PATH="$HOME/toolchain/avr-gcc/bin:$HOME/toolchain/gcc-arm-none-eabi-6-2017-q2-update/bin:$PATH"
+ - export PATH="$HOME/toolchain/avr-gcc/bin:$HOME/toolchain/gcc-arm-none-eabi-7-2017-q4-major/bin:$PATH"
  - echo $PATH
  - ls -l $HOME/toolchain
  - ls -l $HOME/toolchain/avr-gcc/bin
- - ls -l $HOME/toolchain/gcc-arm-none-eabi-6-2017-q2-update/bin
+ - ls -l $HOME/toolchain/gcc-arm-none-eabi-7-2017-q4-major/bin
  - ls -l $HOME/toolchain/boost
  - which avr-g++
  - avr-g++ --version


### PR DESCRIPTION
Circle CI needs to be updated indirectly via https://github.com/strongly-typed/docker-arm-none-eabi-gcc/pull/1.

cc @strongly-typed 