### PR TITLE
Adds ADC support for STM32 F0

### DIFF
--- a/src/xpcc/architecture/platform/driver/adc/stm32f0/adc.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f0/adc.hpp.in
@@ -1,0 +1,269 @@
+// coding: utf-8
+/* Copyright (c) 2018, Álan Crístoffer
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_STM32F0_ADC_HPP
+#define XPCC_STM32F0_ADC_HPP
+
+#include <stdint.h>
+#include "../../../type_ids.hpp"
+#include "../../../device.hpp"
+#include <xpcc/architecture/interface/register.hpp>
+
+/**
+ * @ingroup 	{{target.string}}
+ * @defgroup	{{target.string}}_adc ADC
+*/
+namespace xpcc
+{
+namespace stm32
+{
+/**
+ * Analog/Digital-Converter module (ADC1).
+ *
+ * The 12-bit ADC is a successive approximation analog-to-digital
+ * converter. It has up to 19 multiplexed channels allowing it measure
+ * signals from 16 external and three internal sources.
+ * The result of the ADC is stored in a left-aligned or right-aligned
+ * 16-bit data register.
+ *
+ * This API is designed for the internal ADCs of STM32F0x1/STM32F0x2/STM32F0x8
+ *
+ * \author	Álan Crístoffer
+ * \ingroup	{{target.string}}_adc
+ */
+class Adc
+{
+public:
+/*
+ * TODO: generate the right number of Channels depending on the specific device.
+ * This code was generated using the family datasheet, but not all devices in the
+ * family have 16 channels.
+ */
+%% for channel in range(0,16)
+	/// TypeId used to connect GPIO pins to this adc's Channel{{ channel }}.
+	static const TypeId::AdcChannel{{ channel }} Channel{{ channel }};
+%% endfor
+
+	/// Channels, which can be used with this ADC.
+	enum class Channel : uint8_t
+	{
+%% for channel in range(0,16)
+		Channel{{ channel }} = {{ channel }},
+%% endfor
+%#
+		Temperature = 16,
+		InternalReference = 17,
+		Battery = 18
+	};
+
+	enum class ClockMode : uint32_t
+	{
+		DoNotChange = 0xFF,// if you do not want to change the clock mode
+		Dedicated14MHzClock = 0,
+		PCLKDividedBy2 = ADC_CFGR2_CKMODE_0,
+		PCLKDividedBy4 = ADC_CFGR2_CKMODE_1
+	};
+
+	enum class SampleTime : uint8_t	// TODO: What is the best type?
+	{
+		Cycles15 	= 0b000,	//! 000:   1.5 ADC clock cycles
+		Cycles75 	= 0b001,	//! 001:   7.5 ADC clock cycles
+		Cycles135 	= 0b010,	//! 010:  13.5 ADC clock cycles
+		Cycles285 	= 0b011,	//! 011:  28.5 ADC clock cycles
+		Cycles415 	= 0b100,	//! 100:  41.5 ADC clock cycles
+		Cycles555 	= 0b101,	//! 101:  55.5 ADC clock cycles
+		Cycles715 	= 0b110,	//! 110:  71.5 ADC clock cycles
+		Cycles2395 	= 0b111,	//! 111: 239.5 ADC clock cycles
+	};
+
+	enum class CalibrationMode : uint32_t
+	{
+		Calibrate = 0,
+		DoNotCalibrate = 0xff,	// if you want to avoid calibration
+	};
+
+	enum class DataAlignment : uint8_t {
+		Right = ADC_CFGR1_ALIGN,
+		Left = 0
+	};
+
+	enum class Resolution : uint8_t {
+		Bits12 = 0,
+		Bits10 = ADC_CFGR1_RES_0,
+		Bits8  = ADC_CFGR1_RES_1,
+		Bits6  = ADC_CFGR1_RES_0 | ADC_CFGR1_RES_1
+	};
+
+	enum class Interrupt : uint32_t
+	{
+		Ready = ADC_IER_ADRDYIE,
+		EndOfSampling = ADC_IER_EOSMPIE,
+		EndOfConversion = ADC_IER_EOCIE,
+		EndOfSequence = ADC_IER_EOSIE,
+		Overrun = ADC_IER_OVRIE,
+		AnalogWatchdog = ADC_IER_AWD1IE
+	};
+	XPCC_FLAGS32(Interrupt);
+
+	enum class InterruptFlag : uint32_t
+	{
+		Ready = ADC_ISR_ADRDY,
+		EndOfSampling = ADC_ISR_EOSMP,
+		EndOfConversion = ADC_ISR_EOC,
+		EndOfSequence = ADC_ISR_EOS,
+		Overrun = ADC_ISR_OVR,
+		AnalogWatchdog = ADC_ISR_AWD1
+	};
+	XPCC_FLAGS32(InterruptFlag);
+
+	/**
+	 * Initialize and enable the A/D converter.
+	 *
+	 * Enables the ADC clock and switches on the ADC. The ADC clock
+	 * prescaler will be set as well.
+	 *
+	 * The ADC can be clocked
+	 *
+	 * @param clk
+	 * 		Set to ClockMode::DoNotChange or leave blank if you
+	 * 		want to leave this setting untouched.
+	 *
+	 */
+	static inline uint16_t
+	initialize(const ClockMode clk = ClockMode::DoNotChange,
+			   const CalibrationMode cal = CalibrationMode::Calibrate);
+
+	static inline void
+	disable(const bool blocking = true);
+
+	static inline void
+	setAutoOffMode(const bool enable);
+
+	/**
+	 * Returns true if the ADRDY bit of the ISR is set
+	 **/
+	static inline bool
+	isReady();
+
+	static inline uint16_t
+	calibrate(const CalibrationMode mode);
+
+	/**
+	 * Change the presentation of the ADC conversion result.
+	 *
+	 * @param enable
+	 * 		Set to \c true to left adjust the result.
+	 *		Otherwise, the result is right adjusted.
+	 *
+	 * @pre The ADC clock must be started and the ADC switched on with
+	 * 		initialize()
+	 */
+	static inline void
+	setDataAlignmentAndResolution(const DataAlignment alignment,
+	       						  const Resolution res);
+
+	/**
+	 * Analog channel selection.
+	 *
+	 * This not for scan mode. The number of channels will be set to 1,
+	 * the channel selected and the corresponding pin will be set to
+	 * analog input.
+	 * If the the channel is modified during a conversion, the current
+	 * conversion is reset and a new start pulse is sent to the ADC to
+	 * convert the new chosen channnel / group of channels.
+	 *
+	 *
+	 * @param channel		The channel which shall be read.
+	 * @param sampleTime	The sample time to sample the input voltage.
+	 *
+	 * @pre The ADC clock must be started and the ADC switched on with
+	 * 		initialize()
+	 */
+	static inline void
+	setChannel(const Channel channel,
+			   const SampleTime sampleTime=static_cast<SampleTime>(0b000));
+
+   	static inline void
+   	clearChannel(const Channel channel);
+
+	/**
+	 * Enables free running mode
+	 *
+	 * The ADC will continously start conversions and provide the most
+	 * recent result in the ADC register.
+	 *
+	 * @pre The ADC clock must be started and the ADC switched on with
+	 * 		initialize()
+	 */
+	static inline void
+	setFreeRunningMode(const bool enable);
+
+	/**
+	 * Start a new conversion or continuous conversions.
+	 *
+	 * @pre A ADC channel must be selected with setChannel().
+	 *
+	 * @post The result can be fetched with getValue()
+	 *
+	 * TODO: is there any limitation to when is can be called??
+	 */
+	static inline void
+	startConversion(void);
+
+	/**
+	 * @return If the conversion is finished.
+	 * @pre A conversion should have been stared with startConversion()
+	 */
+	static inline bool
+	isConversionFinished(void);
+
+	/**
+	 * @return The most recent 16bit result of the ADC conversion.
+	 * @pre A conversion should have been stared with startConversion()
+	 *
+	 * To have a blocking GET you might do it this way:
+	 * @code
+		while(!isConversionFinished())
+		{
+			// Waiting for conversion
+		}
+		@endcode
+	 */
+	static inline uint16_t
+	getValue(void)
+	{
+		return ADC1->DR;
+	}
+
+	static inline void
+	enableInterruptVector(const uint32_t priority, const bool enable = true);
+
+	static inline void
+	enableInterrupt(const Interrupt_t interrupt);
+
+	static inline void
+	disableInterrupt(const Interrupt_t interrupt);
+
+	static inline InterruptFlag_t
+	getInterruptFlags();
+
+	static inline void
+	acknowledgeInterruptFlag(const InterruptFlag_t flags);
+
+	static inline void
+	setWaitMode(const bool enable);
+};
+
+}
+
+}
+
+#include "adc_impl.hpp"
+
+#endif	// XPCC_STM32F0_ADC_HPP

--- a/src/xpcc/architecture/platform/driver/adc/stm32f0/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f0/adc_impl.hpp.in
@@ -1,0 +1,200 @@
+// coding: utf-8
+/* Copyright (c) 2018, Álan Crístoffer
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_STM32F0_ADC_HPP
+#    error     "Don't include this file directly, use 'adc_{{ id }}.hpp' instead!"
+#endif
+
+#include <xpcc/architecture/driver/delay.hpp>    // xpcc::delayMicroseconds
+
+uint16_t
+xpcc::stm32::Adc::initialize(const ClockMode clk,
+                             const CalibrationMode cal)
+{
+    RCC->APB2ENR |= RCC_APB2ENR_ADC1EN;
+
+    if (clk == ClockMode::Dedicated14MHzClock) {
+        RCC->CR2 |= RCC_CR2_HSI14ON;
+        while ((RCC->CR2 & RCC_CR2_HSI14RDY) == 0)
+            ;
+        ADC1->CFGR2 &= (~ADC_CFGR2_CKMODE);
+    } else if (clk != ClockMode::DoNotChange) {
+        ADC1->CFGR2 |= static_cast<uint32_t>(clk);
+    }
+
+    uint16_t calibrationResult = xpcc::stm32::Adc::calibrate(cal);
+
+    ADC1->ISR |= ADC_ISR_ADRDY; // ISR is cleared by setting 1 to the bit
+    ADC1->CR  |= ADC_CR_ADEN;
+
+    while ( (ADC1->ISR & ADC_ISR_ADRDY) == 0 )
+        ;
+
+    return calibrationResult;
+}
+
+void
+xpcc::stm32::Adc::disable(const bool blocking)
+{
+    ADC1->CR |= ADC_CR_ADDIS;
+    while ( blocking && (ADC1->CR & ADC_CR_ADEN) != 0 )
+        ;
+}
+
+void
+xpcc::stm32::Adc::setAutoOffMode(const bool enable)
+{
+    if (enable) {
+        ADC1->CFGR1 |= ADC_CFGR1_AUTOFF;
+    } else {
+        ADC1->CFGR1 &= ~ADC_CFGR1_AUTOFF;
+    }
+}
+
+bool
+xpcc::stm32::Adc::isReady()
+{
+    return static_cast<bool>(getInterruptFlags() & InterruptFlag::Ready);
+}
+
+uint16_t
+xpcc::stm32::Adc::calibrate(const CalibrationMode mode)
+{
+    if (mode != CalibrationMode::DoNotCalibrate) {
+        if ( (ADC1->CR & ADC_CR_ADEN) != 0 ) {
+            ADC1->CR |= ADC_CR_ADDIS;
+            while ( (ADC1->CR & ADC_CR_ADEN) != 0 )
+                ;
+        }
+
+        ADC1->CFGR1 &= ~ADC_CFGR1_DMAEN;
+        ADC1->CR    |= ADC_CR_ADCAL;
+
+        while ( (ADC1->CR & ADC_CR_ADCAL) != 0 )
+            ;
+
+        return ADC1->DR;
+    }
+
+    return 0;
+}
+
+void
+xpcc::stm32::Adc::setDataAlignmentAndResolution(const DataAlignment align,
+                                                const Resolution res)
+{
+    ADC1->CFGR1 = static_cast<uint32_t>(align) |
+                  static_cast<uint32_t>(res)   |
+                  (ADC1->CFGR1 & ~(ADC_CFGR1_ALIGN | ADC_CFGR1_RES));
+}
+
+void
+xpcc::stm32::Adc::setChannel(const Channel channel,
+                             const SampleTime sampleTime)
+{
+    ADC1->CHSELR |= 1 << static_cast<uint32_t>(channel);
+    ADC1->SMPR   = static_cast<uint32_t>(sampleTime);
+
+    if (channel == Channel::InternalReference) {
+        ADC1_COMMON->CCR |= ADC_CCR_VREFEN;
+    } else if (channel == Channel::Temperature) {
+        ADC1_COMMON->CCR |= ADC_CCR_TSEN;
+    } else {
+        const uint32_t tbc = 0x3 << (2 * static_cast<uint32_t>(channel));
+        GPIOA->MODER |= tbc;
+        GPIOA->PUPDR &= ~tbc;
+    }
+}
+
+void
+xpcc::stm32::Adc::clearChannel(const Channel channel)
+{
+    ADC1->CHSELR &= ~(1 << static_cast<uint32_t>(channel));
+    if (channel == Channel::InternalReference) {
+        ADC1_COMMON->CCR &= ~ADC_CCR_VREFEN;
+    } else if (channel == Channel::Temperature) {
+        ADC1_COMMON->CCR &= ~ADC_CCR_TSEN;
+    }
+}
+
+void
+xpcc::stm32::Adc::setFreeRunningMode(const bool enable)
+{
+    if (enable) {
+        ADC1->CFGR1 |= ADC_CFGR1_CONT;
+    } else {
+        ADC1->CFGR1 &= ~ADC_CFGR1_CONT;
+    }
+}
+
+void
+xpcc::stm32::Adc::startConversion(void)
+{
+    acknowledgeInterruptFlag(InterruptFlag::EndOfConversion |
+                             InterruptFlag::EndOfSampling   |
+                             InterruptFlag::EndOfSequence   |
+                             InterruptFlag::Overrun         |
+                             InterruptFlag::AnalogWatchdog);
+    // starts single conversion for the regular group
+    ADC1->CR |= ADC_CR_ADSTART;
+}
+
+bool
+xpcc::stm32::Adc::isConversionFinished(void)
+{
+    return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfSampling);
+}
+
+void
+xpcc::stm32::Adc::enableInterruptVector(const uint32_t priority,
+                                                const bool enable)
+{
+    if (enable) {
+        NVIC_EnableIRQ(ADC1_COMP_IRQn);
+        NVIC_SetPriority(ADC1_COMP_IRQn, priority);
+    } else {
+        NVIC_DisableIRQ(ADC1_COMP_IRQn);
+    }
+}
+
+void
+xpcc::stm32::Adc::enableInterrupt(const Interrupt_t interrupt)
+{
+    ADC1->IER |= interrupt.value;
+}
+
+void
+xpcc::stm32::Adc::disableInterrupt(const Interrupt_t interrupt)
+{
+    ADC1->IER &= ~interrupt.value;
+}
+
+xpcc::stm32::Adc::InterruptFlag_t
+xpcc::stm32::Adc::getInterruptFlags()
+{
+    return InterruptFlag_t(ADC1->ISR);
+}
+
+void
+xpcc::stm32::Adc::acknowledgeInterruptFlag(const InterruptFlag_t flags)
+{
+    // Flags are cleared by writing a one to the flag position.
+    // Writing a zero is ignored.
+    ADC1->ISR = flags.value;
+}
+
+void
+xpcc::stm32::Adc::setWaitMode(const bool enable)
+{
+    if (enable) {
+        ADC1->CFGR1 |= ADC_CFGR1_WAIT;
+    } else {
+        ADC1->CFGR1 &= ~ADC_CFGR1_WAIT;
+    }
+}

--- a/src/xpcc/architecture/platform/driver/adc/stm32f0/driver.xml
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f0/driver.xml
@@ -1,7 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE rca SYSTEM "../../xml/driver.dtd">
 <rca version="1.0">
-	<driver type="adc" name="stm32f0">
-		<template>type_ids.hpp.in</template>
-	</driver>
+    <driver type="adc" name="stm32f0">
+        <template>adc.hpp.in</template>
+        <template>adc_impl.hpp.in</template>
+        <template>type_ids.hpp.in</template>
+    </driver>
 </rca>


### PR DESCRIPTION
Class created following the Familly Datasheet. Tested on a STM32F030C8T6.
Not tested: interrupts and watchdog, but the code for activating those is (hopefully complete) in the class.