### PR TITLE
Should not assume PORTA is always going to be used

### DIFF
--- a/src/xpcc/architecture/platform/driver/adc/stm32f0/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f0/adc_impl.hpp.in
@@ -105,10 +105,6 @@ xpcc::stm32::Adc::setChannel(const Channel channel,
         ADC1_COMMON->CCR |= ADC_CCR_VREFEN;
     } else if (channel == Channel::Temperature) {
         ADC1_COMMON->CCR |= ADC_CCR_TSEN;
-    } else {
-        const uint32_t tbc = 0x3 << (2 * static_cast<uint32_t>(channel));
-        GPIOA->MODER |= tbc;
-        GPIOA->PUPDR &= ~tbc;
     }
 }
 


### PR DESCRIPTION
I wrote code there to enable PORTA because it's the one I'm using. I forgot to take it out of the class.