### PR TITLE
[driver] Block device: Add missing include

### DIFF
--- a/examples/avr/block_device_mirror/SConstruct
+++ b/examples/avr/block_device_mirror/SConstruct
@@ -1,0 +1,5 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/avr/block_device_mirror/main.cpp
+++ b/examples/avr/block_device_mirror/main.cpp
@@ -1,0 +1,96 @@
+#include <xpcc/architecture.hpp>
+
+#include <xpcc/driver/storage/block_device_heap.hpp>
+#include <xpcc/driver/storage/block_device_mirror.hpp>
+
+#include <xpcc/debug/logger.hpp>
+
+using namespace xpcc::atmega;
+typedef xpcc::avr::SystemClock clock;
+
+// Create a new UART object and configure it to a baudrate of 115200
+Uart0 uart;
+xpcc::IODeviceWrapper< Uart0, xpcc::IOBuffer::BlockIfFull > loggerDevice(uart);
+
+// Set all four logger streams to use the UART
+xpcc::log::Logger xpcc::log::debug(loggerDevice);
+xpcc::log::Logger xpcc::log::info(loggerDevice);
+xpcc::log::Logger xpcc::log::warning(loggerDevice);
+xpcc::log::Logger xpcc::log::error(loggerDevice);
+
+// Set the log level
+#undef	XPCC_LOG_LEVEL
+#define	XPCC_LOG_LEVEL xpcc::log::INFO
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		XPCC_LOG_INFO.printf("%x", address[i]);
+	}
+}
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns into
+	 * two `xpcc::BdFile` block device with a size of 1M
+	 * to test the virtual `xpcc::BdMirror` block device.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 */
+
+	constexpr uint32_t BlockSize = 8;
+	constexpr uint32_t MemorySize = 64;
+
+	uint8_t bufferA[BlockSize];
+	uint8_t bufferB[BlockSize];
+	uint8_t bufferC[BlockSize];
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	xpcc::BdMirror<xpcc::BdHeap<MemorySize>, xpcc::BdHeap<MemorySize>> storageDevice;
+
+	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+		XPCC_LOG_INFO << "Error: Unable to initialize device.";
+		exit(1);
+	}
+
+	XPCC_LOG_INFO << "Starting memory test!" << xpcc::endl;
+
+	for(uint16_t iteration = 0; iteration < 10; iteration++) {
+		uint8_t* pattern = (iteration % 2 == 0) ? bufferA : bufferB;
+
+		if(!RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
+			XPCC_LOG_INFO << "Error: Unable to erase device.";
+			exit(1);
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.program(pattern, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to write data.";
+				exit(1);
+			}
+		}
+
+		for(uint32_t i = 0; i < MemorySize; i += BlockSize) {
+			if(!RF_CALL_BLOCKING(storageDevice.read(bufferC, i, BlockSize))) {
+				XPCC_LOG_INFO << "Error: Unable to read data.";
+				exit(1);
+			}
+			else if(std::memcmp(pattern, bufferC, BlockSize)) {
+				XPCC_LOG_INFO << "Error: Read '";
+				printMemoryContent(bufferC, BlockSize);
+				XPCC_LOG_INFO << "', expected: '";
+				printMemoryContent(pattern, BlockSize);
+				XPCC_LOG_INFO << "'." << xpcc::endl;
+				break;
+			}
+		}
+		XPCC_LOG_INFO << ".";
+	}
+
+	XPCC_LOG_INFO << xpcc::endl << "Finished!" << xpcc::endl;
+
+	return 0;
+}

--- a/examples/avr/block_device_mirror/project.cfg
+++ b/examples/avr/block_device_mirror/project.cfg
@@ -1,0 +1,4 @@
+[build]
+device = atmega644
+clock = 14745600
+buildpath = ${xpccpath}/build/avr/${name}

--- a/src/stdc++/internal/algorithm_base.hpp
+++ b/src/stdc++/internal/algorithm_base.hpp
@@ -45,7 +45,7 @@ namespace std
 	 * preprocessor macro.
 	 */
 	template<typename T>
-	inline const T&
+	constexpr inline const T&
 	min(const T& a, const T& b)
 	{
 		if (b < a)
@@ -66,7 +66,7 @@ namespace std
 	 * preprocessor macro.
 	 */
 	template<typename T>
-	inline const T&
+	constexpr inline const T&
 	max(const T& a, const T& b)
 	{
 		if (a < b)
@@ -87,7 +87,7 @@ namespace std
 	 * once, unlike a preprocessor macro.
 	 */
 	template<typename T, typename Compare>
-	inline const T&
+	constexpr inline const T&
 	min(const T& a, const T& b, Compare compare)
 	{
 		if (compare(b, a))
@@ -108,7 +108,7 @@ namespace std
 	 * once, unlike a preprocessor macro.
 	 */
 	template<typename T, typename Compare>
-	inline const T&
+	constexpr inline const T&
 	max(const T& a, const T& b, Compare compare)
 	{
 		if (compare(a, b))

--- a/src/xpcc/architecture/interface/block_device.hpp
+++ b/src/xpcc/architecture/interface/block_device.hpp
@@ -104,6 +104,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 1;
 	static constexpr bd_size_t BlockSizeErase = 1;
+	static constexpr bd_size_t BlockDevice = 1024;
 
 #endif
 };

--- a/src/xpcc/driver/storage/block_device_file.hpp
+++ b/src/xpcc/driver/storage/block_device_file.hpp
@@ -28,7 +28,7 @@ namespace xpcc
  * \ingroup	driver_storage
  * \author	Raphael Lehmann
  */
-template <class Filename, size_t DeviceSize>
+template <class Filename, size_t DeviceSize_>
 class BdFile : public xpcc::BlockDevice, protected xpcc::NestedResumable<3>
 {
 public:
@@ -89,6 +89,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 1;
 	static constexpr bd_size_t BlockSizeErase = 1;
+	static constexpr bd_size_t DeviceSize = DeviceSize_;
 private:
 	std::fstream file;
 };

--- a/src/xpcc/driver/storage/block_device_heap.hpp
+++ b/src/xpcc/driver/storage/block_device_heap.hpp
@@ -29,7 +29,7 @@ namespace xpcc
  * \ingroup	driver_storage
  * \author	Raphael Lehmann
  */
-template <size_t DeviceSize, bool externalMemory = false>
+template <size_t DeviceSize_, bool externalMemory = false>
 class BdHeap : public xpcc::BlockDevice, protected xpcc::NestedResumable<3>
 {
 public:
@@ -94,6 +94,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 1;
 	static constexpr bd_size_t BlockSizeErase = 1;
+	static constexpr bd_size_t DeviceSize = DeviceSize_;
 
 public:
 	void

--- a/src/xpcc/driver/storage/block_device_mirror.hpp
+++ b/src/xpcc/driver/storage/block_device_mirror.hpp
@@ -91,6 +91,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = BlockDeviceA::BlockSizeRead;
 	static constexpr bd_size_t BlockSizeWrite = std::max(BlockDeviceA::BlockSizeWrite, BlockDeviceB::BlockSizeWrite);
 	static constexpr bd_size_t BlockSizeErase = std::max(BlockDeviceA::BlockSizeErase, BlockDeviceB::BlockSizeErase);
+	static constexpr bd_size_t DeviceSize = std::min(BlockDeviceA::DeviceSize, BlockDeviceB::DeviceSize);
 
 public:
 	/** Direct access to the BlockDeviceA

--- a/src/xpcc/driver/storage/block_device_mirror.hpp
+++ b/src/xpcc/driver/storage/block_device_mirror.hpp
@@ -11,8 +11,8 @@
 #define XPCC_BLOCK_DEVICE_MIRROR_HPP
 
 #include <xpcc/architecture/interface/block_device.hpp>
-
 #include <xpcc/processing/resumable.hpp>
+#include <algorithm>
 
 namespace xpcc
 {

--- a/src/xpcc/driver/storage/block_device_spiflash.hpp
+++ b/src/xpcc/driver/storage/block_device_spiflash.hpp
@@ -146,6 +146,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 256;
 	static constexpr bd_size_t BlockSizeErase = 4 * 1024;
+	static constexpr bd_size_t DeviceSize = flashSize;
 
 private:
 	uint8_t instructionBuffer[7];


### PR DESCRIPTION
In `driver/block_device_mirror.hpp` `std::max()` is used, but `#include <algorithm>` was missing.

Additionally `std::min()` and `std::max()` in the mock-up stdc++ implementation are now *constexpr* and a example for AVR was added (but not tested in hardware).

Furthermore `BlockDevice::DeviceSize` was added.