### PR TITLE
Fix timing in HD44780 driver.

### DIFF
--- a/src/xpcc/driver/display/hd44780_base_impl.hpp
+++ b/src/xpcc/driver/display/hd44780_base_impl.hpp
@@ -188,12 +188,14 @@ xpcc::Hd44780Base<DATA, RW, RS, E>::Bus<Data, Enable, 4>::write(uint8_t data)
 	E::set();
 	xpcc::delayMicroseconds(1);
 	E::reset();
+	xpcc::delayNanoseconds(10);
 
 	DATA::write(data);
 
 	E::set();
 	xpcc::delayMicroseconds(1);
 	E::reset();
+	xpcc::delayNanoseconds(10);
 }
 
 template <typename DATA, typename RW, typename RS, typename E>
@@ -216,6 +218,7 @@ xpcc::Hd44780Base<DATA, RW, RS, E>::Bus<Data, Enable, 4>::read()
 	xpcc::delayMicroseconds(1);
 	data = DATA::read();
 	E::reset();
+	xpcc::delayNanoseconds(10);
 
 	data <<= 4;
 
@@ -223,6 +226,7 @@ xpcc::Hd44780Base<DATA, RW, RS, E>::Bus<Data, Enable, 4>::read()
 	xpcc::delayMicroseconds(1);
 	data |= DATA::read();
 	E::reset();
+	xpcc::delayNanoseconds(10);
 
 	return data;
 }
@@ -239,6 +243,7 @@ xpcc::Hd44780Base<DATA, RW, RS, E>::Bus<Data, Enable, 8>::write(uint8_t data)
 	E::set();
 	xpcc::delayMicroseconds(1);
 	E::reset();
+	xpcc::delayNanoseconds(500);
 }
 
 template <typename DATA, typename RW, typename RS, typename E>
@@ -261,6 +266,7 @@ xpcc::Hd44780Base<DATA, RW, RS, E>::Bus<Data, Enable, 8>::read()
 	xpcc::delayMicroseconds(1);
 	data = DATA::read();
 	E::reset();
+	xpcc::delayNanoseconds(500);
 
 	return data;
 }


### PR DESCRIPTION
Hi!

I have a (supposedly) HD44780 compatible 4x160 LCD display. I don't know anything more exact than this about it, the only thing printed on it is "1604A" which seems to be the code for these kind of 4x16 displays. It looks something like in this datasheet: https://www.farnell.com/datasheets/50577.pdf

When I tried to use it with xpcc's HD44780 driver, it was working fine in 8-bit mode if I compiled the project with no optimization, probably because everything is slower, but it was glitching when ran with optimizations enabled, it was probably missing commands.

I tried some ways to make it work based on the above datasheet, and what can be seen here is what I arrived at after some trial and error. This way the display seem to work perfectly in both 4-bit and 8-bit modes. I'll try to explain how I arrived at these values, but the process wasn't too scientific :)

First, the 10ns delays in the 4-bit mode come from the Th and Tah (hold time) values in the timing diagram (both 10ns). For the 8-bit mode, I looked at Tc (cycle time), which is 1.2us, but waiting 200ns didn't work, so I kind of arbitrarily tried 500ns, and it did work, so I just settled on that. If you are now asking "But what about the 1.2us cycle time in 4-bit mode?", I don't know the answer to that, but it works as it is.