### PR TITLE
[driver] Block device

### DIFF
--- a/examples/linux/block_device/file/SConstruct
+++ b/examples/linux/block_device/file/SConstruct
@@ -1,0 +1,8 @@
+# path to the xpcc root directory
+xpccpath = '../../../..'
+
+# create empty `test.bin~` file (if it does not exist)
+open('test.bin~', 'a').close()
+
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/linux/block_device/file/main.cpp
+++ b/examples/linux/block_device/file/main.cpp
@@ -1,0 +1,85 @@
+#include <xpcc/architecture.hpp>
+#include <xpcc/debug/logger.hpp>
+
+#include <xpcc/driver/storage/block_device_file.hpp>
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		XPCC_LOG_INFO.printf("%x", address[i]);
+	}
+}
+
+// `test.bin~` file is created from `SConstruct`
+struct Filename {
+	static constexpr const char* name = "test.bin~";
+};
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns into
+	 * a `xpcc::BdFile` block device with a size of 1M.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 */
+
+	constexpr uint32_t BlockSize = 64;
+	constexpr uint32_t MemorySize = 1024*1024;
+
+	uint8_t bufferA[BlockSize];
+	uint8_t bufferB[BlockSize];
+	uint8_t bufferC[BlockSize];
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	xpcc::BdFile<Filename, MemorySize> storageDevice;
+
+	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+		XPCC_LOG_INFO << "Error: Unable to initialize device.";
+		exit(1);
+	}
+
+	if(!RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
+		XPCC_LOG_INFO << "Error: Unable to erase device.";
+		exit(1);
+	}
+
+	XPCC_LOG_INFO << "Starting memory test!" << xpcc::endl;
+
+	for(uint16_t iteration = 0; iteration < 10; iteration++) {
+		uint8_t* pattern = (iteration % 2 == 0) ? bufferA : bufferB;
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.write(pattern, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to write data.";
+				exit(1);
+			}
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.read(bufferC, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to read data.";
+				exit(1);
+			}
+			else if(std::memcmp(pattern, bufferC, BlockSize)) {
+				XPCC_LOG_INFO << "Error: Read '";
+				printMemoryContent(bufferC, BlockSize);
+				XPCC_LOG_INFO << "', expected: '";
+				printMemoryContent(pattern, BlockSize);
+				XPCC_LOG_INFO << "'." << xpcc::endl;
+				exit(1);
+			}
+		}
+		XPCC_LOG_INFO << ".";
+	}
+
+	XPCC_LOG_INFO << xpcc::endl << "Finished!" << xpcc::endl;
+
+	return 0;
+}

--- a/examples/linux/block_device/file/project.cfg
+++ b/examples/linux/block_device/file/project.cfg
@@ -1,0 +1,3 @@
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/linux/${name}

--- a/examples/linux/block_device/mirror/SConstruct
+++ b/examples/linux/block_device/mirror/SConstruct
@@ -1,0 +1,9 @@
+# path to the xpcc root directory
+xpccpath = '../../../..'
+
+# create empty `testA.bin~` and `testA.bin~` files (if they do not exist)
+open('testA.bin~', 'a').close()
+open('testB.bin~', 'a').close()
+
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/linux/block_device/mirror/main.cpp
+++ b/examples/linux/block_device/mirror/main.cpp
@@ -1,0 +1,90 @@
+#include <xpcc/architecture.hpp>
+#include <xpcc/debug/logger.hpp>
+
+#include <xpcc/driver/storage/block_device_file.hpp>
+#include <xpcc/driver/storage/block_device_mirror.hpp>
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		XPCC_LOG_INFO.printf("%x", address[i]);
+	}
+}
+// `testA.bin~` and `testB.bin~` files are created from `SConstruct`
+struct FilenameA {
+	static constexpr const char* name = "testA.bin~";
+};
+
+struct FilenameB {
+	static constexpr const char* name = "testB.bin~";
+};
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns into
+	 * two `xpcc::BdFile` block device with a size of 1M
+	 * to test the virtual `xpcc::BdMirror` block device.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 */
+
+	constexpr uint32_t BlockSize = 256;
+	constexpr uint32_t MemorySize = 16*1024*1024;
+
+	uint8_t bufferA[BlockSize];
+	uint8_t bufferB[BlockSize];
+	uint8_t bufferC[BlockSize];
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	xpcc::BdMirror<xpcc::BdFile<FilenameA, MemorySize>, xpcc::BdFile<FilenameB, MemorySize>> storageDevice;
+
+	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+		XPCC_LOG_INFO << "Error: Unable to initialize device.";
+		exit(1);
+	}
+
+	XPCC_LOG_INFO << "Starting memory test!" << xpcc::endl;
+
+	for(uint16_t iteration = 0; iteration < 10; iteration++) {
+		uint8_t* pattern = (iteration % 2 == 0) ? bufferA : bufferB;
+
+		if(!RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
+			XPCC_LOG_INFO << "Error: Unable to erase device.";
+			exit(1);
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.program(pattern, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to write data.";
+				exit(1);
+			}
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.read(bufferC, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to read data.";
+				exit(1);
+			}
+			else if(std::memcmp(pattern, bufferC, BlockSize)) {
+				XPCC_LOG_INFO << "Error: Read '";
+				printMemoryContent(bufferC, BlockSize);
+				XPCC_LOG_INFO << "', expected: '";
+				printMemoryContent(pattern, BlockSize);
+				XPCC_LOG_INFO << "'." << xpcc::endl;
+				break;
+			}
+		}
+		XPCC_LOG_INFO << ".";
+	}
+
+	XPCC_LOG_INFO << xpcc::endl << "Finished!" << xpcc::endl;
+
+	return 0;
+}

--- a/examples/linux/block_device/mirror/project.cfg
+++ b/examples/linux/block_device/mirror/project.cfg
@@ -1,0 +1,3 @@
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/linux/${name}

--- a/examples/linux/block_device/ram/SConstruct
+++ b/examples/linux/block_device/ram/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../../..'
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/linux/block_device/ram/main.cpp
+++ b/examples/linux/block_device/ram/main.cpp
@@ -1,0 +1,75 @@
+#include <xpcc/architecture.hpp>
+#include <xpcc/debug/logger.hpp>
+
+#include <xpcc/driver/storage/block_device_heap.hpp>
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		XPCC_LOG_INFO.printf("%x", address[i]);
+	}
+}
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns into
+	 * a `xpcc::BdHeap` block device with a size of 1M.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 */
+
+	constexpr uint32_t BlockSize = 64;
+	constexpr uint32_t MemorySize = 1024*1024;
+
+	uint8_t bufferA[BlockSize];
+	uint8_t bufferB[BlockSize];
+	uint8_t bufferC[BlockSize];
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	xpcc::BdHeap<MemorySize> storageDevice;
+	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+		XPCC_LOG_INFO << "Error: Unable to initialize device.";
+		exit(1);
+	}
+	RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize));
+
+	XPCC_LOG_INFO << "Starting memory test!" << xpcc::endl;
+
+	for(uint16_t iteration = 0; iteration < 1000; iteration++) {
+		uint8_t* pattern = (iteration % 2 == 0) ? bufferA : bufferB;
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.write(pattern, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to write data.";
+				exit(1);
+			}
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.read(bufferC, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to read data.";
+				exit(1);
+			}
+			else if(std::memcmp(pattern, bufferC, BlockSize)) {
+				XPCC_LOG_INFO << "Error: Read '";
+				printMemoryContent(bufferC, BlockSize);
+				XPCC_LOG_INFO << "', expected: '";
+				printMemoryContent(pattern, BlockSize);
+				XPCC_LOG_INFO << "'." << xpcc::endl;
+				exit(1);
+			}
+		}
+		XPCC_LOG_INFO << ".";
+	}
+
+	XPCC_LOG_INFO << xpcc::endl << "Finished!" << xpcc::endl;
+
+	return 0;
+}

--- a/examples/linux/block_device/ram/project.cfg
+++ b/examples/linux/block_device/ram/project.cfg
@@ -1,0 +1,3 @@
+[build]
+device = hosted
+buildpath = ${xpccpath}/build/linux/block_device/${name}

--- a/examples/nucleo_f429zi/spi_flash/SConstruct
+++ b/examples/nucleo_f429zi/spi_flash/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/nucleo_f429zi/spi_flash/main.cpp
+++ b/examples/nucleo_f429zi/spi_flash/main.cpp
@@ -1,0 +1,131 @@
+#include <xpcc/architecture/platform.hpp>
+
+#include <xpcc/driver/storage/block_device_spiflash.hpp>
+
+using namespace Board;
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		XPCC_LOG_INFO.printf("%x", address[i]);
+	}
+}
+
+using SpiMaster = SpiMaster1;
+
+// Spi flash chip wiring:
+using Cs = GpioA4;
+using Mosi = GpioB5;
+using Miso = GpioB4;
+using Sck = GpioB3;
+// Connect WP and HOLD pins to +3V3
+// and of course Vdd to +3V3 and Vss to GND
+
+
+constexpr uint32_t BlockSize = 256;
+constexpr uint32_t MemorySize = 8*1024*1024;
+constexpr uint32_t TestMemorySize = 8*1024;
+
+uint8_t bufferA[BlockSize];
+uint8_t bufferB[BlockSize];
+uint8_t bufferC[BlockSize];
+
+xpcc::BdSpiFlash<SpiMaster, Cs, MemorySize> storageDevice;
+
+void doMemoryTest()
+{
+	LedBlue::set();
+	XPCC_LOG_INFO << "Starting memory test!" << xpcc::endl;
+
+	for(uint16_t iteration = 0; iteration < 4; iteration++) {
+		uint8_t* pattern = (iteration % 2 == 0) ? bufferA : bufferB;
+
+		if(!RF_CALL_BLOCKING(storageDevice.erase(0, TestMemorySize))) {
+			XPCC_LOG_INFO << "Error: Unable to erase device.";
+			return;
+		}
+
+		for(uint32_t i = 0; i < TestMemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.program(pattern, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to write data.";
+				return;
+			}
+			XPCC_LOG_INFO << ".";
+		}
+
+		for(uint32_t i = 0; i < TestMemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.read(bufferC, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to read data.";
+				return;
+			}
+			else if(std::memcmp(pattern, bufferC, BlockSize)) {
+				XPCC_LOG_INFO << "i=" << i << xpcc::endl;
+				XPCC_LOG_INFO << "Error: Read '";
+				printMemoryContent(bufferC, BlockSize);
+				XPCC_LOG_INFO << "', expected: '";
+				printMemoryContent(pattern, BlockSize);
+				XPCC_LOG_INFO << "'." << xpcc::endl;
+				return;
+			}
+		}
+		XPCC_LOG_INFO << "." << xpcc::endl;
+	}
+
+	XPCC_LOG_INFO << xpcc::endl << "Finished!" << xpcc::endl;
+	LedBlue::reset();
+}
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns a 64MBit
+	 * flash chip (SST26VF064B) attached to SPI0 using the
+	 * `xpcc::BdSpiFlash` block device interface.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 *
+	 * See above for how to wire the flash chip.
+	 */
+
+	// initialize board and SPI
+	Board::initialize();
+	Mosi::connect(SpiMaster::Mosi);
+	Miso::connect(SpiMaster::Miso);
+	Sck::connect(SpiMaster::Sck);
+	SpiMaster::initialize<Board::systemClock, 11000000>();
+
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	bool initializeSuccess = false;
+
+	XPCC_LOG_INFO << "Erasing complete flash chip... (This may take a while)" << xpcc::endl;
+
+	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+		XPCC_LOG_INFO << "Error: Unable to initialize device.";
+	}
+	else if(!RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
+		XPCC_LOG_INFO << "Error: Unable to erase device.";
+	}
+	else {
+		auto id = RF_CALL_BLOCKING(storageDevice.readId());
+		XPCC_LOG_INFO << "deviceId=" << id.deviceId << " manufacturerId=" << id.manufacturerId;
+		XPCC_LOG_INFO << " deviceType=" << id.deviceType << xpcc::endl;
+
+		XPCC_LOG_INFO << "status=" << static_cast<uint8_t>(RF_CALL_BLOCKING(storageDevice.readStatus())) << xpcc::endl;
+
+		XPCC_LOG_INFO << "Press USER button to start the memory test." << xpcc::endl;
+		initializeSuccess = true;
+	}
+
+	while (1)
+	{
+		if(initializeSuccess && Button::read())
+		{
+			doMemoryTest();
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f429zi/spi_flash/project.cfg
+++ b/examples/nucleo_f429zi/spi_flash/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = nucleo_f429zi
+buildpath = ${xpccpath}/build/nucleo_f429zi/${name}

--- a/src/xpcc/architecture/interface/block_device.hpp
+++ b/src/xpcc/architecture/interface/block_device.hpp
@@ -1,0 +1,113 @@
+// coding: utf-8
+/* Copyright (c) 2017, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_INTERFACE_BLOCK_DEVICE_HPP
+#define XPCC_INTERFACE_BLOCK_DEVICE_HPP
+
+#include <stdint.h>
+#include <xpcc/architecture/interface.hpp>
+#include <xpcc/processing/resumable.hpp>
+
+/**
+ * @ingroup		interface
+ * @defgroup	storage	Data storage
+ */
+
+namespace xpcc
+{
+
+/**
+ * Interface of a Block Device
+ *
+ * Access to storage devices like flash chips
+ *
+ * @author	Raphael Lehmann
+ * @ingroup	storage
+ */
+class BlockDevice
+{
+public:
+	BlockDevice() = default;
+	BlockDevice(const BlockDevice&) = delete;
+	BlockDevice& operator= (const BlockDevice&) = delete;
+
+	using bd_address_t = uint32_t;
+	using bd_size_t = uint32_t;
+
+#ifdef __DOXYGEN__
+public:
+	/// Initializes the storage hardware
+	xpcc::ResumableResult<bool>
+	initialize();
+
+	/// Deinitializes the storage hardware
+	xpcc::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	read(uint8_t *buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	program(const uint8_t *buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased proir to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	xpcc::ResumableResult<bool>
+	write(const uint8_t *buffer, bd_address_t address, bd_size_t size);
+
+public:
+	/** Minimum block sizes for block device operations
+	 *
+	 * Most persistent storage devices require `program()`,  `erase()`
+	 * and sometimes `read()` operations to be executed on fixed sized blocks.
+	 */
+	static constexpr bd_size_t BlockSizeRead = 1;
+	static constexpr bd_size_t BlockSizeWrite = 1;
+	static constexpr bd_size_t BlockSizeErase = 1;
+
+#endif
+};
+
+}	// namespace xpcc
+
+#endif // XPCC_INTERFACE_BLOCK_DEVICE_HPP

--- a/src/xpcc/driver/storage/block_device_file.hpp
+++ b/src/xpcc/driver/storage/block_device_file.hpp
@@ -1,0 +1,99 @@
+// coding: utf-8
+/* Copyright (c) 2018, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_FILE_HPP
+#define XPCC_BLOCK_DEVICE_FILE_HPP
+
+#include <xpcc/architecture/interface/block_device.hpp>
+
+#include <xpcc/processing/resumable.hpp>
+
+#include <fstream>
+#include <string>
+
+namespace xpcc
+{
+
+/**
+ * \brief	Block device using a file
+ *
+ * Persistant and useful for testing and hosted code
+ *
+ * \ingroup	driver_storage
+ * \author	Raphael Lehmann
+ */
+template <class Filename, size_t DeviceSize>
+class BdFile : public xpcc::BlockDevice, protected xpcc::NestedResumable<3>
+{
+public:
+	/// Initializes the storage hardware
+	xpcc::ResumableResult<bool>
+	initialize();
+
+	/// Deinitializes the storage hardware
+	xpcc::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	read(uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	program(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased prior to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	xpcc::ResumableResult<bool>
+	write(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+public:
+	static constexpr bd_size_t BlockSizeRead = 1;
+	static constexpr bd_size_t BlockSizeWrite = 1;
+	static constexpr bd_size_t BlockSizeErase = 1;
+private:
+	std::fstream file;
+};
+
+}
+#include "block_device_file_impl.hpp"
+
+#endif // XPCC_BLOCK_DEVICE_FILE_HPP

--- a/src/xpcc/driver/storage/block_device_file_impl.hpp
+++ b/src/xpcc/driver/storage/block_device_file_impl.hpp
@@ -1,0 +1,117 @@
+// coding: utf-8
+/* Copyright (c) 2018, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_FILE_HPP
+	#error	"Don't include this file directly, use 'block_device_file.hpp' instead!"
+#endif
+#include "block_device_file.hpp"
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::initialize()
+{
+	RF_BEGIN();
+	file.open(Filename::name, std::fstream::binary | std::fstream::in | std::fstream::out | std::fstream::ate);
+	if(!file.is_open())
+		RF_RETURN(false);
+	if(file.tellg() != DeviceSize) {
+		if(file.tellg() == 0) {
+			// create empty file with size of DeviceSize
+			for(size_t i = 0; i < DeviceSize; i++) {
+				file.put(0);
+			}
+		}
+		else {
+			RF_RETURN(false);
+		}
+	}
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::deinitialize()
+{
+	RF_BEGIN();
+	file.close();
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::read(uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeRead != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	file.seekg(address);
+	file.read(reinterpret_cast<char*>(buffer), size);
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::program(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	file.seekp(address);
+	file.write(reinterpret_cast<char*>(const_cast<uint8_t*>(buffer)), size);
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::erase(bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	// erasing does nothing, memory is undefined after erase and has to be programed first
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <class Filename, size_t DeviceSize>
+xpcc::ResumableResult<bool>
+xpcc::BdFile<Filename, DeviceSize>::write(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->erase(address, size))) {
+		RF_RETURN(false);
+	}
+
+	RF_END_RETURN_CALL(this->program(buffer, address, size));
+}

--- a/src/xpcc/driver/storage/block_device_heap.hpp
+++ b/src/xpcc/driver/storage/block_device_heap.hpp
@@ -1,0 +1,109 @@
+// coding: utf-8
+/* Copyright (c) 2017, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_HEAP_HPP
+#define XPCC_BLOCK_DEVICE_HEAP_HPP
+
+#include <xpcc/architecture/interface/block_device.hpp>
+
+#include <xpcc/processing/resumable.hpp>
+
+namespace xpcc
+{
+
+/**
+ * \brief	Block device using heap (RAM)
+ *
+ * Usually not persistant, but at least useful for testing.
+ * This is also useful for battery backed SRAM, some STM32 have up to 4kB of this stuff.
+ *
+ * \tparam	DeviceSize The size of the block device
+ * \tparam	externalMemory Set to true to use an external supplied memory block (see `initialize(uint8_t*)`)
+ *
+ * \ingroup	driver_storage
+ * \author	Raphael Lehmann
+ */
+template <size_t DeviceSize, bool externalMemory = false>
+class BdHeap : public xpcc::BlockDevice, protected xpcc::NestedResumable<3>
+{
+public:
+	/// Initializes the memory with zeros
+	xpcc::ResumableResult<bool>
+	initialize();
+
+	/// Data will be stored at externalMemoryAddress
+	xpcc::ResumableResult<bool>
+	initialize(uint8_t* externalMemoryAddress);
+
+	/// Deinitializes nothing
+	xpcc::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	read(uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	program(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased prior to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	xpcc::ResumableResult<bool>
+	write(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+public:
+	static constexpr bd_size_t BlockSizeRead = 1;
+	static constexpr bd_size_t BlockSizeWrite = 1;
+	static constexpr bd_size_t BlockSizeErase = 1;
+
+public:
+	void
+	setMemoryAddress(uint8_t* memory);
+
+private:
+	typename xpcc::tmp::Select<externalMemory, uint8_t*, uint8_t[DeviceSize]>::Result data;
+};
+
+}
+#include "block_device_heap_impl.hpp"
+
+#endif // XPCC_BLOCK_DEVICE_HEAP_HPP

--- a/src/xpcc/driver/storage/block_device_heap_impl.hpp
+++ b/src/xpcc/driver/storage/block_device_heap_impl.hpp
@@ -1,0 +1,114 @@
+// coding: utf-8
+/* Copyright (c) 2017, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_HEAP_HPP
+	#error	"Don't include this file directly, use 'block_device_heap.hpp' instead!"
+#endif
+
+#include <xpcc/debug.hpp>
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::initialize()
+{
+	static_assert(externalMemory == false, "Use xpcc::BdHeap::initialize(uint8_t* memory) for externalMemory==true");
+	RF_BEGIN();
+	std::memset(data, 0, DeviceSize);
+	RF_END_RETURN(true);
+}
+
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::initialize(uint8_t* memory)
+{
+	static_assert(externalMemory == true, "xpcc::BdHeap::initialize(uint8_t* memory) is only allowed for externalMemory==true");
+	RF_BEGIN();
+	data = memory;
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::deinitialize()
+{
+	RF_BEGIN();
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::read(uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeRead != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	std::memcpy(buffer, &data[address], size);
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::program(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	std::memcpy(&data[address], buffer, size);
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::erase(bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	// erasing does nothing, memory is undefined after erase and has to be programed first
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <size_t DeviceSize, bool externalMemory>
+xpcc::ResumableResult<bool>
+xpcc::BdHeap<DeviceSize, externalMemory>::write(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->erase(address, size))) {
+		RF_RETURN(false);
+	}
+
+	RF_END_RETURN_CALL(this->program(buffer, address, size));
+}

--- a/src/xpcc/driver/storage/block_device_mirror.hpp
+++ b/src/xpcc/driver/storage/block_device_mirror.hpp
@@ -1,0 +1,121 @@
+// coding: utf-8
+/* Copyright (c) 2018, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_MIRROR_HPP
+#define XPCC_BLOCK_DEVICE_MIRROR_HPP
+
+#include <xpcc/architecture/interface/block_device.hpp>
+
+#include <xpcc/processing/resumable.hpp>
+
+namespace xpcc
+{
+
+/**
+ * \brief	Virtual block device consists of two mirrored block devices.
+ *
+ * Write operations (`erase()`, `program()` and `write()`) are forwarded
+ * to both block devices.
+ * Read operations (`read()`) are only performed on BlockDeviceA.
+ *
+ * \tparam BlockDeviceA		First block device of the mirrored block devices
+ * \tparam BlockDeviceB		Second block device
+ *
+ * \ingroup	driver_storage
+ * \author	Raphael Lehmann
+ */
+template <typename BlockDeviceA, typename BlockDeviceB>
+class BdMirror : public xpcc::BlockDevice, protected NestedResumable<3>
+{
+public:
+	/// Initializes the storage hardware
+	xpcc::ResumableResult<bool>
+	initialize();
+
+	/// Deinitializes the storage hardware
+	xpcc::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	read(uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	program(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased prior to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	xpcc::ResumableResult<bool>
+	write(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+public:
+	static constexpr bd_size_t BlockSizeRead = BlockDeviceA::BlockSizeRead;
+	static constexpr bd_size_t BlockSizeWrite = std::max(BlockDeviceA::BlockSizeWrite, BlockDeviceB::BlockSizeWrite);
+	static constexpr bd_size_t BlockSizeErase = std::max(BlockDeviceA::BlockSizeErase, BlockDeviceB::BlockSizeErase);
+
+public:
+	/** Direct access to the BlockDeviceA
+	*
+	*  @return	BlockDeviceA
+	*/
+	inline BlockDeviceA& getBlockDeviceA() {return blockDeviceA;};
+
+	/** Direct access to the BlockDeviceB
+	*
+	*  @return	BlockDeviceB
+	*/
+	inline BlockDeviceB& getBlockDeviceB() {return blockDeviceB;};
+
+private:
+	BlockDeviceA blockDeviceA;
+	BlockDeviceB blockDeviceB;
+
+private:
+	bool resultA;
+	bool resultB;
+
+};
+
+}
+#include "block_device_mirror_impl.hpp"
+
+#endif // XPCC_BLOCK_DEVICE_MIRROR_HPP

--- a/src/xpcc/driver/storage/block_device_mirror_impl.hpp
+++ b/src/xpcc/driver/storage/block_device_mirror_impl.hpp
@@ -1,0 +1,101 @@
+// coding: utf-8
+/* Copyright (c) 2018, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_MIRROR_HPP
+	#error	"Don't include this file directly, use 'block_device_mirror.hpp' instead!"
+#endif
+#include "block_device_mirror.hpp"
+
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::initialize()
+{
+	RF_BEGIN();
+
+	resultA = RF_CALL(blockDeviceA.initialize());
+	resultB = RF_CALL(blockDeviceB.initialize());
+
+	RF_END_RETURN(resultA && resultA);
+}
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::deinitialize()
+{
+	RF_BEGIN();
+
+	resultA = RF_CALL(blockDeviceA.deinitialize());
+	resultB = RF_CALL(blockDeviceB.deinitialize());
+
+	RF_END_RETURN(resultA && resultA);
+}
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::read(uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	return blockDeviceA.read(buffer, address, size);
+}
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::program(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeWrite != 0)) {
+		RF_RETURN(false);
+	}
+
+	resultA = RF_CALL(blockDeviceA.program(buffer, address, size));
+	resultB = RF_CALL(blockDeviceB.program(buffer, address, size));
+
+	RF_END_RETURN(resultA && resultA);
+}
+
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::erase(bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0)) {
+		RF_RETURN(false);
+	}
+
+	resultA = RF_CALL(blockDeviceA.erase(address, size));
+	resultB = RF_CALL(blockDeviceB.erase(address, size));
+
+	RF_END_RETURN(resultA && resultA);
+}
+
+
+// ----------------------------------------------------------------------------
+template <typename BlockDeviceA, typename BlockDeviceB>
+xpcc::ResumableResult<bool>
+xpcc::BdMirror<BlockDeviceA, BlockDeviceB>::write(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (size % BlockSizeWrite != 0)) {
+		RF_RETURN(false);
+	}
+
+	resultA = RF_CALL(blockDeviceA.write(buffer, address, size));
+	resultB = RF_CALL(blockDeviceB.write(buffer, address, size));
+
+	RF_END_RETURN(resultA && resultA);
+}

--- a/src/xpcc/driver/storage/block_device_spiflash.hpp
+++ b/src/xpcc/driver/storage/block_device_spiflash.hpp
@@ -1,0 +1,230 @@
+// coding: utf-8
+/* Copyright (c) 2017, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_SPIFLASH_HPP
+#define XPCC_BLOCK_DEVICE_SPIFLASH_HPP
+
+#include <xpcc/architecture/interface/block_device.hpp>
+
+#include <xpcc/architecture/interface/register.hpp>
+#include <xpcc/architecture/interface/spi_device.hpp>
+#include <xpcc/processing/resumable.hpp>
+
+namespace xpcc
+{
+
+
+/**
+ * \brief	Block device with SPI Flash (Microchip SST26VF064B)
+ *
+ * 64MBit flash chip in SOIJ-8, WDFN-8 or SOIC-16
+ *
+ * \tparam Spi			The SpiMaster interface
+ * \tparam Cs			The GpioOutput pin connected to the flash chip select
+ * \tparam flashSize	Flash chip size in byte
+ *
+ * The `read()`, `erase()`,`program()` and `write()` methodes wait for
+ * the chip to finish writing to the flash.
+ *
+ * \ingroup	driver_storage
+ * \author	Raphael Lehmann
+ */
+template <typename Spi, typename Cs, uint32_t flashSize>
+class BdSpiFlash : public xpcc::BlockDevice, public xpcc::SpiDevice< Spi >, protected NestedResumable<5>
+{
+public:
+	/// Initializes the storage hardware
+	xpcc::ResumableResult<bool>
+	initialize();
+
+	/// Deinitializes the storage hardware
+	xpcc::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	read(uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	program(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	xpcc::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased prior to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	xpcc::ResumableResult<bool>
+	write(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+public:
+	struct
+	JedecId
+	{
+		uint8_t manufacturerId;
+		uint8_t deviceType;
+		uint8_t deviceId;
+
+		JedecId() {
+			manufacturerId = 0;
+			deviceType = 0;
+			deviceId = 0;
+		}
+
+		JedecId(uint8_t mi, uint8_t dt, uint8_t di) {
+			manufacturerId = mi;
+			deviceType = dt;
+			deviceId = di;
+		}
+	};
+
+	/** Reads the Jedec ID from the flash chip
+	*
+	*  @return The Jedec Id returned from the flash chip
+	*/
+	xpcc::ResumableResult<JedecId>
+	readId();
+
+public:
+	enum class
+	StatusRegister : uint8_t
+	{
+		Busy					= Bit0,
+		WriteEnabled			= Bit1,
+		EraseSuspended			= Bit2,
+		ProgramSuspended		= Bit3,
+		WriteProtectionLockDown	= Bit4,
+		SecurityIdLocked		= Bit5,
+		//Reserved				= Bit6,
+		//Busy					= Bit7, // see Bit0
+	};
+	XPCC_FLAGS8(StatusRegister);
+
+	/** Read status register of thew Spi Flash chip
+	*
+	*  @return	Status register
+	*/
+	xpcc::ResumableResult<StatusRegister>
+	readStatus();
+
+public:
+	static constexpr bd_size_t BlockSizeRead = 1;
+	static constexpr bd_size_t BlockSizeWrite = 256;
+	static constexpr bd_size_t BlockSizeErase = 4 * 1024;
+
+private:
+	uint8_t instructionBuffer[7];
+	uint8_t i;
+
+	uint8_t resultBuffer[3];
+	uint32_t result;
+
+	size_t index;
+
+	// See http://ww1.microchip.com/downloads/en/DeviceDoc/20005119G.pdf p.13
+	enum class
+	Instruction : uint8_t
+	{
+		//Configuration
+		Nop		= 0x00, /// No Operation
+		RstEn	= 0x66, /// Reset Enable
+		Rst		= 0x99, /// Reset Memory
+		//EQio	= 0x38, /// Enable Quad IO
+		//RstQio	= 0xff, /// reste Quad IO
+		RdSr	= 0x05, /// Read Status Register
+		WrSr	= 0x01, /// Write Status Register
+		RdCr	= 0x35, /// Read Configuration Register
+		// Read
+		Read	= 0x03, /// Read
+		ReadHS	= 0x0B, /// Read High Speed
+		SQOR	= 0x6B, /// SPI Quad Output Read
+		SQIOR	= 0xEB, /// SPI Quad I/O Read
+		SDOR	= 0x3B, /// SPI Dual Output Read
+		SDIOR	= 0xBB, /// SPI Dual I/O Read
+		SB		= 0xC0, /// Set Burst Length
+		RBSQI	= 0x0C, /// SQI Read Burst with Wrap
+		RBSPI	= 0xEC, /// SPI Read Burst with Wrap
+		// Identification
+		JedecId	= 0x9f, /// JEDEC-ID Read
+		QuadJId	= 0xAF, /// Quad I/O J-ID Read
+		SFDP	= 0x5A, /// Serial Flash Discoverable Parameters
+		// Write
+		WrEn	= 0x06, /// Write Enable
+		WrDi	= 0x04, /// Write Disable
+		SE		= 0x20, /// Erase 4 KBytes of Memory Array
+		BE		= 0xD8, /// Erase 64, 32 or 8 KBytes of Memory Array
+		CE		= 0xC7, /// Erase Full Array
+		PP		= 0x02, /// Page Program
+		SQPP	= 0x32, /// SQI Quad Page Program
+		WRSU	= 0xB0, /// Suspends Program/Erase
+		WRRE	= 0x30, /// Resumes Program/Erase
+		// Protection
+		RBpR	= 0x72, /// Read Block-Protection Register
+		WBpR	= 0x42, /// Write Block-Protection Register
+		LBpR	= 0x8D, /// Lock Down Block-Protection Register
+		nVWLDR	= 0xE8, /// non-Volatile Write Lock-Down Register
+		ULBPR	= 0x98, /// Global Block Protection Unlock
+		RSID	= 0x88, /// Read Security ID
+		PSID	= 0xA5, /// Program User Security ID area
+		LSID	= 0x85, /// Lockout Security ID Programming
+	};
+
+private:
+	/** Check if device is busy
+	 *
+	 * @return True if device is busy.
+	 */
+	xpcc::ResumableResult<bool>
+	isBusy();
+
+	/** This function can be used in another resumable function
+	 * to wait until the flash operation is finished.
+	 */
+	xpcc::ResumableResult<void>
+	waitWhileBusy();
+
+	/** Send an operation instruction to the spi flash chip
+	 */
+	xpcc::ResumableResult<void>
+	spiOperation(Instruction instruction, size_t dataLength = 0, uint8_t* rxData = nullptr, const uint8_t* txData = nullptr, uint32_t address = UINT32_MAX, uint8_t nrDummyCycles = 0);
+};
+
+}
+#include "block_device_spiflash_impl.hpp"
+
+#endif // XPCC_BLOCK_DEVICE_SPIFLASH_HPP

--- a/src/xpcc/driver/storage/block_device_spiflash_impl.hpp
+++ b/src/xpcc/driver/storage/block_device_spiflash_impl.hpp
@@ -1,0 +1,213 @@
+// coding: utf-8
+/* Copyright (c) 2017, Raphael Lehmann
+ * All Rights Reserved.
+ *
+ * The file is part of the xpcc library and is released under the 3-clause BSD
+ * license. See the file `LICENSE` for the full license governing this code.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef XPCC_BLOCK_DEVICE_SPIFLASH_HPP
+#error	"Don't include this file directly, use 'block_device_spiflash.hpp' instead!"
+#endif
+#include "block_device_spiflash.hpp"
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::initialize()
+{
+	RF_BEGIN();
+	this->attachConfigurationHandler([]() {
+		Spi::setDataMode(Spi::DataMode::Mode0);
+		Spi::setDataOrder(Spi::DataOrder::MsbFirst);
+	});
+	Cs::setOutput(xpcc::Gpio::High);
+
+	RF_CALL(spiOperation(Instruction::RstEn));
+	// Wait T_CPH = 25ns
+	RF_CALL(spiOperation(Instruction::Rst));
+	RF_CALL(waitWhileBusy());
+
+	RF_CALL(spiOperation(Instruction::WrEn));
+	RF_CALL(spiOperation(Instruction::ULBPR));
+	RF_CALL(waitWhileBusy());
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::deinitialize()
+{
+	RF_BEGIN();
+	// nothing
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<typename xpcc::BdSpiFlash<Spi, Cs, flashSize>::JedecId>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::readId()
+{
+	RF_BEGIN();
+
+	RF_CALL(spiOperation(Instruction::JedecId, 3, resultBuffer));
+
+	RF_END_RETURN(JedecId(resultBuffer[0], resultBuffer[1], resultBuffer[2]));
+}
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::read(uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeRead != 0) || (address + size > flashSize)) {
+		RF_RETURN(false);
+	}
+
+	RF_CALL(spiOperation(Instruction::ReadHS, size, buffer, nullptr, address, 1));
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::program(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeWrite != 0) || (address + size > flashSize)) {
+		RF_RETURN(false);
+	}
+
+	index = 0;
+	while(index < size) {
+		RF_CALL(spiOperation(Instruction::WrEn));
+		RF_CALL(spiOperation(Instruction::PP, BlockSizeWrite, nullptr, &buffer[index], address+index));
+		RF_CALL(waitWhileBusy());
+		index += BlockSizeWrite;
+	}
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::erase(bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (address + size > flashSize)) {
+		RF_RETURN(false);
+	}
+
+	index = 0;
+	while(index < size) {
+		RF_CALL(spiOperation(Instruction::WrEn));
+		RF_CALL(spiOperation(Instruction::SE, 0, nullptr, nullptr, address+index));
+		RF_CALL(waitWhileBusy());
+		index += BlockSizeErase;
+	}
+
+	RF_END_RETURN(true);
+}
+
+
+// ----------------------------------------------------------------------------
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::write(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (size % BlockSizeWrite != 0) || (address + size > flashSize)) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->erase(address, size))) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->program(buffer, address, size))) {
+		RF_RETURN(false);
+	}
+
+	RF_END_RETURN(true);
+}
+
+// ============================================================================
+
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<typename xpcc::BdSpiFlash<Spi, Cs, flashSize>::StatusRegister>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::readStatus()
+{
+	RF_BEGIN();
+	RF_CALL(spiOperation(Instruction::RdSr, 1, resultBuffer));
+	RF_END_RETURN(static_cast<StatusRegister>(resultBuffer[0]));
+}
+
+
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<bool>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::isBusy()
+{
+	RF_BEGIN();
+	if(RF_CALL(readStatus()) & StatusRegister::Busy)
+		RF_RETURN(true);
+	else
+		RF_RETURN(false);
+	RF_END();
+}
+
+
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<void>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::waitWhileBusy()
+{
+	RF_BEGIN();
+	while(RF_CALL(isBusy())) {
+		RF_YIELD();
+	}
+	RF_END();
+}
+
+
+template <typename Spi, typename Cs, uint32_t flashSize>
+xpcc::ResumableResult<void>
+xpcc::BdSpiFlash<Spi, Cs, flashSize>::spiOperation(Instruction instruction, size_t dataLength, uint8_t* rxData, const uint8_t* txData, uint32_t address, uint8_t nrDummyCycles)
+{
+	RF_BEGIN();
+
+	i = 0;
+	instructionBuffer[i++] = static_cast<uint8_t>(instruction);
+	if(address != UINT32_MAX) {
+		instructionBuffer[i++] = (address >> 16) & 0xFF;
+		instructionBuffer[i++] = (address >> 8) & 0xFF;
+		instructionBuffer[i++] = address & 0xFF;
+	}
+	for(uint8_t j = 0; j < nrDummyCycles; j++) {
+		instructionBuffer[i++] = 0x00;
+	}
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+	Cs::reset();
+
+	RF_CALL(Spi::transfer(instructionBuffer, nullptr, i));
+
+	if(dataLength > 0) {
+		RF_CALL(Spi::transfer(const_cast<uint8_t*>(txData), rxData, dataLength));
+	}
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	RF_END_RETURN(true);
+}


### PR DESCRIPTION
This PR adds a block device interface to xpcc, inspired by mbeds [block device](https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/storage/block_device/) interface.

Drivers to store data in a SPI SST flash `xpcc::BdSpiFlash`, to store data in a file (on hosted) `xpcc::BdFile` and to store data in RAM (for testing purposes) `xpcc::BdHeap` are included.
Additionally `xpcc::BdMirror` is a virtual block device that behaves like [RAID1](https://en.wikipedia.org/wiki/Standard_RAID_levels#RAID_1) devices.

For every driver a test is included.

The flash chip driver has been tested on a [Nucleo-F429ZI board](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/).