### PR TITLE
Replace remaining "execfile" usage.

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -169,7 +169,7 @@ Create an minimal example in `xpcc/examples/sam4/minimal`, containing:
 # path to the xpcc root directory
 xpccpath = '../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))
 ```
 
 - a minimal `main.cpp` file:

--- a/examples/generic/resumable/SConstruct
+++ b/examples/generic/resumable/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/generic/ros/environment/SConstruct
+++ b/examples/generic/ros/environment/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/generic/ros/sub_pub/SConstruct
+++ b/examples/generic/ros/sub_pub/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/linux/static_serial_interface/SConstruct
+++ b/examples/linux/static_serial_interface/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/lpcxpresso/lpc11c24/can/SConstruct
+++ b/examples/lpcxpresso/lpc11c24/can/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/nucleo_l476rg/i2c_test/SConstruct
+++ b/examples/nucleo_l476rg/i2c_test/SConstruct
@@ -1,4 +1,4 @@
 # path to the xpcc root directory
 xpccpath = '../../..'
 # execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/scons/SConstruct
+++ b/scons/SConstruct
@@ -5,7 +5,7 @@ WARNING: THIS IS A GENERIC SCONSTRUCT FILE FOR ALL XPCC PROJECTS!
 # path to the xpcc root directory (modify as required!)
 xpccpath = '../xpcc'
 # execute the xpcc basic
-execfile(xpccpath + '/scons/SConstruct')
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))
 """
 
 # This variable MUST be defined externally


### PR DESCRIPTION
For Python 3 compatibility.