### PR TITLE
STM32F030F4P6 Demo Board

### DIFF
--- a/examples/stm32f030f4p6_demo_board/blink/SConstruct
+++ b/examples/stm32f030f4p6_demo_board/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/stm32f030f4p6_demo_board/blink/main.cpp
+++ b/examples/stm32f030f4p6_demo_board/blink/main.cpp
@@ -1,0 +1,27 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+/*
+ * Blinks the orange user LED with 1 Hz.
+ * It is on for 90% of the time and off for 10% of the time.
+ */
+
+int
+main()
+{
+	Board::initialize();
+
+	LedOrange::set();
+
+	while (true)
+	{
+		LedOrange::set();
+		xpcc::delayMilliseconds(900);
+
+		LedOrange::reset();
+		xpcc::delayMilliseconds(100);
+	}
+
+	return 0;
+}

--- a/examples/stm32f030f4p6_demo_board/blink/project.cfg
+++ b/examples/stm32f030f4p6_demo_board/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f030f4p6_demo_board
+buildpath = ${xpccpath}/build/stm32f030f4p6_demo_board/${name}

--- a/src/xpcc/architecture/platform/board/stm32f030f4p6_demo_board/board.cfg
+++ b/src/xpcc/architecture/platform/board/stm32f030f4p6_demo_board/board.cfg
@@ -1,0 +1,10 @@
+[build]
+device = stm32f030f4p6
+
+[parameters]
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = A
+core.cortex.0.hardfault_handler_led_pin = 4
+
+[openocd]
+configfile = xpcc/stm32f030_demo_board.cfg

--- a/src/xpcc/architecture/platform/board/stm32f030f4p6_demo_board/stm32f030f4p6_demo_board.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f030f4p6_demo_board/stm32f030f4p6_demo_board.hpp
@@ -1,0 +1,103 @@
+// coding: utf-8
+/* Copyright (c) 2018, Raphael Lehmann
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+*/
+// ----------------------------------------------------------------------------
+
+//
+// STM32F030F4P6 "Demo Board" Minimum System Development Board
+//
+// Cheap and bread-board-friendly board for STM32 F0 series.
+// Sold for less than 1.5 USD on well known Internet shops from China.
+//
+// http://www.hotmcu.com/stm32f030f4p6-minimum-systerm-boardcortexm0-p-208.html
+// http://www.haoyuelectronics.com/Attachment/STM32F030-Dev-Board/STM32F030F4P6.pdf
+//
+
+#ifndef XPCC_STM32_F030F4P6_DEMO_BOARD_HPP
+#define XPCC_STM32_F030F4P6_DEMO_BOARD_HPP
+
+#include <xpcc/architecture/platform.hpp>
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F030 running at 48MHz generated from the external 8MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = MHz48;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Hsi = MHz8;
+	static constexpr uint32_t Hsi14 = 14 * MHz1;
+
+	static constexpr uint32_t Adc1 = Hsi14;
+
+	static constexpr uint32_t Spi1 = Apb;
+
+	static constexpr uint32_t Usart1 = Apb;
+
+	static constexpr uint32_t I2c1   = Hsi;
+
+	static constexpr uint32_t Timer1 = Apb;
+	static constexpr uint32_t Timer3 = Apb;
+	static constexpr uint32_t Timer14 = Apb;
+	static constexpr uint32_t Timer16 = Apb;
+	static constexpr uint32_t Timer17 = Apb;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalCrystal();
+
+		// external clock / 1 * 6 = 48MHz
+		ClockControl::enablePll(ClockControl::PllSource::ExternalCrystal, 6, 1);
+
+		// set flash latency for 48MHz
+		ClockControl::setFlashLatency(Frequency);
+
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+
+		// AHB has max 48MHz
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+
+		// APB1 has max. 48MHz
+		ClockControl::setApbPrescaler(ClockControl::ApbPrescaler::Div1);
+
+
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000.f / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// User LED
+using LedOrange = GpioOutputA4;
+using Leds = xpcc::SoftwareGpioPort< LedOrange >;
+
+using Button = xpcc::GpioUnused;
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	LedOrange::setOutput(xpcc::Gpio::Low);
+}
+
+} // Board namespace
+
+#endif	// XPCC_STM32_F030F4P6_DEMO_BOARD_HPP

--- a/tools/openocd/xpcc/stm32f030_demo_board.cfg
+++ b/tools/openocd/xpcc/stm32f030_demo_board.cfg
@@ -1,0 +1,9 @@
+# Cheap STM32F030F4P6 "Demo Board" Minimum System Development Board
+
+source [find interface/stlink-v2.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f0x.cfg]
+
+reset_config none


### PR DESCRIPTION
This PR adds support for the "new" STM32F030F4P6 "Demo Board" available from [Chinese](http://www.hotmcu.com/stm32f030f4p6-minimum-systerm-boardcortexm0-p-208.html) [online](https://www.aliexpress.com/item/STM32F030F4P6-ARM-CORTEX-M0-Core-Board-Minimum-System-Development-Board-Microcontroller-SWD-ISP-Dual-Download/32823139132.html) [shops](http://www.watterott.com/de/STM32F030F4P6-Minimum-Systerm-Board-Cortex-M0) for less than 1.5U$. (Similar to the STM32F103 Blue Pill Board #154)
Features:
* [STM32F030PF4P6](http://www.st.com/en/microcontrollers/stm32f030f4.html) *Mainstream ARM Cortex-M0 Value line MCU with 16 Kbytes Flash, 48 MHz CPU*
* 8MHz crystal
* 3.3V regualtor (AMS1117)
* Micro USB only for power supply
* Reset button
* BOOT0 jumper for UART bootloader (no DFU 😒)
* UART pin header
* SWD pin header
* 15 GPIO pins
* Orange LED

(Only) the blink example has been tested in hardware.

![STM32F030F4P6 Demo Board](https://user-images.githubusercontent.com/2820734/35486087-1d310168-0469-11e8-90b5-4c0f7b3ba3d6.png)

Clock tree (8MHz and Pll supply core and all peripherals with 48MHz):
![STM32F030F4Px clock configuration](https://user-images.githubusercontent.com/2820734/35485953-13771eca-0467-11e8-92c0-3287a28984eb.png)

Schematic (in case it disappears from the Chinese online shops) for V1.0, my board is V1.1 and misses J2:
![image](https://user-images.githubusercontent.com/2820734/35486120-bc302f5a-0469-11e8-9758-b0bd23d71d90.png)
