### PR TITLE
[driver] CAN: Bit timing calculation for all clock frequencies

### DIFF
--- a/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
+++ b/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
@@ -1,5 +1,7 @@
 // coding: utf-8
 /* Copyright (c) 2016, Roboterclub Aachen e.V.
+ * Copyright (c) 2018, Christopher Durand
+ * Copyright (c) 2018, Raphael Lehmann
  * All Rights Reserved.
  *
  * The file is part of the xpcc library and is released under the 3-clause BSD
@@ -43,40 +45,50 @@ template<int32_t Clk, int32_t Bitrate>
 class CanBitTiming
 {
 private:
-	static constexpr uint16_t calculatePrescaler(uint8_t bs1, uint8_t bs2) {
-		return Clk / (Bitrate * (1 + bs1 + bs2));
-	}
-
-	struct CanBitTimingConfguration {
+	struct CanBitTimingConfiguration {
 		uint8_t bs1;	// 1-16
 		uint8_t bs2;	// 1-8
 		uint8_t sjw;
 		uint16_t prescaler;
+		float minError;
 	};
 
-	static constexpr uint8_t calcBS1() {
-		return (Clk ==  xpcc::clock::MHz8)? 11 :
-		       (Clk == xpcc::clock::MHz48)? 11 :
-		       (Clk == xpcc::clock::MHz30)? 10 :
-		       (Clk == xpcc::clock::MHz36)? 12 :
-		       (Clk == xpcc::clock::MHz42)? 14 :
-		       (Clk == xpcc::clock::MHz32)? 11 : 0;
+	static constexpr uint32_t round_uint32(float f)
+	{
+		uint32_t f_int = (uint32_t) f;
+		if(f - f_int > 0.5)
+			return f_int + 1;
+		else
+			return f_int;
 	}
 
-	static constexpr uint8_t calcBS2() {
-		return (Clk ==  xpcc::clock::MHz8)?  4 :
-		       (Clk == xpcc::clock::MHz48)?  4 :
-		       (Clk == xpcc::clock::MHz30)?  4 :
-		       (Clk == xpcc::clock::MHz36)?  5 :
-		       (Clk == xpcc::clock::MHz42)?  6 :
-		       (Clk == xpcc::clock::MHz32)?  4 : 0;
+	static constexpr CanBitTimingConfiguration calculateBestConfig()
+	{
+		constexpr uint8_t minBs1Bs2 = 14;
+		constexpr uint8_t maxBs1Bs2 = 20;
+
+		float minError = 10000;
+		uint16_t bestPrescaler = 0;
+		uint8_t bestBs1Bs2 = 0;
+
+		for(uint8_t bs1Bs2 = minBs1Bs2; bs1Bs2 <= maxBs1Bs2; ++bs1Bs2) {
+			float idealPrescaler = float(Clk) / (Bitrate * (1 + bs1Bs2));
+			uint32_t intPrescaler = round_uint32(idealPrescaler);
+			float error = fabs(1 - intPrescaler/idealPrescaler);
+			if(error <= minError) {
+				bestPrescaler = intPrescaler;
+				minError = error;
+				bestBs1Bs2 = bs1Bs2;
+			}
+		}
+
+		uint8_t bs2 = round_uint32(0.275f * (bestBs1Bs2 + 1));
+		uint8_t bs1 = bestBs1Bs2 - bs2;
+
+		return CanBitTimingConfiguration{bs1, bs2, 1, bestPrescaler, minError};
 	}
 
-	static constexpr CanBitTimingConfguration calculateBestConfig() {
-		return { calcBS1(), calcBS2(), 1, calculatePrescaler(calcBS1(), calcBS2()) };
-	}
-
-	static constexpr CanBitTimingConfguration BestConfig = calculateBestConfig();
+	static constexpr CanBitTimingConfiguration BestConfig = calculateBestConfig();
 
 public:
 	static constexpr uint8_t getBS1() { return BestConfig.bs1; }
@@ -86,10 +98,8 @@ public:
 
 private:
 	// check assertions
-	static_assert(getBS1() > 0 and getBS2() > 0,
-		"Unsupported frequency for Can peripheral. "
-		"Only 8MHz, 30 Mhz, 36 MHz, 42 MHz and 48 MHz are supported at the moment.");
 	static_assert(getPrescaler() > 0, "CAN bitrate is too high for standard bit timings!");
+	static_assert(getPrescaler() < ((1 << 10) - 1), "Prescaler value too large"); // 10 bit prescaler on STM32
 };
 
 }	// namespace xpcc

--- a/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
+++ b/src/xpcc/architecture/platform/driver/can/generic/can_bit_timings.hpp
@@ -96,6 +96,13 @@ public:
 	static constexpr uint8_t getSJW() { return BestConfig.sjw; }
 	static constexpr uint8_t getPrescaler() { return BestConfig.prescaler; }
 
+	template<uint16_t tolerance>
+	static constexpr void assertBitrateInTolerance()
+	{
+		static_assert(tolerance >= static_cast<uint16_t>(BestConfig.minError * 1000.f),
+			"The closest available bitrate exceeds the specified maximum tolerance!");
+	}
+
 private:
 	// check assertions
 	static_assert(getPrescaler() > 0, "CAN bitrate is too high for standard bit timings!");

--- a/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
+++ b/src/xpcc/architecture/platform/driver/can/stm32/can.hpp.in
@@ -110,6 +110,8 @@ public:
 	{
 		using Timings = CanBitTiming<SystemClock::Can{{ id }}, bitrate>;
 
+		Timings::template assertBitrateInTolerance<tolerance>();
+
 		return initializeWithPrescaler(
 			Timings::getPrescaler(),
 			Timings::getBS1(),

--- a/src/xpcc/architecture/platform/test/can_bit_timings_test.cpp
+++ b/src/xpcc/architecture/platform/test/can_bit_timings_test.cpp
@@ -50,9 +50,9 @@ CanBitTimingsTest::testPrecalculatedValues()
 	TEST_TIMING(MHz48, kBps500, 11, 4,  6);
 	TEST_TIMING(MHz48,   MBps1, 11, 4,  3);
 
-	TEST_TIMING(MHz30, kBps125, 10, 4, 16);
-	TEST_TIMING(MHz30, kBps250, 10, 4,  8);
-	TEST_TIMING(MHz30, kBps500, 10, 4,  4);
+	TEST_TIMING(MHz30, kBps125, 14, 5, 12);
+	TEST_TIMING(MHz30, kBps250, 14, 5,  6);
+	TEST_TIMING(MHz30, kBps500, 14, 5,  3);
 	TEST_TIMING(MHz30,   MBps1, 10, 4,  2);
 
 	TEST_TIMING(MHz36, kBps125, 12, 5, 16);
@@ -70,5 +70,14 @@ CanBitTimingsTest::testPrecalculatedValues()
 	TEST_TIMING(MHz32, kBps500, 11, 4,  4);
 	TEST_TIMING(MHz32,   MBps1, 11, 4,  2);
 
+	TEST_TIMING(MHz80,  kBps125, 14, 5, 32);
+	TEST_TIMING(MHz80,  kBps250, 14, 5, 16);
+	TEST_TIMING(MHz80,  kBps500, 14, 5,  8);
+	TEST_TIMING(MHz80,    MBps1, 14, 5,  4);
+
+	TEST_TIMING(MHz180,  kBps125, 14, 5, 72);
+	TEST_TIMING(MHz180,  kBps250, 14, 5, 36);
+	TEST_TIMING(MHz180,  kBps500, 14, 5, 18);
+	TEST_TIMING(MHz180,    MBps1, 14, 5,  9);
 }
 


### PR DESCRIPTION
The lookup table is replaced by a [constexpr function](https://pastebin.com/UfE9U9LB) written by @chris-durand to calculate the bit timings and prescaler for CAN.