### PR TITLE
[driver] SPI SoftwareSpiMaster: Fix acquire()

### DIFF
--- a/src/xpcc/architecture/platform/driver/spi/generic/spi_master_impl.hpp
+++ b/src/xpcc/architecture/platform/driver/spi/generic/spi_master_impl.hpp
@@ -67,7 +67,7 @@ template <typename SCK, typename MOSI, typename MISO>
 uint8_t
 xpcc::SoftwareSpiMaster<SCK, MOSI, MISO>::acquire(void *ctx, ConfigurationHandler handler)
 {
-	if (ctx == nullptr)
+	if (context == nullptr)
 	{
 		context = ctx;
 		count = 1;


### PR DESCRIPTION
In commit ff0823abdced91817a3af520cd87cbd5683e42ea the `SoftwareSpiMaster` implementation was not fixed.
Fixes #357 

See modm-io/modm#16