### PR TITLE
Fix compilation for various STM32L4 targets

### DIFF
--- a/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
+++ b/src/xpcc/architecture/platform/driver/adc/stm32f3/adc_impl.hpp.in
@@ -20,8 +20,13 @@
 	%% set id_common_u = '3_4_COMMON'
 %% endif
 %% elif target is stm32l4
-	%% set id_common = '123'
-	%% set id_common_u = '123_COMMON'
+	%% if target.name in ['471','475','476','485','486', '496', '4a6']
+		%% set id_common = '123'
+		%% set id_common_u = '123_COMMON'
+	%% else
+		%% set id_common = '1'
+		%% set id_common_u = '1_COMMON'
+	%% endif
 %% endif
 %% if target is stm32f3
 	%% set adc_ccr = 'ADC12_CCR'

--- a/src/xpcc/architecture/platform/driver/gpio/stm32/driver.xml
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/driver.xml
@@ -5,5 +5,7 @@
 		<!-- Template: file that needs to be turned into a source file -->
 		<template>gpio.hpp.in</template>
 		<template>gpio_enable.cpp.in</template>
+
+		<ascr_register device-family="l4" device-name="471|475|476|485|486">True</ascr_register>
 	</driver>
 </rca>

--- a/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
+++ b/src/xpcc/architecture/platform/driver/gpio/stm32/gpio.hpp.in
@@ -214,6 +214,10 @@ private:
 
 	xpcc_always_inline static void
 	setAlternateFunction(AlternateFunction alt) {
+		%% if ascr_register is defined
+		{{reg}}->ASCR &= ~mask;
+		%% endif
+
 		{{reg}}->AFR[af_id] = ({{reg}}->AFR[af_id] & ~af_mask)
 								| (i(alt) << af_offset);
 		{{reg}}->MODER = ({{reg}}->MODER   & ~mask2)
@@ -224,8 +228,9 @@ private:
 	xpcc_always_inline static void
 	setAnalogInput() {
 		{{reg}}->MODER |= i(Mode::Analog) << (pin * 2);
-		%% if target is stm32l4
-		{{reg}}->ASCR |= (1 << pin);
+
+		%% if ascr_register is defined
+		{{reg}}->ASCR |= mask;
 		%% endif
 	}
 
@@ -250,6 +255,10 @@ public:
 	// GpioOutput
 	// start documentation inherited
 	xpcc_always_inline static void setOutput() {
+		%% if ascr_register is defined
+		{{reg}}->ASCR &= ~mask;
+		%% endif
+
 		{{reg}}->MODER   = ({{reg}}->MODER   & ~mask2) | (i(Mode::Output)<< pin * 2);
 	}
 	xpcc_always_inline static void setOutput(bool status) {
@@ -296,6 +305,9 @@ public:
 		// reset output type and speed
 		{{reg}}->OTYPER  &= ~mask;
 		{{reg}}->OSPEEDR &= ~mask2;
+		%% if ascr_register is defined
+		{{reg}}->ASCR &= ~mask;
+		%% endif
 	}
 	xpcc_always_inline static bool read() {
 		return ({{reg}}->IDR & mask);
@@ -422,6 +434,9 @@ public:
 		{{reg}}->OTYPER  &= ~mask;
 		{{reg}}->OSPEEDR &= ~mask2;
 		{{reg}}->PUPDR &= ~mask2;
+		%% if ascr_register is defined
+		{{reg}}->ASCR &= ~mask;
+		%% endif
 		%% else
 		setInput(InputType::Floating);
 		%% endif
@@ -586,9 +601,15 @@ class GpioPortBase<Gpio::Port::{{port.name}}, StartPin, Width, PortOrder> : publ
 
 public:
 	xpcc_always_inline static void setOutput() {
+		%% if ascr_register is defined
+		GPIO{{port.name}}->ASCR &= ~portMask;
+		%% endif
 		GPIO{{port.name}}->MODER = (GPIO{{port.name}}->MODER & ~portMask2) | port01;
 	}
 	xpcc_always_inline static void setInput() {
+		%% if ascr_register is defined
+		GPIO{{port.name}}->ASCR &= ~portMask;
+		%% endif
 		GPIO{{port.name}}->MODER &= ~portMask2;
 	}
 	inline static void


### PR DESCRIPTION
This fixes bugs in the HAL that prevent compilation for many STM32L4 targets:

- On L4 the ADC driver assumes the device header defines ADC123_COMMON, which is not true for STM32L4 with a single ADC peripheral.
- Some L4 devices (471, 475, 476, 485, 486) require the ASCR (analog switch) register to be configured when a pin is used as an ADC input. On all other devices the register is not present. Thus, compilation fails. Furthermore the register is not reset when the pin is reconfigured to a different mode.
 