### PR TITLE
Added initial support for "Black Pill" board.

### DIFF
--- a/examples/stm32f103c8t6_black_pill/blink/SConstruct
+++ b/examples/stm32f103c8t6_black_pill/blink/SConstruct
@@ -1,0 +1,4 @@
+# path to the xpcc root directory
+xpccpath = '../../..'
+# execute the common SConstruct file
+exec(compile(open(xpccpath + '/scons/SConstruct', "rb").read(), xpccpath + '/scons/SConstruct', 'exec'))

--- a/examples/stm32f103c8t6_black_pill/blink/main.cpp
+++ b/examples/stm32f103c8t6_black_pill/blink/main.cpp
@@ -1,0 +1,27 @@
+#include <xpcc/architecture/platform.hpp>
+
+using namespace Board;
+
+/*
+ * Blinks the green user LED with 1 Hz.
+ * It is on for 90% of the time and off for 10% of the time.
+ */
+
+int
+main()
+{
+	Board::initialize();
+
+	LedGreen::set();
+
+	while (true)
+	{
+		LedGreen::set();
+		xpcc::delayMilliseconds(900);
+
+		LedGreen::reset();
+		xpcc::delayMilliseconds(100);
+	}
+
+	return 0;
+}

--- a/examples/stm32f103c8t6_black_pill/blink/project.cfg
+++ b/examples/stm32f103c8t6_black_pill/blink/project.cfg
@@ -1,0 +1,3 @@
+[build]
+board = stm32f103c8t6_black_pill
+buildpath = ${xpccpath}/build/stm32f103_black_pill/${name}

--- a/src/xpcc/architecture/platform/board/stm32f103c8t6_black_pill/board.cfg
+++ b/src/xpcc/architecture/platform/board/stm32f103c8t6_black_pill/board.cfg
@@ -1,0 +1,10 @@
+[build]
+device = stm32f103c8t6
+
+[parameters]
+core.cortex.0.enable_hardfault_handler_led = true
+core.cortex.0.hardfault_handler_led_port = B
+core.cortex.0.hardfault_handler_led_pin = 12
+
+[openocd]
+configfile = xpcc/stm32f103_blue_pill.cfg

--- a/src/xpcc/architecture/platform/board/stm32f103c8t6_black_pill/stm32f103c8t6_black_pill.hpp
+++ b/src/xpcc/architecture/platform/board/stm32f103c8t6_black_pill/stm32f103c8t6_black_pill.hpp
@@ -1,0 +1,110 @@
+// coding: utf-8
+/* Copyright (c) 2018, Nick Sarten
+* All Rights Reserved.
+*
+* The file is part of the xpcc library and is released under the 3-clause BSD
+* license. See the file `LICENSE` for the full license governing this code.
+*/
+// ----------------------------------------------------------------------------
+
+//
+// STM32F103C8T6 "Black Pill" Minimum System Development Board
+//
+// Cheap and bread-board-friendly board for STM32 F1 series.
+// Sold for less than 2 USD on well known Internet shops from China.
+//
+// http://wiki.stm32duino.com/index.php?title=Black_Pill
+//
+
+#ifndef XPCC_STM32_F103C8T6_BLACK_PILL_HPP
+#define XPCC_STM32_F103C8T6_BLACK_PILL_HPP
+
+#include <xpcc/architecture/platform.hpp>
+
+using namespace xpcc::stm32;
+
+
+namespace Board
+{
+
+/// STM32F103 running at 72MHz generated from the external 8MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = MHz72;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1 = Apb2;
+	static constexpr uint32_t Adc2 = Apb2;
+	static constexpr uint32_t Adc3 = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+
+	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can2   = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableExternalCrystal();
+
+		// external clock * 9 = 72MHz, => 72/1.5 = 48 => good for USB
+		ClockControl::enablePll(ClockControl::PllSource::ExternalCrystal, ClockControl::UsbPrescaler::Div1_5, 9);
+
+		// set flash latency for 72MHz
+		ClockControl::setFlashLatency(Frequency);
+
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+
+		// AHB has max 72MHz
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+
+		// APB1 has max. 36MHz
+		ClockControl::setApb1Prescaler(ClockControl::Apb1Prescaler::Div2);
+
+		// APB2 has max. 72MHz
+		ClockControl::setApb2Prescaler(ClockControl::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+
+
+		// update frequencies for busy-wait delay functions
+		xpcc::clock::fcpu     = Frequency;
+		xpcc::clock::fcpu_kHz = Frequency / 1000;
+		xpcc::clock::fcpu_MHz = Frequency / 1000000;
+		xpcc::clock::ns_per_loop = ::round(3000.f / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// User LED (inverted, because connected to 3V3)
+using LedGreen = xpcc::GpioInverted< GpioOutputB12 >;
+using Leds = xpcc::SoftwareGpioPort< LedGreen >;
+
+using Button = xpcc::GpioUnused;
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	xpcc::cortex::SysTickTimer::initialize<systemClock>();
+
+	LedGreen::setOutput(xpcc::Gpio::Low);
+}
+
+} // Board namespace
+
+#endif	// XPCC_STM32_F103C8T6_BLACK_PILL_HPP


### PR DESCRIPTION
[This board](http://wiki.stm32duino.com/index.php?title=Black_Pill) is a variant on the more common "Blue Pill" board that is already supported. The only significant change between the two boards is the pin used for the user LED.

I've added support for the board in the most obvious way: by cloning some of the existing support for the blue pill board and modifying it where appropriate to support the new board. I would like to find a way to refactor the common platform information and examples for both boards; this pull request can either serve as a starting point for this conversation, or it can be accepted as it stands to add support for this board.