### PR TITLE
[io] fprint: Print NaN and +-Inf correctly

### DIFF
--- a/src/xpcc/io/iostream_float.cpp
+++ b/src/xpcc/io/iostream_float.cpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>		// snprintf()
 #include <stdlib.h>
+#include <cmath>
 
 #include <xpcc/utils/arithmetic_traits.hpp>
 #include <xpcc/utils/template_metaprogramming.hpp>
@@ -20,6 +21,29 @@ xpcc::IOStream::writeFloat(const float& value)
 {
 	// hard coded for -2.22507e-308
 	char str[13 + 1]; // +1 for '\0'
+
+	if(!std::isfinite(value)) {
+		char *ptr = &str[0];
+		if(std::isinf(value)) {
+			if (value < 0) {
+				*ptr++ = '-';
+			}
+			*ptr++ = 'i';
+			*ptr++ = 'n';
+			*ptr++ = 'f';
+			*ptr++ = '\0';	// End of string
+			this->device->write(str);
+			return;
+		}
+		else {
+			*ptr++ = 'n';
+			*ptr++ = 'a';
+			*ptr++ = 'n';
+			*ptr++ = '\0';	// End of string
+			this->device->write(str);
+			return;
+		}
+	}
 
 #if defined(XPCC__CPU_AVR)
 	dtostre(value, str, 5, 0);

--- a/src/xpcc/io/iostream_printf.cpp
+++ b/src/xpcc/io/iostream_printf.cpp
@@ -135,6 +135,24 @@ xpcc::IOStream::vprintf(const char *fmt, va_list ap)
 			// va_arg(ap, float) not allowed
 			float float_value = va_arg(ap, double);
 
+			if(!std::isfinite(float_value)) {
+				if(std::isinf(float_value)) {
+					if (float_value < 0) {
+						this->device->write('-');
+					}
+					this->device->write('i');
+					this->device->write('n');
+					this->device->write('f');
+					return *this;
+				}
+				else {
+					this->device->write('n');
+					this->device->write('a');
+					this->device->write('n');
+					return *this;
+				}
+			}
+
 			if (float_value < 0)
 			{
 				float_value = -float_value; // make it positive

--- a/src/xpcc/io/test/io_stream_test.cpp
+++ b/src/xpcc/io/test/io_stream_test.cpp
@@ -13,6 +13,18 @@
 #include <stdio.h>	// snprintf
 #include <string.h>	// memset
 
+#if not defined(XPCC__CPU_AVR)
+#include <limits>
+#else
+#include <math.h>
+namespace std {
+template <typename T> struct numeric_limits {
+	static constexpr T quiet_NaN() { return NAN; }
+	static constexpr T infinity() { return INFINITY; }
+};
+}
+#endif
+
 // ----------------------------------------------------------------------------
 // simple IODevice which stores all data in a memory buffer
 // used for testing the output of an IOStream
@@ -298,6 +310,28 @@ IoStreamTest::testFloat4()
 
 	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 12);
 	TEST_ASSERT_EQUALS(device.bytesWritten, 12U);
+}
+
+void
+IoStreamTest::testFloat5()
+{
+	char string[] = "nan";
+
+	(*stream) << std::numeric_limits<float>::quiet_NaN();
+
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 3);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 3U);
+}
+
+void
+IoStreamTest::testFloat6()
+{
+	char string[] = "inf";
+
+	(*stream) << std::numeric_limits<float>::infinity();
+
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 3);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 3U);
 }
 
 void

--- a/src/xpcc/io/test/io_stream_test.hpp
+++ b/src/xpcc/io/test/io_stream_test.hpp
@@ -82,6 +82,12 @@ public:
 	void
 	testFloat4();
 
+	void
+	testFloat5();
+
+	void
+	testFloat6();
+
 	// bool
 	void
 	testBool1();


### PR DESCRIPTION
Currently `NaN`, `Inf` and `-Inf` are printed as `0.00000e+00`, which can cause confusion.