### PR TITLE
Fixed shared UARTirq for stm32f030cc

### DIFF
--- a/src/xpcc/architecture/platform/driver/uart/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/driver.xml
@@ -15,5 +15,18 @@
 		<parameter name="flow" type="bool">false</parameter>
 		<parameter name="tx_buffer" type="int" min="1" max="65534">250</parameter>
 		<parameter name="rx_buffer" type="int" min="1" max="65534">16</parameter>
+		<!-- shared Uart interrupt -->
+		<shared_irq device-family="f0" device-name="030" device-size-id="c">USART3_6</shared_irq>
+		<shared_irq device-family="f0" device-name="070|071|072" device-size-id="b">USART3_4</shared_irq>
+		<shared_irq device-family="f0" device-name="078">USART3_4</shared_irq>
+		<shared_irq device-family="f0" device-name="091" device-size-id="c">USART3_8</shared_irq>
+		<shared_irq device-family="f0" device-name="098">USART3_8</shared_irq>
+		<shared_irq device-family="l0">USART4_5</shared_irq>
+		<shared_irq_ids device-family="f0" device-name="030" device-size-id="c">3 4 5 6</shared_irq_ids>
+		<shared_irq_ids device-family="f0" device-name="070|071|072" device-size-id="b">3 4</shared_irq_ids>
+		<shared_irq_ids device-family="f0" device-name="078">3 4</shared_irq_ids>
+		<shared_irq_ids device-family="f0" device-name="091" device-size-id="c">3 4 5 6 7 8</shared_irq_ids>
+		<shared_irq_ids device-family="f0" device-name="098" >3 4 5 6 7 8</shared_irq_ids>
+		<shared_irq_ids device-family="l0">4 5</shared_irq_ids>
 	</driver>
 </rca>

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.cpp.in
@@ -14,10 +14,22 @@
 %#
 %% set name = uart ~ id
 %% set hal = uart ~ "Hal" ~ id
+%#
+%% if shared_irq_ids is defined
+%%  set shared_irq_ids = shared_irq_ids.split(" ")
+%% else
+%%  set shared_irq_ids = []
+%% endif
 
 #include "../../../device.hpp"
 #include "uart_hal_{{ id }}.hpp"
 #include "uart_{{ id }}.hpp"
+
+%% if id == 4
+%% for s in shared_irq_ids
+#include "uart_{{ s }}.hpp"
+%% endfor
+%% endif
 
 %% if parameters.buffered
 #include <xpcc/architecture/driver/atomic.hpp>
@@ -192,7 +204,12 @@ xpcc::stm32::{{ name }}::discardReceiveBuffer()
 
 %% if parameters.buffered
 %% set hal = "xpcc::stm32::" ~ hal
+%% if id | string in shared_irq_ids
+void
+xpcc::stm32::{{ name }}::irq()
+%% else
 XPCC_ISR({{ uart | upper ~ id }})
+%% endif
 {
 	if ({{ hal }}::isReceiveRegisterNotEmpty()) {
 		// TODO: save the errors
@@ -210,5 +227,14 @@ XPCC_ISR({{ uart | upper ~ id }})
 			txBuffer.pop();
 		}
 	}
+}
+%% endif
+
+%% if id == 4
+XPCC_ISR({{ shared_irq }})
+{
+%% for s in shared_irq_ids
+    xpcc::stm32::Usart{{ s }}::irq();
+%% endfor
 }
 %% endif

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart.hpp.in
@@ -12,6 +12,12 @@
 %%	set uart = "Uart"
 %% endif
 %% set hal = uart ~ "Hal" ~ id
+%#
+%% if shared_irq_ids is defined
+%%  set shared_irq_ids = shared_irq_ids.split(" ")
+%% else
+%%  set shared_irq_ids = []
+%% endif
 
 #ifndef XPCC_STM32_UART_{{ id }}_HPP
 #define XPCC_STM32_UART_{{ id }}_HPP
@@ -115,6 +121,11 @@ template< 	class SystemClock, uint32_t baudrate,
 
 	static std::size_t
 	discardReceiveBuffer();
+
+%% if id | string in shared_irq_ids
+	static void
+	irq();
+%% endif
 };
 
 }	// namespace stm32

--- a/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/uart/stm32/uart_hal_impl.hpp.in
@@ -25,6 +25,12 @@
 %%  set enr  = "ENR"
 %%  set rstr = "RSTR"
 %% endif
+%#
+%% if shared_irq_ids is defined
+%%  set shared_irq_ids = shared_irq_ids.split(" ")
+%% else
+%%  set shared_irq_ids = []
+%% endif
 
 #ifndef XPCC_STM32_UARTHAL_{{ id }}_HPP
 #	error 	"Don't include this file directly, use" \
@@ -233,8 +239,8 @@ xpcc::stm32::{{ name }}::isTransmitRegisterEmpty()
 void
 xpcc::stm32::{{ name }}::enableInterruptVector(bool enable, uint32_t priority)
 {
-%% if target is stm32f0 and id in [3,4]
-	%%set irq = "USART3_4"
+%% if id | string in shared_irq_ids
+	%%set irq = shared_irq
 %% else
 	%% set irq = peripheral
 %% endif


### PR DESCRIPTION
Okay, this is my attempt to somehow fix the issue with shared IRQs on stm32 devices mentioned in #88 and #348 . The fix has two stages.

First new paramters are added to the `driver.xml`. A parameter called `shared_irq` containing the name of the shared UART (As far as I have seen it, this is either USART3_6 or USART3_8) and a parameter called `shared_irq_ids` containing a whitespace seperated list of the UART ids that are shared.

Than these new parameters are used to generate the appropriate code in the `uart.cpp`, `uart.hpp` and `uart_hal_impl.hpp`.

If an UART is shared, than in the `uart.cpp` there is a class member function `::irq()` defined instead of the interrupt ISR. This function is than called by the shared irq to ensure proper functionality. So where is the shared irq defined?

My first attempt was to generate a seperate file cpp/hpp pair which contains the shared irq routine. Unfortunately irqs - although **_KNOWN_** by the arm compiler - are treated as weak functions and are therefore not linked by the linker, and the common workaround is to add in another function into you .cpp and call it somewhere....great!

Long story short - I put it in the uart3.cpp.

For now it only fixes the issue on the stm32f030cc but more stm32 devices can be supported by adding more variants to the `driver.xml`  - of course it would be far more sophisticated to get these parameters from the devicefile directly.

Fixes #348 and fixes #88.