### PR TITLE
Fixes for AMSYS5915 driver

### DIFF
--- a/src/xpcc/driver/pressure/amsys5915.hpp
+++ b/src/xpcc/driver/pressure/amsys5915.hpp
@@ -84,7 +84,7 @@ struct amsys5915
  *
  * The device runs a cyclic program, which will store a corrected pressure value with
  * 12 bit resolution about every 500 μs within the output registers of the internal ASIC.
- * 
+ *
  * Datasheet: http://www.amsys.de/sheets/amsys.de.ams5915.pdf
  *
  * @ingroup driver_pressure
@@ -96,12 +96,9 @@ class Amsys5915 : public amsys5915, public xpcc::I2cDevice<I2cMaster, 1, I2cRead
 public:
 	/**
 	 * @param	data	a amsys5915::Data object
-	 * @bug The address of the sensor is by factory default set to 0x28.
-	 *      This means you cannot use two AMSYS 5915 sensors on the same bus!
-	 *      You have to use a MUX or two seperate I2C busses.
 	 */
-	Amsys5915(Data &data)
-	:	I2cDevice<I2cMaster,1,I2cReadTransaction>(0x28), data(data)
+	Amsys5915(Data &data, uint8_t i2cAddress = 0x28)
+	:	I2cDevice<I2cMaster,1,I2cReadTransaction>(i2cAddress), data(data)
 	{
 		this->transaction.configureRead(data.data, 4);
 	}

--- a/src/xpcc/driver/pressure/amsys5915.hpp
+++ b/src/xpcc/driver/pressure/amsys5915.hpp
@@ -30,6 +30,18 @@ struct amsys5915
 		friend class Amsys5915;
 
 	public:
+		uint16_t
+		getPressureRaw()
+		{
+			// mask undefined bits
+			data[0] &= 0b00111111;
+
+			auto rData = reinterpret_cast<const uint16_t*>(data);
+			const uint16_t pressureRaw{xpcc::fromBigEndian(*rData)};
+
+			return pressureRaw;
+		}
+
 		/**
 		 * This method returns the pressure as a normalized float from 0-1.
 		 * You have to scale and offset this according to the specific sensor
@@ -42,16 +54,12 @@ struct amsys5915
 		float
 		getPressure()
 		{
-			// mask undefined bits
-			data[0] &= 0b00111111;
+			const uint16_t pressureRaw{getPressureRaw()};
 
 			// Full scale span is typically 13107, with offset 1638
 			// Caution: sensors may output values slightly exceeding the expected range!
 			const uint16_t offset{1638};
 			const uint16_t span{13107};
-
-			auto rData = reinterpret_cast<const uint16_t*>(data);
-			const uint16_t pressureRaw{xpcc::fromBigEndian(*rData)};
 
 			if(pressureRaw <= offset) {
 				return 0.f;


### PR DESCRIPTION
Fixes:
- Prevent int underflow
- Make I2C address adjustable (You can actually get a sensor address reprogramming kit from AMSYS)
- Expose raw measurement value. The specified value range assumed in getPressure() is just specified as a "typical value" in the datasheet and will deviate for different sensors.